### PR TITLE
Fix: Paginated Queries

### DIFF
--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -17,6 +17,10 @@ import { Database, Json } from '@post-for-me/db';
 import { PostValidation } from './dto/post-validation.dto';
 import { SocialPostMetersService } from 'src/social-post-meters/social-post-meters.service';
 
+type ProviderTypeEnum = Database['public']['Enums']['social_provider'];
+
+type PostStatusEnum = Database['public']['Enums']['social_post_status'];
+
 @Injectable()
 export class SocialPostsService {
   constructor(
@@ -437,52 +441,66 @@ export class SocialPostsService {
       .range(offset, offset + limit - 1);
 
     if (platform) {
-      if (typeof platform === 'string') {
-        query.eq(
-          'social_post_provider_connections.social_provider_connections.provider',
-          platform as
-            | 'facebook'
-            | 'instagram'
-            | 'x'
-            | 'tiktok'
-            | 'youtube'
-            | 'pinterest'
-            | 'linkedin'
-            | 'bluesky'
-            | 'threads',
-        );
-      } else if (Array.isArray(platform)) {
-        query.in(
-          'social_post_provider_connections.social_provider_connections.provider',
-          platform as (
-            | 'facebook'
-            | 'instagram'
-            | 'x'
-            | 'tiktok'
-            | 'youtube'
-            | 'pinterest'
-            | 'linkedin'
-            | 'bluesky'
-            | 'threads'
-          )[],
-        );
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof platform === 'string': {
+          values.push(...(platform as string).split(','));
+          break;
+        }
+        case Array.isArray(platform):
+          values.push(...platform);
+          break;
+        default:
+          values.push(platform);
+          break;
       }
+
+      query.in(
+        'social_post_provider_connections.social_provider_connections.provider',
+        values.map((v) => v as ProviderTypeEnum),
+      );
     }
 
     if (external_id) {
-      if (typeof external_id === 'string') {
-        query.eq('external_id', external_id);
-      } else if (Array.isArray(external_id)) {
-        query.in('external_id', external_id);
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof external_id === 'string': {
+          values.push(...(external_id as string).split(','));
+          break;
+        }
+        case Array.isArray(external_id):
+          values.push(...external_id);
+          break;
+        default:
+          values.push(external_id);
+          break;
       }
+
+      query.in('external_id', values);
     }
 
     if (status) {
-      if (typeof status === 'string') {
-        query.eq('status', status);
-      } else if (Array.isArray(status)) {
-        query.in('status', status);
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof status === 'string': {
+          values.push(...(status as string).split(','));
+          break;
+        }
+        case Array.isArray(status):
+          values.push(...status);
+          break;
+        default:
+          values.push(status);
+          break;
       }
+
+      query.in(
+        'status',
+        values.map((v) => v as PostStatusEnum),
+      );
     }
 
     query.order('created_at', { ascending: false });

--- a/api/src/social-provider-connections/dto/social-accounts-query.dto.ts
+++ b/api/src/social-provider-connections/dto/social-accounts-query.dto.ts
@@ -45,5 +45,5 @@ export class SocialAccountQueryDto extends BasePaginatedQueryDto {
   })
   @IsString({ each: true })
   @IsOptional()
-  id?: string;
+  id?: string[];
 }

--- a/api/src/social-provider-connections/social-provider-connections.service.ts
+++ b/api/src/social-provider-connections/social-provider-connections.service.ts
@@ -14,6 +14,9 @@ import {
   CreateSocialAccountDto,
   SocialAccountMetadata,
 } from './dto/create-social-account.dto';
+import { Database } from '@post-for-me/db';
+
+type ProviderEnum = Database['public']['Enums']['social_provider'];
 
 @Injectable()
 export class SocialAccountsService {
@@ -35,50 +38,80 @@ export class SocialAccountsService {
       .range(offset, offset + limit - 1);
 
     if (platform) {
-      if (typeof platform === 'string') {
-        query.eq('provider', platform);
-      } else if (Array.isArray(platform)) {
-        query.in(
-          'provider',
-          platform.map(
-            (provider) =>
-              provider as
-                | 'facebook'
-                | 'instagram'
-                | 'x'
-                | 'tiktok'
-                | 'youtube'
-                | 'pinterest'
-                | 'linkedin'
-                | 'bluesky'
-                | 'threads',
-          ),
-        );
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof platform === 'string': {
+          values.push(...(platform as string).split(','));
+          break;
+        }
+        case Array.isArray(platform):
+          values.push(...platform);
+          break;
+        default:
+          values.push(platform);
+          break;
       }
+
+      query.in(
+        'provider',
+        values.map((provider) => provider as ProviderEnum),
+      );
     }
 
     if (external_id) {
-      if (typeof external_id === 'string') {
-        query.eq('external_id', external_id);
-      } else if (Array.isArray(external_id)) {
-        query.in('external_id', external_id);
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof external_id === 'string': {
+          values.push(...(external_id as string).split(','));
+          break;
+        }
+        case Array.isArray(external_id):
+          values.push(...external_id);
+          break;
+        default:
+          values.push(external_id);
+          break;
       }
+
+      query.in('external_id', values);
     }
 
     if (id) {
-      if (typeof id === 'string') {
-        query.eq('id', id);
-      } else if (Array.isArray(id)) {
-        query.in('id', id);
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof id === 'string': {
+          values.push(...(id as string).split(','));
+          break;
+        }
+        case Array.isArray(id):
+          values.push(...id);
+          break;
+        default:
+          values.push(id);
+          break;
       }
+      query.in('id', values);
     }
 
     if (username) {
-      if (typeof username === 'string') {
-        query.eq('username', username);
-      } else if (Array.isArray(username)) {
-        query.in('username', username);
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof username === 'string': {
+          values.push(...(username as string).split(','));
+          break;
+        }
+        case Array.isArray(username):
+          values.push(...username);
+          break;
+        default:
+          values.push(username);
+          break;
       }
+      query.in('username', values);
     }
 
     query.order('created_at', { ascending: false });

--- a/api/src/webhooks/dto/webhook-query.dto.ts
+++ b/api/src/webhooks/dto/webhook-query.dto.ts
@@ -34,5 +34,5 @@ export class WebhookQueryDto extends BasePaginatedQueryDto {
   })
   @IsString({ each: true })
   @IsOptional()
-  id?: string;
+  id?: string[];
 }

--- a/api/src/webhooks/webhooks.service.ts
+++ b/api/src/webhooks/webhooks.service.ts
@@ -33,30 +33,63 @@ export class WebhooksService {
       .range(offset, offset + limit - 1);
 
     if (url) {
-      if (typeof url === 'string') {
-        webhookQuery.eq('url', url);
-      } else if (Array.isArray(url)) {
-        webhookQuery.in('url', url);
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof url === 'string': {
+          values.push(...(url as string).split(','));
+          break;
+        }
+        case Array.isArray(url):
+          values.push(...url);
+          break;
+        default:
+          values.push(url);
+          break;
       }
+
+      webhookQuery.in('url', values);
     }
 
     if (event_type) {
-      if (typeof event_type === 'string') {
-        webhookQuery.in('webhook_subscribed_event_types.type', [event_type]);
-      } else if (Array.isArray(event_type)) {
-        webhookQuery.in(
-          'webhook_subscribed_event_types.type',
-          event_type as WebhookEventType[],
-        );
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof event_type === 'string': {
+          values.push(...(event_type as string).split(','));
+          break;
+        }
+        case Array.isArray(event_type):
+          values.push(...event_type);
+          break;
+        default:
+          values.push(event_type);
+          break;
       }
+
+      webhookQuery.in(
+        'webhook_subscribed_event_types.type',
+        values as WebhookEventType[],
+      );
     }
 
     if (id) {
-      if (typeof id === 'string') {
-        webhookQuery.eq('id', id);
-      } else if (Array.isArray(id)) {
-        webhookQuery.in('id', id);
+      const values: string[] = [];
+
+      switch (true) {
+        case typeof id === 'string': {
+          values.push(...(id as string).split(','));
+          break;
+        }
+        case Array.isArray(id):
+          values.push(...id);
+          break;
+        default:
+          values.push(id);
+          break;
       }
+
+      webhookQuery.in('id', values);
     }
 
     const { data: webhooks, error, count } = await webhookQuery;


### PR DESCRIPTION
## Changes
The sdks are sending query filters as one param separated by commas i.e. external_id=ex_123,ex_456.  
I have updated the paginated requests to handle the passed in params regardless of how they are formatted.
