### PR TITLE
fix: Improve the type checking on the files that are remotely referenced/uploaded

### DIFF
--- a/trigger/process-post-medium.ts
+++ b/trigger/process-post-medium.ts
@@ -1,21 +1,21 @@
-import { logger, task } from "@trigger.dev/sdk";
-import path from "path";
-import { createClient } from "@supabase/supabase-js";
-import { v4 as uuidv4 } from "uuid";
-import { Upload } from "tus-js-client";
 import { Database } from "@post-for-me/db";
+import { createClient } from "@supabase/supabase-js";
+import { logger, task } from "@trigger.dev/sdk";
 import fetch from "node-fetch";
+import path from "path";
+import { Upload } from "tus-js-client";
+import { v4 as uuidv4 } from "uuid";
 
 // Single Supabase client instance
 const supabaseClient = createClient<Database>(
   process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
 // Helper function to determine media type
 const getMediaType = (
   contentType: string,
-  fileExtension: string
+  fileExtension: string,
 ): "image" | "video" => {
   const imageTypes = [
     "image/jpeg",
@@ -71,9 +71,117 @@ const getFileExtension = (url: string, contentType?: string): string => {
   return ".bin";
 };
 
+// Helper function to detect content type from file signature
+const detectContentTypeFromBytes = (bytes: Uint8Array): string | null => {
+  if (bytes.length < 12) return null;
+
+  // JPEG
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+
+  // PNG
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+
+  // GIF
+  if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46) {
+    return "image/gif";
+  }
+
+  // WebP
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+
+  // MP4
+  if (
+    bytes.length >= 8 &&
+    bytes[4] === 0x66 &&
+    bytes[5] === 0x74 &&
+    bytes[6] === 0x79 &&
+    bytes[7] === 0x70
+  ) {
+    return "video/mp4";
+  }
+
+  // WebM
+  if (
+    bytes[0] === 0x1a &&
+    bytes[1] === 0x45 &&
+    bytes[2] === 0xdf &&
+    bytes[3] === 0xa3
+  ) {
+    return "video/webm";
+  }
+
+  // AVI
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x41 &&
+    bytes[9] === 0x56 &&
+    bytes[10] === 0x49 &&
+    bytes[11] === 0x20
+  ) {
+    return "video/avi";
+  }
+
+  // MOV/QuickTime
+  if (
+    bytes.length >= 12 &&
+    bytes[4] === 0x66 &&
+    bytes[5] === 0x74 &&
+    bytes[6] === 0x79 &&
+    bytes[7] === 0x70 &&
+    bytes[8] === 0x71 &&
+    bytes[9] === 0x74
+  ) {
+    return "video/quicktime";
+  }
+
+  return null;
+};
+
 // Helper function to stream download and upload file
 const streamDownloadAndUpload = async (fileUrl: string, prefix: string) => {
   logger.info(`Streaming download from: ${fileUrl}`);
+
+  // First, download just the first 512 bytes to detect file type
+  let detectedContentType: string | null = null;
+  try {
+    const partialResponse = await fetch(fileUrl, {
+      headers: { Range: "bytes=0-511" },
+    });
+
+    if (partialResponse.ok && partialResponse.status === 206) {
+      const partialBuffer = await partialResponse.arrayBuffer();
+      const bytes = new Uint8Array(partialBuffer);
+      detectedContentType = detectContentTypeFromBytes(bytes);
+      logger.info(
+        `Detected content type from file signature: ${detectedContentType}`,
+      );
+    }
+  } catch (error) {
+    logger.info("Range request failed, will try full download");
+  }
 
   const response = await fetch(fileUrl);
   if (!response.ok) {
@@ -87,8 +195,35 @@ const streamDownloadAndUpload = async (fileUrl: string, prefix: string) => {
     throw new Error("No response body available for streaming");
   }
 
-  const contentType =
-    response.headers.get("content-type") || "application/octet-stream";
+  let contentType =
+    detectedContentType ||
+    response.headers.get("content-type") ||
+    "application/octet-stream";
+
+  // Normalize binary/octet-stream to application/octet-stream
+  if (contentType === "binary/octet-stream") {
+    contentType = "application/octet-stream";
+  }
+
+  // If we couldn't detect a media type, reject the file
+  if (
+    (contentType === "application/octet-stream" ||
+      contentType === "binary/octet-stream") &&
+    !detectedContentType
+  ) {
+    throw new Error(
+      "Unable to determine file type - may not be a supported image or video format",
+    );
+  }
+
+  // Validate that the content type is actually image or video
+  const isValidMediaType =
+    contentType.startsWith("image/") || contentType.startsWith("video/");
+  if (!isValidMediaType) {
+    throw new Error(
+      `Unsupported file type: ${contentType}. Only images and videos are allowed.`,
+    );
+  }
   const contentLength = response.headers.get("content-length");
   const fileExtension = getFileExtension(fileUrl, contentType);
   const fileName = `${prefix}_${uuidv4()}`;
@@ -207,7 +342,7 @@ export const processPostMedium = task({
       if (thumbnail_url) {
         thumbnailResult = await streamDownloadAndUpload(
           thumbnail_url,
-          "thumbnail"
+          "thumbnail",
         );
       }
 


### PR DESCRIPTION
## Problem
In some instances, a server will return a non-normalized type for the mime type. In one case, Warmik returned `binary/octet-stream` instead of `video/mp4` for the resulting streamed data. In this case, we attempt to upload the remote asset, but the mime type we attempt to upload is also set to `binary/octet-stream` which is invalid for our media bucket

## Solution
Add a more robust check that checks the content-type and if it's invalid, we confirm by downloading a small amount of bytes to determine the file type. if that still returns with an invalid type, we reject the media asset all-together