### PR TITLE
Fix: Instagram Dashboard Connection

### DIFF
--- a/dashboard/app/routes/_protected.$teamId.$projectId.accounts.connect._index/route.loader.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.accounts.connect._index/route.loader.ts
@@ -27,7 +27,12 @@ export const loader = withSupabase(async function loader({
           cred.app_id !== "" &&
           cred.app_secret !== ""
       )
-      ?.map((cred) => cred.provider) || []
+      ?.map((cred) => {
+        if (cred.provider === "instagram_w_facebook") {
+          return "instagram";
+        }
+        return cred.provider;
+      }) || []
   );
 
   // All available social providers


### PR DESCRIPTION
## Changes
- Updating so if instagram_w_facebook is setup then Instagram connection is enabled when connecting an account through the dashboard