### PR TITLE
Chore: Social Account Created Webhook Data

### DIFF
--- a/dashboard/app/lib/.server/social-accounts/social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.ts
@@ -105,6 +105,7 @@ export async function addSocialAccountConnections({
           platform: c.provider || "",
           username: c.social_provider_user_name || "",
           user_id: c.social_provider_user_id || "",
+          profile_photo_url: c.social_provider_profile_photo_url,
           status: c.access_token ? "connected" : "disconnected",
           external_id: c.external_id,
           access_token: c.access_token || "",


### PR DESCRIPTION
## Changes: 

- Fixing issue where the profile photo url was not returned in the social.account.created webhook