### PR TITLE
Fix: Post to Platform OOM errors

### DIFF
--- a/trigger/post-to-platform.ts
+++ b/trigger/post-to-platform.ts
@@ -131,9 +131,14 @@ const handleTokenRefresh = async ({
 
 export const postToPlatform = task({
   id: "post-to-platform",
-  machine: "medium-1x",
   maxDuration: 3600,
-  retry: { maxAttempts: 1 },
+  retry: {
+    maxAttempts: 2,
+    outOfMemory: {
+      machine: "large-1x",
+    },
+  },
+  machine: "medium-2x",
   run: async (payload: IndividualPostData): Promise<PostResult> => {
     const {
       platform,


### PR DESCRIPTION
##Changes: 

Since we are compressing videos for bluesky in the post to platform task, we occasionally hit memory errors. Increasing machine size for now and adding retry with a larger machine when necessary. 

In the future will probably extract all image/video processing logic to separate tasks so the post tasks can be run on smaller machines, and only when necessary use larger machines. As there should be no need for a text only post to run on medium+ machines