### PR TITLE
Fix: Incorrect Extneral Id Filter

### DIFF
--- a/api/src/social-account-feeds/social-account-feeds.service.ts
+++ b/api/src/social-account-feeds/social-account-feeds.service.ts
@@ -415,7 +415,7 @@ export class SocialAccountFeedsService {
           break;
       }
 
-      postResultsQuery.in('social_posts.external_post_id', values);
+      postResultsQuery.in('social_posts.external_id', values);
       executePostsQuery = true;
     }
 


### PR DESCRIPTION
## About

Fixing issue where social account feed lookup was using "external_post_id" instead of correct field "external_id"