### PR TITLE
feat: add private CMS module

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -6,6 +6,16 @@ SUPABASE_JWT_SECRET=
 UNKEY_ROOT_KEY=
 UNKEY_API_ID=
 
+# Private namespace (internal CMS endpoints) is authorized via Unkey RBAC:
+# each route requires a permission query (default `cms.read`, overridable
+# per-route via the `@ProtectPrivate({ permissions })` decorator). Grant
+# `cms.read` (directly or via a role like `service`) to any key that needs
+# to hit `/private/*`. These routes are excluded from the OpenAPI spec.
+
+# Optional: set to "true" in dev/preview to include draft articles
+# in `/private/cms/articles` responses.
+CMS_SHOW_DRAFTS=
+
 DASHBOARD_APP_URL=http://localhost:5173
 
 TRIGGER_SECRET_KEY=

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -9,10 +9,12 @@ import { SocialAccountsModule } from './social-provider-connections/social-provi
 
 import { SupabaseModule } from './supabase/supabase.module';
 import { AuthGuard } from './auth/auth.guard';
+import { VerifyKeyGuard } from './auth/verify-key.guard';
 import { UnkeyModule } from './unkey/unkey.module';
 import { SocialPostPreviewsModule } from './social-posts-previews/social-posts-previews.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { SocialAccountFeedsModule } from './social-account-feeds/social-account-feeds.module';
+import { PrivateModule } from './private/private.module';
 
 @Module({
   imports: [
@@ -28,8 +30,9 @@ import { SocialAccountFeedsModule } from './social-account-feeds/social-account-
     SocialPostPreviewsModule,
     WebhooksModule,
     SocialAccountFeedsModule,
+    PrivateModule,
   ],
   controllers: [],
-  providers: [AuthGuard],
+  providers: [AuthGuard, VerifyKeyGuard],
 })
 export class AppModule {}

--- a/api/src/auth/verify-key.decorator.ts
+++ b/api/src/auth/verify-key.decorator.ts
@@ -1,0 +1,32 @@
+import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+
+import { VerifyKeyGuard } from './verify-key.guard';
+
+export const VERIFY_KEY_PERMISSIONS = 'verify_key_permissions';
+
+export interface VerifyKeyOptions {
+  /**
+   * Unkey permission query required to access this route. Supports the same
+   * syntax as `keys.verifyKey({ permissions })`:
+   *   - single: "cms.read"
+   *   - AND/OR: "cms.read AND cms.write"
+   *   - grouped: "(cms.read OR cms.write) AND authors.view"
+   *
+   * When omitted, the guard only checks that the key itself is valid — no
+   * permission requirement.
+   */
+  permissions?: string;
+}
+
+/**
+ * Require a valid Unkey bearer token for this route or controller, with an
+ * optional permission query enforced by Unkey RBAC. Controllers (including
+ * those under `/private/*`) opt in explicitly — nothing is protected by
+ * being located in a particular module.
+ */
+export function VerifyKey(options: VerifyKeyOptions = {}) {
+  return applyDecorators(
+    SetMetadata(VERIFY_KEY_PERMISSIONS, options.permissions),
+    UseGuards(VerifyKeyGuard),
+  );
+}

--- a/api/src/auth/verify-key.guard.ts
+++ b/api/src/auth/verify-key.guard.ts
@@ -1,0 +1,105 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { Unkey } from '@unkey/api';
+import type { Request } from 'express';
+
+import { UNKEY_INSTANCE } from '../unkey/unkey.module';
+
+import { VERIFY_KEY_PERMISSIONS } from './verify-key.decorator';
+
+/**
+ * Generic Unkey-backed auth guard. Verifies the bearer token and optionally
+ * enforces a permission query (via Unkey RBAC). Apply with `@VerifyKey(...)`.
+ *
+ * This is *not* the customer-facing auth primitive — that's `AuthGuard`,
+ * which also extracts user/project/team identity and runs plan-type checks.
+ * Use this guard for internal service-to-service calls where you only care
+ * about "is the key valid and does it have permission X?".
+ */
+@Injectable()
+export class VerifyKeyGuard implements CanActivate {
+  constructor(
+    @Inject(UNKEY_INSTANCE) private unkey: Unkey,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    if (!request) {
+      throw new UnauthorizedException('Request object not available.');
+    }
+
+    const token = this.getBearerToken(request);
+
+    if (!token) {
+      throw new UnauthorizedException('Authorization token not found.');
+    }
+
+    const permissions = this.reflector.getAllAndOverride<string | undefined>(
+      VERIFY_KEY_PERMISSIONS,
+      [context.getHandler(), context.getClass()],
+    );
+
+    try {
+      const response = await this.unkey.keys.verifyKey({
+        key: token,
+        permissions,
+      });
+
+      const data = response.data;
+
+      if (!data) {
+        throw new UnauthorizedException('Key verification failed.');
+      }
+
+      if (data.valid) return true;
+
+      switch (data.code) {
+        case 'INSUFFICIENT_PERMISSIONS':
+        case 'FORBIDDEN':
+          throw new ForbiddenException(
+            permissions
+              ? `Key lacks required permission: ${permissions}`
+              : 'Key is forbidden from accessing this resource.',
+          );
+        default:
+          throw new UnauthorizedException('Invalid or expired key.');
+      }
+    } catch (error) {
+      if (
+        error instanceof UnauthorizedException ||
+        error instanceof ForbiddenException
+      ) {
+        throw error;
+      }
+      console.error('[VerifyKeyGuard] verifyKey error', error);
+      throw new UnauthorizedException('Authentication failed.');
+    }
+  }
+
+  private getBearerToken(request: Request): string | null {
+    const authorization = request.headers.authorization;
+
+    if (typeof authorization !== 'string') {
+      return null;
+    }
+
+    if (!authorization.startsWith('Bearer ')) {
+      return null;
+    }
+
+    const parts = authorization.split(' ');
+    if (parts.length !== 2 || !parts[1]) {
+      return null;
+    }
+
+    return parts[1].trim() || null;
+  }
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -72,7 +72,10 @@ async function bootstrap() {
     }),
   );
 
-  await app.listen(process.env.PORT ?? 3000);
+  const port = process.env.PORT ?? 3000;
+  await app.listen(port);
+
+  console.log(`🚀 API listening on port ${port}`);
 }
 
 void bootstrap();

--- a/api/src/private/cms/cms.controller.ts
+++ b/api/src/private/cms/cms.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, Param, Query, VERSION_NEUTRAL } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+
+import { VerifyKey } from '../../auth/verify-key.decorator';
+
+import { ArticleQueryDto } from './dto/article-query.dto';
+import { CmsService } from './cms.service';
+import type {
+  ArticleSingleResponse,
+  ArticlesListResponse,
+  AuthorsListResponse,
+  CategoriesListResponse,
+  TagsListResponse,
+} from './cms.types';
+
+@Controller({ version: VERSION_NEUTRAL })
+@ApiExcludeController()
+@VerifyKey({ permissions: 'cms.read' })
+export class CmsController {
+  constructor(private readonly cmsService: CmsService) {}
+
+  @Get('articles')
+  async listArticles(
+    @Query() query: ArticleQueryDto,
+  ): Promise<ArticlesListResponse> {
+    return this.cmsService.listArticles(query);
+  }
+
+  @Get('articles/:identifier')
+  async getArticle(
+    @Param('identifier') identifier: string,
+  ): Promise<ArticleSingleResponse> {
+    const data = await this.cmsService.getArticle(identifier);
+    return { data };
+  }
+
+  @Get('authors')
+  async listAuthors(): Promise<AuthorsListResponse> {
+    return this.cmsService.listAuthors();
+  }
+
+  @Get('categories')
+  async listCategories(): Promise<CategoriesListResponse> {
+    return this.cmsService.listCategories();
+  }
+
+  @Get('tags')
+  async listTags(): Promise<TagsListResponse> {
+    return this.cmsService.listTags();
+  }
+}

--- a/api/src/private/cms/cms.module.ts
+++ b/api/src/private/cms/cms.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { CmsController } from './cms.controller';
+import { CmsService } from './cms.service';
+
+@Module({
+  controllers: [CmsController],
+  providers: [CmsService],
+})
+export class CmsModule {}

--- a/api/src/private/cms/cms.service.ts
+++ b/api/src/private/cms/cms.service.ts
@@ -1,0 +1,395 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { SupabaseService } from '../../supabase/supabase.service';
+
+import type { ArticleQueryDto } from './dto/article-query.dto';
+import type {
+  ArticleResponse,
+  ArticlesListResponse,
+  AuthorResponse,
+  AuthorsListResponse,
+  CategoriesListResponse,
+  CategoryResponse,
+  CmsArticleRow,
+  CmsAuthorRow,
+  CmsCategoryRow,
+  CmsTagRow,
+  Pagination,
+  Social,
+  TagResponse,
+  TagsListResponse,
+} from './cms.types';
+
+const ARTICLE_ID_PREFIX = 'art_';
+
+type ArticleRowWithJoins = CmsArticleRow & {
+  category: CmsCategoryRow | null;
+  article_authors: Array<{
+    position: number;
+    author: CmsAuthorRow;
+  }>;
+  article_tags: Array<{
+    tag: CmsTagRow;
+  }>;
+};
+
+@Injectable()
+export class CmsService {
+  private readonly showDrafts: boolean;
+
+  constructor(
+    private readonly supabaseService: SupabaseService,
+    private readonly configService: ConfigService,
+  ) {
+    this.showDrafts =
+      this.configService.get<string>('CMS_SHOW_DRAFTS') === 'true';
+  }
+
+  private get client(): SupabaseClient {
+    return this.supabaseService
+      .supabaseServiceRole as unknown as SupabaseClient;
+  }
+
+  private articlesTable() {
+    return this.client.schema('cms' as never).from('articles');
+  }
+
+  private categoriesTable() {
+    return this.client.schema('cms' as never).from('categories');
+  }
+
+  private tagsTable() {
+    return this.client.schema('cms' as never).from('tags');
+  }
+
+  private authorsTable() {
+    return this.client.schema('cms' as never).from('authors');
+  }
+
+  private articleTagsTable() {
+    return this.client.schema('cms' as never).from('article_tags');
+  }
+
+  async listArticles(query: ArticleQueryDto): Promise<ArticlesListResponse> {
+    const limit = query.limit;
+    const page = query.page;
+    const offset = (page - 1) * limit;
+
+    let builder = this.articlesTable()
+      .select(
+        `
+          id,
+          slug,
+          title,
+          description,
+          content,
+          content_format,
+          cover_image_url,
+          featured,
+          status,
+          attribution,
+          category_id,
+          published_at,
+          created_at,
+          updated_at,
+          deleted_at,
+          category:categories(id, slug, name, description, created_at, updated_at, deleted_at),
+          article_authors(position, author:authors(id, slug, name, image_url, bio, role, socials, created_at, updated_at, deleted_at)),
+          article_tags(tag:tags(id, slug, name, description, created_at, updated_at, deleted_at))
+        `,
+        { count: 'exact' },
+      )
+      .is('deleted_at', null)
+      .order('published_at', { ascending: query.order === 'asc' })
+      .range(offset, offset + limit - 1);
+
+    if (!this.showDrafts) {
+      builder = builder.eq('status', 'published');
+    }
+
+    if (query.category?.length) {
+      const ids = await this.resolveSlugsToIds('categories', query.category);
+      if (ids.length === 0) return this.emptyList(limit, page);
+      builder = builder.in('category_id', ids);
+    }
+
+    if (query.exclude_category?.length) {
+      const ids = await this.resolveSlugsToIds(
+        'categories',
+        query.exclude_category,
+      );
+      if (ids.length) {
+        builder = builder.not('category_id', 'in', `(${ids.join(',')})`);
+      }
+    }
+
+    if (query.tag?.length) {
+      const articleIds = await this.articleIdsForTagSlugs(query.tag);
+      if (articleIds.length === 0) return this.emptyList(limit, page);
+      builder = builder.in('id', articleIds);
+    }
+
+    if (query.exclude_tag?.length) {
+      const articleIds = await this.articleIdsForTagSlugs(query.exclude_tag);
+      if (articleIds.length) {
+        builder = builder.not('id', 'in', `(${articleIds.join(',')})`);
+      }
+    }
+
+    if (typeof query.featured === 'boolean') {
+      builder = builder.eq('featured', query.featured);
+    }
+
+    if (query.q) {
+      const pattern = `%${query.q}%`;
+      builder = builder.or(
+        `title.ilike.${pattern},description.ilike.${pattern}`,
+      );
+    }
+
+    const { data, error, count } = await builder;
+
+    if (error) {
+      console.error('[cms-private] listArticles error', error);
+      throw new Error('Failed to fetch articles');
+    }
+
+    const rows = (data ?? []) as unknown as ArticleRowWithJoins[];
+    const totalItems = count ?? 0;
+
+    return {
+      data: rows.map(mapArticle),
+      pagination: buildPagination({
+        limit,
+        currentPage: page,
+        totalItems,
+      }),
+    };
+  }
+
+  async getArticle(identifier: string): Promise<ArticleResponse> {
+    const lookupColumn = identifier.startsWith(ARTICLE_ID_PREFIX)
+      ? 'id'
+      : 'slug';
+
+    let builder = this.articlesTable()
+      .select(
+        `
+          id,
+          slug,
+          title,
+          description,
+          content,
+          content_format,
+          cover_image_url,
+          featured,
+          status,
+          attribution,
+          category_id,
+          published_at,
+          created_at,
+          updated_at,
+          deleted_at,
+          category:categories(id, slug, name, description, created_at, updated_at, deleted_at),
+          article_authors(position, author:authors(id, slug, name, image_url, bio, role, socials, created_at, updated_at, deleted_at)),
+          article_tags(tag:tags(id, slug, name, description, created_at, updated_at, deleted_at))
+        `,
+      )
+      .eq(lookupColumn, identifier)
+      .is('deleted_at', null)
+      .limit(1);
+
+    if (!this.showDrafts) {
+      builder = builder.eq('status', 'published');
+    }
+
+    const { data, error } = await builder.maybeSingle();
+
+    if (error) {
+      console.error('[cms-private] getArticle error', error);
+      throw new Error('Failed to fetch article');
+    }
+
+    if (!data) {
+      throw new NotFoundException('Article not found');
+    }
+
+    return mapArticle(data as unknown as ArticleRowWithJoins);
+  }
+
+  async listAuthors(): Promise<AuthorsListResponse> {
+    const { data, error } = await this.authorsTable()
+      .select('id, slug, name, image_url, bio, role, socials')
+      .is('deleted_at', null)
+      .order('name', { ascending: true });
+
+    if (error) {
+      console.error('[cms-private] listAuthors error', error);
+      throw new Error('Failed to fetch authors');
+    }
+
+    return {
+      data: ((data ?? []) as unknown as CmsAuthorRow[]).map(mapAuthor),
+    };
+  }
+
+  async listCategories(): Promise<CategoriesListResponse> {
+    const { data, error } = await this.categoriesTable()
+      .select('id, slug, name, description')
+      .is('deleted_at', null)
+      .order('name', { ascending: true });
+
+    if (error) {
+      console.error('[cms-private] listCategories error', error);
+      throw new Error('Failed to fetch categories');
+    }
+
+    return {
+      data: ((data ?? []) as unknown as CmsCategoryRow[]).map(mapCategory),
+    };
+  }
+
+  async listTags(): Promise<TagsListResponse> {
+    const { data, error } = await this.tagsTable()
+      .select('id, slug, name, description')
+      .is('deleted_at', null)
+      .order('name', { ascending: true });
+
+    if (error) {
+      console.error('[cms-private] listTags error', error);
+      throw new Error('Failed to fetch tags');
+    }
+
+    return {
+      data: ((data ?? []) as unknown as CmsTagRow[]).map(mapTag),
+    };
+  }
+
+  private emptyList(limit: number, page: number): ArticlesListResponse {
+    return {
+      data: [],
+      pagination: buildPagination({ limit, currentPage: page, totalItems: 0 }),
+    };
+  }
+
+  private async resolveSlugsToIds(
+    table: 'categories' | 'tags',
+    slugs: string[],
+  ): Promise<string[]> {
+    const builder =
+      table === 'categories' ? this.categoriesTable() : this.tagsTable();
+
+    const { data, error } = await builder
+      .select('id')
+      .in('slug', slugs)
+      .is('deleted_at', null);
+
+    if (error) {
+      console.error(`[cms-private] resolveSlugsToIds(${table}) error`, error);
+      return [];
+    }
+
+    return ((data ?? []) as Array<{ id: string }>).map((r) => r.id);
+  }
+
+  private async articleIdsForTagSlugs(slugs: string[]): Promise<string[]> {
+    const tagIds = await this.resolveSlugsToIds('tags', slugs);
+    if (tagIds.length === 0) return [];
+
+    const { data, error } = await this.articleTagsTable()
+      .select('article_id')
+      .in('tag_id', tagIds);
+
+    if (error) {
+      console.error('[cms-private] articleIdsForTagSlugs error', error);
+      return [];
+    }
+
+    return [
+      ...new Set(
+        ((data ?? []) as Array<{ article_id: string }>).map(
+          (r) => r.article_id,
+        ),
+      ),
+    ];
+  }
+}
+
+// ── Mappers ────────────────────────────────────────────────────────
+
+function mapAuthor(row: CmsAuthorRow): AuthorResponse {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    image: row.image_url,
+    bio: row.bio,
+    role: row.role,
+    socials: (row.socials as Social[] | null) ?? [],
+  };
+}
+
+function mapCategory(row: CmsCategoryRow): CategoryResponse {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+  };
+}
+
+function mapTag(row: CmsTagRow): TagResponse {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+  };
+}
+
+function mapArticle(row: ArticleRowWithJoins): ArticleResponse {
+  const authors = (row.article_authors ?? [])
+    .slice()
+    .sort((a, b) => a.position - b.position)
+    .map((entry) => mapAuthor(entry.author));
+
+  const tags = (row.article_tags ?? []).map((entry) => mapTag(entry.tag));
+
+  return {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    description: row.description ?? '',
+    content: row.content ?? '',
+    featured: row.featured,
+    cover_image: row.cover_image_url,
+    published_at: row.published_at ?? row.updated_at,
+    updated_at: row.updated_at,
+    attribution: (row.attribution as ArticleResponse['attribution']) ?? null,
+    authors,
+    category: row.category ? mapCategory(row.category) : null,
+    tags,
+  };
+}
+
+function buildPagination({
+  limit,
+  currentPage,
+  totalItems,
+}: {
+  limit: number;
+  currentPage: number;
+  totalItems: number;
+}): Pagination {
+  const totalPages = Math.max(1, Math.ceil(totalItems / limit));
+  return {
+    limit,
+    current_page: currentPage,
+    next_page: currentPage < totalPages ? currentPage + 1 : null,
+    previous_page: currentPage > 1 ? currentPage - 1 : null,
+    total_items: totalItems,
+    total_pages: totalPages,
+  };
+}

--- a/api/src/private/cms/cms.types.ts
+++ b/api/src/private/cms/cms.types.ts
@@ -1,0 +1,144 @@
+export type ArticleStatus = 'draft' | 'published' | 'archived';
+export type ContentFormat = 'html' | 'markdown';
+
+export interface CmsAuthorRow {
+  id: string;
+  slug: string;
+  name: string;
+  image_url: string | null;
+  bio: string | null;
+  role: string | null;
+  socials: unknown;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+export interface CmsCategoryRow {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+export interface CmsTagRow {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+export interface CmsArticleRow {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  content: string | null;
+  content_format: ContentFormat;
+  cover_image_url: string | null;
+  featured: boolean;
+  status: ArticleStatus;
+  attribution: unknown;
+  category_id: string | null;
+  published_at: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+export interface CmsArticleAuthorRow {
+  article_id: string;
+  author_id: string;
+  position: number;
+}
+
+export interface CmsArticleTagRow {
+  article_id: string;
+  tag_id: string;
+}
+
+export interface Social {
+  url: string;
+  platform: string;
+}
+
+export interface AuthorResponse {
+  id: string;
+  slug: string;
+  name: string;
+  image: string | null;
+  bio: string | null;
+  role: string | null;
+  socials: Social[];
+}
+
+export interface CategoryResponse {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+}
+
+export interface TagResponse {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+}
+
+export interface Attribution {
+  author: string;
+  url: string;
+}
+
+export interface ArticleResponse {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  content: string;
+  featured: boolean;
+  cover_image: string | null;
+  published_at: string;
+  updated_at: string;
+  attribution: Attribution | null;
+  authors: AuthorResponse[];
+  category: CategoryResponse | null;
+  tags: TagResponse[];
+}
+
+export interface Pagination {
+  limit: number;
+  current_page: number;
+  next_page: number | null;
+  previous_page: number | null;
+  total_items: number;
+  total_pages: number;
+}
+
+export interface ArticlesListResponse {
+  data: ArticleResponse[];
+  pagination: Pagination;
+}
+
+export interface ArticleSingleResponse {
+  data: ArticleResponse;
+}
+
+export interface AuthorsListResponse {
+  data: AuthorResponse[];
+}
+
+export interface CategoriesListResponse {
+  data: CategoryResponse[];
+}
+
+export interface TagsListResponse {
+  data: TagResponse[];
+}

--- a/api/src/private/cms/dto/article-query.dto.ts
+++ b/api/src/private/cms/dto/article-query.dto.ts
@@ -1,0 +1,102 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+const toStringArray = ({ value }: { value: unknown }): string[] | undefined => {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((v) =>
+      typeof v === 'string'
+        ? v
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : [],
+    );
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  return undefined;
+};
+
+const toBoolean = ({ value }: { value: unknown }): boolean | undefined => {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+  }
+  return undefined;
+};
+
+export class ArticleQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(MAX_LIMIT)
+  limit: number = DEFAULT_LIMIT;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  order: 'asc' | 'desc' = 'desc';
+
+  @IsOptional()
+  @Transform(toStringArray)
+  @IsArray()
+  @IsString({ each: true })
+  category?: string[];
+
+  @IsOptional()
+  @Transform(toStringArray)
+  @IsArray()
+  @IsString({ each: true })
+  exclude_category?: string[];
+
+  @IsOptional()
+  @Transform(toStringArray)
+  @IsArray()
+  @IsString({ each: true })
+  tag?: string[];
+
+  @IsOptional()
+  @Transform(toStringArray)
+  @IsArray()
+  @IsString({ each: true })
+  exclude_tag?: string[];
+
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @IsOptional()
+  @Transform(toBoolean)
+  @IsBoolean()
+  featured?: boolean;
+}

--- a/api/src/private/private.module.ts
+++ b/api/src/private/private.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+
+import { CmsModule } from './cms/cms.module';
+
+/**
+ * PrivateModule — aggregates internal, non-customer-facing sub-modules and
+ * mounts them under the `/private/*` URL prefix. Every sub-module's
+ * controllers must use `@ProtectPrivate()` to authenticate requests and to
+ * stay out of the public OpenAPI document.
+ *
+ * Add future private sub-modules by (a) importing them here and (b) adding
+ * them as `children` on the `private` route below.
+ */
+@Module({
+  imports: [
+    CmsModule,
+    RouterModule.register([
+      {
+        path: 'private',
+        children: [{ path: 'cms', module: CmsModule }],
+      },
+    ]),
+  ],
+})
+export class PrivateModule {}

--- a/api/src/unkey/unkey.module.ts
+++ b/api/src/unkey/unkey.module.ts
@@ -2,11 +2,13 @@ import { Global, Module } from '@nestjs/common';
 import { Unkey } from '@unkey/api';
 import { ConfigService } from '@nestjs/config';
 
+export const UNKEY_INSTANCE = 'UNKEY_INSTANCE';
+
 @Global()
 @Module({
   providers: [
     {
-      provide: 'UNKEY_INSTANCE',
+      provide: UNKEY_INSTANCE,
       useFactory: (configService: ConfigService): Unkey => {
         const rootKey = configService.get<string>('UNKEY_ROOT_KEY');
 
@@ -14,15 +16,11 @@ import { ConfigService } from '@nestjs/config';
           throw new Error('UNKEY_ROOT_KEY is not defined');
         }
 
-        const client = new Unkey({
-          rootKey,
-        });
-
-        return client;
+        return new Unkey({ rootKey });
       },
       inject: [ConfigService],
     },
   ],
-  exports: ['UNKEY_INSTANCE'],
+  exports: [UNKEY_INSTANCE],
 })
 export class UnkeyModule {}

--- a/bun.lock
+++ b/bun.lock
@@ -996,7 +996,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -1310,7 +1310,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 
@@ -2948,11 +2948,7 @@
 
     "@post-for-me/api/@atproto/api": ["@atproto/api@0.14.22", "", { "dependencies": { "@atproto/common-web": "^0.4.1", "@atproto/lexicon": "^0.4.10", "@atproto/syntax": "^0.4.0", "@atproto/xrpc": "^0.6.12", "await-lock": "^2.2.2", "multiformats": "^9.9.0", "tlds": "^1.234.0", "zod": "^3.23.8" } }, "sha512-ziXPau+sUdFovObSnsoN7JbOmUw1C5e5L28/yXf3P8vbEnSS3HVVGD1jYcscBYY34xQqi4bVDpwMYx/4yRsTuQ=="],
 
-    "@post-for-me/api/@supabase/supabase-js": ["@supabase/supabase-js@2.87.1", "", { "dependencies": { "@supabase/auth-js": "2.87.1", "@supabase/functions-js": "2.87.1", "@supabase/postgrest-js": "2.87.1", "@supabase/realtime-js": "2.87.1", "@supabase/storage-js": "2.87.1" } }, "sha512-tVgqZqnHZVum584KuUKSQZgcy6ZkhVd6gG8QWg2QfIXH9HmXdamauxdVsLXwaNPJxEdOyfAfwIyi5XUsiVYWtg=="],
-
     "@post-for-me/api/@trigger.dev/sdk": ["@trigger.dev/sdk@4.0.0-v4-beta.27", "", { "dependencies": { "@opentelemetry/api": "1.9.0", "@opentelemetry/semantic-conventions": "1.36.0", "@trigger.dev/core": "4.0.0-v4-beta.27", "chalk": "^5.2.0", "cronstrue": "^2.21.0", "debug": "^4.3.4", "evt": "^2.4.13", "slug": "^6.0.0", "ulid": "^2.3.0", "uncrypto": "^0.1.3", "uuid": "^9.0.0", "ws": "^8.11.0" }, "peerDependencies": { "ai": "^4.2.0", "zod": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["ai"] }, "sha512-iSxXkcb7rcMF6aG1Xqq3TFHOkAWG6zrkV7lKjqRu/qRS31mbx2dlSgsB1UHFsL47vGpkrebTIkcQreXIp2GSpA=="],
-
-    "@post-for-me/api/@unkey/api": ["@unkey/api@2.2.0", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-XoFWPbZnyos04u+qQTAT+lHymRTNidMK64QywZaWNKbJmorPDd/jZlyKZvL+LNxxBlFXcHOHFtPHPk90wWmcvg=="],
 
     "@post-for-me/api/googleapis": ["googleapis@144.0.0", "", { "dependencies": { "google-auth-library": "^9.0.0", "googleapis-common": "^7.0.0" } }, "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw=="],
 
@@ -3206,6 +3202,8 @@
 
     "handlebars/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "icons/@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+
     "istanbul-lib-instrument/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "istanbul-lib-source-maps/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -3400,16 +3398,6 @@
 
     "@post-for-me/api/@atproto/api/@atproto/xrpc": ["@atproto/xrpc@0.6.12", "", { "dependencies": { "@atproto/lexicon": "^0.4.10", "zod": "^3.23.8" } }, "sha512-Ut3iISNLujlmY9Gu8sNU+SPDJDvqlVzWddU8qUr0Yae5oD4SguaUFjjhireMGhQ3M5E0KljQgDbTmnBo1kIZ3w=="],
 
-    "@post-for-me/api/@supabase/supabase-js/@supabase/auth-js": ["@supabase/auth-js@2.87.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-6RDeOf5TVoaXFtEstN188ykp3pXLZaU9qoAWfx8dc50FFAAqt+kcFJ96V0IvSmcpb4mDAWcpTJ7BegmVDn/WIw=="],
-
-    "@post-for-me/api/@supabase/supabase-js/@supabase/functions-js": ["@supabase/functions-js@2.87.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-rWmYo4gRD0XAjMhYDlz7IH67bp4TIQ1UE4VqwIQtl1gGPwtLDq6wcRnu7jLKlXx0Gtrknw/eoiHYG9//XrCTzQ=="],
-
-    "@post-for-me/api/@supabase/supabase-js/@supabase/postgrest-js": ["@supabase/postgrest-js@2.87.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-Yzu5eL3iGmZW0C/8x+vEojAOou63FI9oVw8HI8YOq63+5yM8g8aGh7Y1E2vbXFb7+gHGsPqLnaC6dPhrYt7qBA=="],
-
-    "@post-for-me/api/@supabase/supabase-js/@supabase/realtime-js": ["@supabase/realtime-js@2.87.1", "", { "dependencies": { "@types/phoenix": "^1.6.6", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-XvLtEznxmYZXA7LYuy5zbSXpSYjDLJq2wQeRh3MzON2OR4U8Kq+RtPz2E2Wi8HEzvBfsc+nNu1TG8LQ9+3DRkA=="],
-
-    "@post-for-me/api/@supabase/supabase-js/@supabase/storage-js": ["@supabase/storage-js@2.87.1", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-0Uc8tNV4yzkNNmp1inpXru0RB4a7ECq05G2S6BDvSpMxTxJrDVJ4vVDwyhqB8ZZ+O9+8prHaQYoByQeuDnwpFQ=="],
-
     "@post-for-me/api/@trigger.dev/sdk/@trigger.dev/core": ["@trigger.dev/core@4.0.0-v4-beta.27", "", { "dependencies": { "@bugsnag/cuid": "^3.1.1", "@electric-sql/client": "1.0.0-beta.1", "@google-cloud/precise-date": "^4.0.0", "@jsonhero/path": "^1.0.21", "@opentelemetry/api": "1.9.0", "@opentelemetry/api-logs": "0.203.0", "@opentelemetry/core": "2.0.1", "@opentelemetry/exporter-logs-otlp-http": "0.203.0", "@opentelemetry/exporter-trace-otlp-http": "0.203.0", "@opentelemetry/instrumentation": "0.203.0", "@opentelemetry/resources": "2.0.1", "@opentelemetry/sdk-logs": "0.203.0", "@opentelemetry/sdk-trace-base": "2.0.1", "@opentelemetry/sdk-trace-node": "2.0.1", "@opentelemetry/semantic-conventions": "1.36.0", "dequal": "^2.0.3", "eventsource": "^3.0.5", "eventsource-parser": "^3.0.0", "execa": "^8.0.1", "humanize-duration": "^3.27.3", "jose": "^5.4.0", "lodash.get": "^4.4.2", "nanoid": "3.3.8", "prom-client": "^15.1.0", "socket.io": "4.7.4", "socket.io-client": "4.7.5", "std-env": "^3.8.1", "superjson": "^2.2.1", "tinyexec": "^0.3.2", "uncrypto": "^0.1.3", "zod": "3.25.76", "zod-error": "1.5.0", "zod-validation-error": "^1.5.0" } }, "sha512-PJzW07GbxeHKigZ0AiO4aAtDdb2r5iioI7P6TLTqp3XfsxLb1ezPNv3zt6dy1uvZsefGR/EO4y7X0VN1pJyLTA=="],
 
     "@post-for-me/api/@trigger.dev/sdk/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
@@ -3549,6 +3537,8 @@
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "fork-ts-checker-webpack-plugin/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "icons/@types/bun/bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 
     "jest-changed-files/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 

--- a/supabase/migrations/20260420120000_cms_articles.sql
+++ b/supabase/migrations/20260420120000_cms_articles.sql
@@ -1,0 +1,162 @@
+------------------------------- 1. ARTICLES: AUTHORS ------------------
+CREATE TABLE cms.authors (
+    id text PRIMARY KEY DEFAULT nanoid('aut'),
+    slug text NOT NULL,
+    name text NOT NULL,
+    image_url text,
+    bio text,
+    role text,
+    socials jsonb NOT NULL DEFAULT '[]'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE INDEX idx_cms_authors_slug ON cms.authors(slug) WHERE deleted_at IS NULL;
+
+------------------------------- 2. ARTICLES: CATEGORIES --------------
+CREATE TABLE cms.categories (
+    id text PRIMARY KEY DEFAULT nanoid('cat'),
+    slug text NOT NULL,
+    name text NOT NULL,
+    description text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE INDEX idx_cms_categories_slug ON cms.categories(slug) WHERE deleted_at IS NULL;
+
+------------------------------- 3. ARTICLES: TAGS --------------------
+CREATE TABLE cms.tags (
+    id text PRIMARY KEY DEFAULT nanoid('tag'),
+    slug text NOT NULL,
+    name text NOT NULL,
+    description text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE INDEX idx_cms_tags_slug ON cms.tags(slug) WHERE deleted_at IS NULL;
+
+------------------------------- 4. ARTICLES --------------------------
+CREATE TABLE cms.articles (
+    id text PRIMARY KEY DEFAULT nanoid('art'),
+    slug text NOT NULL UNIQUE,
+    title text NOT NULL,
+    description text,
+    content text,
+    content_format text NOT NULL DEFAULT 'html' CHECK (content_format IN ('html','markdown')),
+    cover_image_url text,
+    featured boolean NOT NULL DEFAULT false,
+    status text NOT NULL DEFAULT 'published' CHECK (status IN ('draft','published','archived')),
+    attribution jsonb,
+    category_id text REFERENCES cms.categories(id) ON DELETE SET NULL,
+    published_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE INDEX idx_cms_articles_status_published_at
+    ON cms.articles(status, published_at DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_cms_articles_category_id
+    ON cms.articles(category_id)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_cms_articles_featured
+    ON cms.articles(featured)
+    WHERE featured = true AND deleted_at IS NULL;
+
+CREATE INDEX idx_cms_articles_slug
+    ON cms.articles(slug)
+    WHERE deleted_at IS NULL;
+
+------------------------------- 5. JOIN TABLES -----------------------
+CREATE TABLE cms.article_authors (
+    article_id text NOT NULL REFERENCES cms.articles(id) ON DELETE CASCADE,
+    author_id text NOT NULL REFERENCES cms.authors(id) ON DELETE CASCADE,
+    position integer NOT NULL DEFAULT 0,
+    PRIMARY KEY (article_id, author_id)
+);
+
+CREATE INDEX idx_cms_article_authors_author_id ON cms.article_authors(author_id);
+
+CREATE TABLE cms.article_tags (
+    article_id text NOT NULL REFERENCES cms.articles(id) ON DELETE CASCADE,
+    tag_id text NOT NULL REFERENCES cms.tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (article_id, tag_id)
+);
+
+CREATE INDEX idx_cms_article_tags_tag_id ON cms.article_tags(tag_id);
+
+------------------------------- 6. TRIGGERS --------------------------
+CREATE TRIGGER trg_cms_authors_updated
+    BEFORE UPDATE ON cms.authors
+    FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+
+CREATE TRIGGER trg_cms_categories_updated
+    BEFORE UPDATE ON cms.categories
+    FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+
+CREATE TRIGGER trg_cms_tags_updated
+    BEFORE UPDATE ON cms.tags
+    FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+
+CREATE TRIGGER trg_cms_articles_updated
+    BEFORE UPDATE ON cms.articles
+    FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+
+------------------------------- 7. RLS -------------------------------
+ALTER TABLE cms.authors          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cms.categories       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cms.tags             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cms.articles         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cms.article_authors  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cms.article_tags     ENABLE ROW LEVEL SECURITY;
+
+/* Public can read live (non-deleted) reference data. */
+CREATE POLICY "Public read: authors"
+    ON cms.authors FOR SELECT
+    USING (deleted_at IS NULL);
+
+CREATE POLICY "Public read: categories"
+    ON cms.categories FOR SELECT
+    USING (deleted_at IS NULL);
+
+CREATE POLICY "Public read: tags"
+    ON cms.tags FOR SELECT
+    USING (deleted_at IS NULL);
+
+/* Articles: only published, non-deleted rows are publicly readable. */
+CREATE POLICY "Public read: articles"
+    ON cms.articles FOR SELECT
+    USING (status = 'published' AND deleted_at IS NULL);
+
+/* Joins are visible only when the article side is visible. */
+CREATE POLICY "Public read: article_authors"
+    ON cms.article_authors FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM cms.articles a
+            WHERE a.id = article_authors.article_id
+              AND a.status = 'published'
+              AND a.deleted_at IS NULL
+        )
+    );
+
+CREATE POLICY "Public read: article_tags"
+    ON cms.article_tags FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM cms.articles a
+            WHERE a.id = article_tags.article_id
+              AND a.status = 'published'
+              AND a.deleted_at IS NULL
+        )
+    );
+
+/* ---------- Done ✔︎ ------------------------------------------- */


### PR DESCRIPTION
Adds a new `private` namespace where we can put internal tool calling, web hooks, etc.

Adds the first `cms` module into the `private` namespace so we can use our own internal CMS