### PR TITLE
Upcoming invoice patch

### DIFF
--- a/api/src/private/webhooks/stripe/stripe-sync.service.ts
+++ b/api/src/private/webhooks/stripe/stripe-sync.service.ts
@@ -242,6 +242,11 @@ export class StripeSyncService {
   }
 
   async upsertInvoice(db: SyncDb, invoice: Stripe.Invoice): Promise<void> {
+    // `invoice.upcoming` previews arrive without an `id` — Stripe synthesises
+    // them ~1h before renewal and they never become real invoices. Persisting
+    // them would violate the NOT NULL PK; skip and let the eventual real
+    // `invoice.created` / `.finalized` event populate the row.
+    if (!invoice.id) return;
     const customerId =
       typeof invoice.customer === 'string'
         ? invoice.customer
@@ -288,7 +293,7 @@ export class StripeSyncService {
     };
     await db
       .insertInto('stripe.invoices')
-      .values({ id: invoice.id! as InvoicesId, ...row })
+      .values({ id: invoice.id as InvoicesId, ...row })
       .onConflict((oc) => oc.column('id').doUpdateSet(row))
       .execute();
   }

--- a/api/src/private/webhooks/stripe/stripe.controller.ts
+++ b/api/src/private/webhooks/stripe/stripe.controller.ts
@@ -53,6 +53,11 @@ export class StripeWebhookController {
       );
     }
 
+    // early return for failed invoice.upcoming event
+    if (event.type === 'invoice.upcoming') {
+      return { received: true };
+    }
+
     try {
       await this.stripeWebhookService.handleEvent(event);
     } catch (err) {


### PR DESCRIPTION
There's an error with `upcoming.invoice` requests not containing an ID. There's 2 patches in here:

1. controller level kill switch to disable processing that event for right now
2. a proposed more mature solution to handle the missing `id` properly