### PR TITLE
Update CD with Unkey now our primary host

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,16 +111,8 @@ jobs:
     outputs:
       docker: ${{ steps.docker.outcome }}
       unkey: ${{ steps.unkey.outcome }}
-      railway: ${{ steps.railway.outcome }}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: api/.bun-version
-
-      - name: Install Railway CLI
-        run: bun add -g @railway/cli
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -161,6 +153,37 @@ jobs:
           UNKEY_PROJECT: post-for-me-api
           UNKEY_APP: default
         run: ./unkey deploy --env=production ghcr.io/daymoondevelopment/api:${{ github.sha }}
+
+  # ---------------------------------------------------------------------------
+  # Railway backup deploy — secondary, non-blocking.
+  #
+  # Unkey (deploy-api) is the primary host for the API; Railway is a warm
+  # backup. This job builds + deploys the API to Railway from source via
+  # `railway up` (Railway's own builder). It is deliberately:
+  #   - gated on deploy-api, so it only fires after the Unkey deploy succeeds
+  #   - absent from deploy-trigger/dashboard/marketing's `needs`, so a slow or
+  #     broken Railway build never holds up the rest of the deploy
+  #   - continue-on-error, so a Railway failure surfaces in Slack and the job
+  #     badge without failing the overall workflow run
+  # ---------------------------------------------------------------------------
+  deploy-api-railway-backup:
+    name: Deploy API to Railway (backup)
+    needs: deploy-api
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    outputs:
+      railway: ${{ steps.railway.outcome }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: api/.bun-version
+
+      - name: Install Railway CLI
+        run: bun add -g @railway/cli
 
       - name: Deploy API to Railway
         id: railway
@@ -264,7 +287,7 @@ jobs:
 
   notify-final:
     name: Notify Slack — Final
-    needs: [notify-start, precheck, migrate, deploy-api, deploy-trigger, deploy-dashboard, deploy-marketing]
+    needs: [notify-start, precheck, migrate, deploy-api, deploy-api-railway-backup, deploy-trigger, deploy-dashboard, deploy-marketing]
     if: always()
     runs-on: ubuntu-latest
     env:
@@ -288,7 +311,7 @@ jobs:
           PRECHECK_STATUS=$(status "${{ needs.precheck.result }}")
           SUPABASE_STATUS=$(status "${{ needs.migrate.outputs.supabase }}")
           TRIGGER_STATUS=$(status "${{ needs.deploy-trigger.outputs.deploy }}")
-          API_STATUS=$(status "${{ needs.deploy-api.outputs.railway }}")
+          API_STATUS=$(status "${{ needs.deploy-api-railway-backup.outputs.railway }}")
           UNKEY_STATUS=$(status "${{ needs.deploy-api.outputs.unkey }}")
           DASHBOARD_STATUS=$(status "${{ needs.deploy-dashboard.outputs.vercel }}")
           MARKETING_STATUS=$(status "${{ needs.deploy-marketing.outputs.vercel }}")

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,6 +2,9 @@
 #
 # Multi-stage build for the PostForMe API.
 #
+# NOTE: ./Dockerfile.railway is a near-copy of this file for Railway's Metal
+# builder, which cannot use the --mount=type=secret below. Keep them in sync.
+#
 # Stages:
 #   deps    — install dependencies with Bun (cached layer, reused by build)
 #   build   — compile TypeScript, upload Sentry source maps

--- a/api/Dockerfile.railway
+++ b/api/Dockerfile.railway
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1
+#
+# Railway-specific multi-stage build for the PostForMe API.
+#
+# This is a near-copy of ./Dockerfile, kept separate ONLY because Railway's
+# Metal builder rejects BuildKit secret mounts (--mount=type=secret). Two
+# deliberate differences from ./Dockerfile:
+#   1. No Sentry source map upload. The GitHub Actions build (./Dockerfile)
+#      already uploads source maps to Sentry for every release, so repeating
+#      it from the Railway build would be redundant.
+#   2. Because there is no upload, the build stage drops the Sentry build
+#      args and the ca-certificates install (that CA bundle existed solely
+#      for sentry-cli's HTTPS upload).
+# Keep this file in sync with ./Dockerfile for every other change.
+#
+# Temporary: when Railway is retired, delete this file and point the
+# dockerfilePath in api/railway.json back at ./Dockerfile.
+#
+# Stages:
+#   deps    — install dependencies with Bun (cached layer, reused by build)
+#   build   — compile TypeScript
+#   runtime — minimal Node.js image that actually runs in production
+#
+# Build context is the api/ directory.
+#
+# Optional build arg (non-sensitive, safe to pass via --build-arg):
+#   SENTRY_RELEASE — release identifier (typically the git SHA). Baked into the
+#                    runtime image so the Sentry SDK tags errors with the same
+#                    release the source maps were uploaded under by the
+#                    ./Dockerfile build. Unset just leaves it blank.
+
+# -----------------------------------------------------------------------------
+# Stage 1 — deps
+# Install all dependencies. Kept as its own stage so the node_modules layer is
+# shared with `build` without re-running install when source files change.
+# -----------------------------------------------------------------------------
+FROM oven/bun:1.3.3 AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+# -----------------------------------------------------------------------------
+# Stage 2 — build
+# Compile TypeScript. No Sentry source map upload here (see header) — so no
+# ca-certificates install and no Sentry build args, unlike ./Dockerfile.
+# -----------------------------------------------------------------------------
+FROM deps AS build
+WORKDIR /app
+COPY . .
+RUN bun run build
+
+# -----------------------------------------------------------------------------
+# Stage 3 — runtime
+# Minimal Node.js image. Bun is not present here — only the compiled output
+# from the build stage and its node_modules are copied across.
+#
+# node_modules is copied from the build stage rather than re-installed so that
+# the runtime image uses exactly the same dependency tree that was compiled
+# against.
+# -----------------------------------------------------------------------------
+FROM node:22-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+
+# Baked in so the Sentry runtime SDK reports the same release that source maps
+# were uploaded under (by the ./Dockerfile build). Declared after the COPYs so
+# node_modules remains cacheable across commits (ARG changes invalidate all
+# subsequent layers).
+ARG SENTRY_RELEASE
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
+
+EXPOSE 3000
+CMD ["node", "dist/src/main"]

--- a/api/railway.json
+++ b/api/railway.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "dockerfilePath": "/api/Dockerfile"
+    "dockerfilePath": "/api/Dockerfile.railway"
   },
   "deploy": {
     "runtime": "V2",


### PR DESCRIPTION
Updates the CD with some changes now that Unkey is the primary hosting provider. Railway's Dockerfile is split out into its own since we can't do secret injection with Railway. It also puts the Railway build into a non-blocking sub-process since all resources will point to Unkey deploys, anyway.