### PR TITLE
marketing: /open-source-social-media-api landing page

### DIFF
--- a/marketing/app/components/footer.tsx
+++ b/marketing/app/components/footer.tsx
@@ -40,6 +40,10 @@ const getFooterSections = (resources: ResourcePreview[] = []) => [
         title: "API Documentation",
         href: "https://api.postforme.dev/docs",
       },
+      {
+        title: "Open Source",
+        href: "/open-source-social-media-api",
+      },
     ],
   },
   {

--- a/marketing/app/components/github-stars-badge.tsx
+++ b/marketing/app/components/github-stars-badge.tsx
@@ -1,0 +1,42 @@
+import { IconStar } from "@central-icons/filled";
+import { IconGithub } from "@central-icons/outlined";
+
+import { Link } from "~/components/link";
+
+import { GITHUB_URL } from "~/lib/constants";
+import { cn } from "~/lib/utils";
+
+function formatStars(count: number): string {
+  if (count >= 1000) {
+    const k = count / 1000;
+    return `${k.toFixed(k >= 10 ? 0 : 1)}k`;
+  }
+  return count.toLocaleString();
+}
+
+export const GitHubStarsBadge = ({
+  stars,
+  className,
+}: {
+  stars: number;
+  className?: string;
+}) => {
+  return (
+    <Link
+      to={GITHUB_URL}
+      target="_blank"
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border bg-card pl-3 pr-1 py-1 text-sm font-medium hover:bg-muted transition-colors",
+        className,
+      )}
+      aria-label={`View Post for Me on GitHub. ${stars} stars.`}
+    >
+      <IconGithub className="size-4" />
+      <span>Star on GitHub</span>
+      <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs">
+        <IconStar className="size-3" />
+        {formatStars(stars)}
+      </span>
+    </Link>
+  );
+};

--- a/marketing/app/components/open-source-section.tsx
+++ b/marketing/app/components/open-source-section.tsx
@@ -1,30 +1,42 @@
-import { IconArrowRight } from "@central-icons/outlined";
+import { IconGithub } from "@central-icons/filled";
+import { IconArrowRight, IconArrowUpRight } from "@central-icons/outlined";
 
 import { Link } from "~/components/link";
 
+import { GITHUB_URL } from "~/lib/constants";
+
 import { Badge } from "~/ui/badge";
+import { Button } from "~/ui/button";
 
 export const OpenSource = () => (
   <div
     id="open-source"
     className="flex items-center justify-center py-16 bg-muted"
   >
-    <div className="text-center">
+    <div className="text-center max-w-2xl px-6">
       <Badge>Open Source</Badge>
-      <h2 className="mt-3 text-2xl md:text-4xl font-semibold tracking-tight max-w-xl text-balanced">
-        We believe in the power of open source for transparency and trust.
+      <h2 className="mt-3 text-2xl md:text-4xl font-semibold tracking-tight max-w-xl text-balanced mx-auto">
+        Built in the open, so you can trust what your product runs on.
       </h2>
-      <p className="mt-4 text-base sm:text-lg text-muted-foreground flex flex-row gap-1.5 items-center justify-center text-center mx-12">
-        Check out our codebase on
-        <Link
-          to="https://github.com/DayMoonDevelopment/post-for-me"
-          target="_blank"
-          className="flex flex-row gap-0.5 items-center hover:underline underline-offset-3"
-        >
-          GitHub
-          <IconArrowRight className="size-4" />
-        </Link>
+      <p className="mt-4 text-base sm:text-lg text-muted-foreground">
+        Every commit, every pull request, every roadmap decision is public on
+        GitHub.
       </p>
+      <div className="mt-6 flex flex-col sm:flex-row items-center justify-center gap-3">
+        <Button asChild>
+          <Link to="/open-source-social-media-api">
+            Why we open-sourced it
+            <IconArrowRight className="size-4" />
+          </Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link to={GITHUB_URL} target="_blank">
+            <IconGithub className="size-4" />
+            Star on GitHub
+            <IconArrowUpRight className="size-4" />
+          </Link>
+        </Button>
+      </div>
     </div>
   </div>
 );

--- a/marketing/app/lib/.server/github.ts
+++ b/marketing/app/lib/.server/github.ts
@@ -1,0 +1,53 @@
+const REPO = "DayMoonDevelopment/post-for-me";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const FALLBACK_STARS = 100;
+
+type CacheEntry = { stars: number; fetchedAt: number };
+
+let cache: CacheEntry | null = null;
+let inflight: Promise<number> | null = null;
+
+async function fetchStars(): Promise<number> {
+  const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "post-for-me-marketing",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub responded ${res.status}`);
+  }
+
+  const data = (await res.json()) as { stargazers_count?: number };
+  return typeof data.stargazers_count === "number"
+    ? data.stargazers_count
+    : FALLBACK_STARS;
+}
+
+export async function getGitHubStars(): Promise<number> {
+  const now = Date.now();
+
+  if (cache && now - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.stars;
+  }
+
+  if (inflight) {
+    return inflight;
+  }
+
+  inflight = fetchStars()
+    .then((stars) => {
+      cache = { stars, fetchedAt: now };
+      return stars;
+    })
+    .catch(() => {
+      if (cache) return cache.stars;
+      return FALLBACK_STARS;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+
+  return inflight;
+}

--- a/marketing/app/lib/.server/sitemap.config.ts
+++ b/marketing/app/lib/.server/sitemap.config.ts
@@ -146,6 +146,7 @@ export function generateStaticSitemapUrls(): SitemapUrl[] {
     "/social-media/posting",
     "/social-media/feeds",
     "/social-media/analytics",
+    "/open-source-social-media-api",
   ];
 
   urls.push(

--- a/marketing/app/routes/_root.compare.$path._index/components/open-source-callout.tsx
+++ b/marketing/app/routes/_root.compare.$path._index/components/open-source-callout.tsx
@@ -1,0 +1,50 @@
+import { IconGithub, IconUnlocked } from "@central-icons/filled";
+import { IconArrowUpRight } from "@central-icons/outlined";
+import { useLoaderData } from "react-router";
+
+import { Link } from "~/components/link";
+
+import { Badge } from "~/ui/badge";
+import { Button } from "~/ui/button";
+
+import type { Route } from "../+types/route";
+
+export const OpenSourceCallout = () => {
+  const { comparison } = useLoaderData<Route.ComponentProps["loaderData"]>();
+  const competitorName = comparison.competitor.name;
+
+  return (
+    <div className="bg-background">
+      <div className="max-w-(--breakpoint-xl) w-full py-12 px-4 mx-auto">
+        <div className="max-w-4xl mx-auto rounded-2xl border bg-muted/30 p-8 md:p-10 flex flex-col md:flex-row gap-6 items-start md:items-center">
+          <div className="flex items-center justify-center size-14 rounded-2xl bg-background border shrink-0">
+            <IconUnlocked className="size-7 text-pop" />
+          </div>
+
+          <div className="flex-1 flex flex-col gap-2">
+            <Badge variant="outline" className="self-start">
+              Open Source
+            </Badge>
+            <h3 className="text-xl md:text-2xl font-semibold tracking-tight">
+              {`Post for Me is built in the open. ${competitorName} isn't.`}
+            </h3>
+            <p className="text-muted-foreground leading-relaxed">
+              Read every line of code that handles your tokens. Watch the
+              roadmap in public. Open an issue for the feature you need.
+            </p>
+          </div>
+
+          <div className="flex-shrink-0">
+            <Button asChild>
+              <Link to="/open-source-social-media-api">
+                <IconGithub className="size-4" />
+                How we build in the open
+                <IconArrowUpRight className="size-4" />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/marketing/app/routes/_root.compare.$path._index/route.component.tsx
+++ b/marketing/app/routes/_root.compare.$path._index/route.component.tsx
@@ -1,6 +1,7 @@
 import { Hero } from "./components/hero";
 import { IntentOfUseNotice } from "./components/intent-of-use-notice";
 import { KeyFeatures } from "./components/key-features";
+import { OpenSourceCallout } from "./components/open-source-callout";
 import { PricingTable } from "./components/pricing-table";
 import { Proposition } from "./components/proposition";
 import { SdkComparison } from "./components/sdk-comparison";
@@ -12,6 +13,7 @@ export function Component() {
       <Hero />
       <KeyFeatures />
       <PricingTable />
+      <OpenSourceCallout />
       <Proposition />
       <YouMightUse />
       <SdkComparison />

--- a/marketing/app/routes/_root.open-source-social-media-api._index/components/build-in-public.tsx
+++ b/marketing/app/routes/_root.open-source-social-media-api._index/components/build-in-public.tsx
@@ -1,0 +1,77 @@
+import { IconDiscord } from "@central-icons/filled";
+import { IconArrowUpRight } from "@central-icons/outlined";
+
+import { Link } from "~/components/link";
+import { XBrandIcon } from "~/components/x-brand-icon";
+
+import { Badge } from "~/ui/badge";
+
+const DISCORD_URL = "https://discord.gg/Nv6xEZ2vP5";
+const X_URL = "https://x.com/postforme_dev";
+
+const channels = [
+  {
+    name: "Join the Discord",
+    handle: "discord.gg/Nv6xEZ2vP5",
+    description:
+      "Drop into the channel where we ship. Ask questions, share what you're building, and see what we're working on before it lands.",
+    href: DISCORD_URL,
+    icon: IconDiscord,
+  },
+  {
+    name: "Follow on X",
+    handle: "@postforme_dev",
+    description:
+      "We post the build log in public. New features, weird bugs, what we learned shipping social media integrations across nine platforms.",
+    href: X_URL,
+    icon: XBrandIcon,
+  },
+];
+
+export const BuildInPublic = () => {
+  return (
+    <div id="build-in-public" className="bg-background scroll-mt-16">
+      <div className="max-w-(--breakpoint-xl) w-full py-20 px-4 mx-auto">
+        <div className="text-center mb-12 max-w-3xl mx-auto">
+          <Badge variant="outline">Building in public</Badge>
+          <h2 className="mt-4 text-3xl md:text-4xl lg:text-5xl font-semibold tracking-[-0.03em] text-balance">
+            Watch us build it. Talk to us while we&apos;re building it.
+          </h2>
+          <p className="mt-4 text-lg text-muted-foreground text-balance">
+            The work happens on GitHub. The conversation happens on Discord and
+            X. Pick the channel that fits how you like to follow along.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+          {channels.map(({ name, handle, description, href, icon: Icon }) => (
+            <Link
+              key={name}
+              to={href}
+              target="_blank"
+              className="group flex flex-col gap-4 p-6 md:p-8 rounded-2xl border bg-card hover:border-foreground/20 transition-colors"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center justify-center size-12 rounded-xl bg-muted">
+                  <Icon className="size-6" />
+                </div>
+                <IconArrowUpRight className="size-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <h3 className="text-xl font-semibold">{name}</h3>
+                <p className="text-sm font-mono text-muted-foreground">
+                  {handle}
+                </p>
+              </div>
+
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {description}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/marketing/app/routes/_root.open-source-social-media-api._index/components/final-cta.tsx
+++ b/marketing/app/routes/_root.open-source-social-media-api._index/components/final-cta.tsx
@@ -1,0 +1,64 @@
+import { IconGithub } from "@central-icons/filled";
+import { IconArrowUpRight } from "@central-icons/outlined";
+import { useLoaderData } from "react-router";
+
+import { GitHubStarsBadge } from "~/components/github-stars-badge";
+import { Link } from "~/components/link";
+
+import { APP_URL, GITHUB_URL } from "~/lib/constants";
+
+import { Button } from "~/ui/button";
+
+import type { Route } from "../+types/route";
+
+export const FinalCta = () => {
+  const { stars } = useLoaderData<Route.ComponentProps["loaderData"]>();
+
+  return (
+    <div className="px-4 py-16">
+      <div className="max-w-(--breakpoint-xl) mx-auto">
+        <div className="dark rounded-3xl bg-card text-card-foreground overflow-hidden border p-10 md:p-16 flex flex-col items-center text-center gap-6">
+          <IconGithub className="size-10" />
+
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight max-w-2xl text-balance">
+            Star us. Read the code. Ship the thing.
+          </h2>
+
+          <p className="text-muted-foreground text-lg max-w-2xl text-balance">
+            The fastest way to support an open source project is a star. The
+            second-fastest is to build something with it.
+          </p>
+
+          <div className="mt-2 flex flex-col sm:flex-row items-center gap-3">
+            <Button size="lg" className="rounded-full text-base" asChild>
+              <Link to={GITHUB_URL} target="_blank">
+                <IconGithub className="h-5! w-5!" />
+                Star on GitHub
+                <IconArrowUpRight className="h-5! w-5!" />
+              </Link>
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              className="rounded-full text-base"
+              asChild
+            >
+              <Link to={APP_URL} target="_blank">
+                Get Started
+              </Link>
+            </Button>
+          </div>
+
+          <div className="mt-4">
+            <GitHubStarsBadge stars={stars} />
+          </div>
+
+          <p className="mt-6 text-xs text-muted-foreground max-w-xl">
+            The repo is public. You can fork it, self-host it, or just read it.
+            Reach out if you do.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/marketing/app/routes/_root.open-source-social-media-api._index/components/hero.tsx
+++ b/marketing/app/routes/_root.open-source-social-media-api._index/components/hero.tsx
@@ -1,0 +1,57 @@
+import { IconArrowUpRight } from "@central-icons/outlined";
+import { useLoaderData } from "react-router";
+
+import { GitHubStarsBadge } from "~/components/github-stars-badge";
+import { Link } from "~/components/link";
+
+import { APP_URL } from "~/lib/constants";
+
+import { Button } from "~/ui/button";
+
+import type { Route } from "../+types/route";
+
+export const Hero = () => {
+  const { stars } = useLoaderData<Route.ComponentProps["loaderData"]>();
+
+  return (
+    <div className="relative flex items-center justify-center px-6 pt-28 pb-20 md:pt-36 md:pb-28 overflow-hidden">
+      {/* Decorative dot grid background. Placeholder visual. */}
+      <div
+        aria-hidden
+        className="absolute inset-0 -z-10 [background-image:radial-gradient(var(--color-border)_1px,transparent_1px)] [background-size:24px_24px] opacity-50 [mask-image:radial-gradient(ellipse_at_center,black_30%,transparent_70%)]"
+      />
+
+      <div className="relative z-10 text-center max-w-4xl mx-auto flex flex-col items-center">
+        <GitHubStarsBadge stars={stars} />
+
+        <h1 className="mt-6 text-4xl sm:text-5xl md:text-6xl lg:text-7xl md:leading-[1.1] font-semibold tracking-tighter text-balance">
+          The best social media API{" "}
+          <span className="text-pop">and open source</span>
+        </h1>
+
+        <p className="mt-6 md:text-lg lg:text-xl text-muted-foreground text-balance max-w-2xl">
+          Post to 9 platforms through one API. Every commit, every issue, every
+          roadmap decision happens in public, so you can trust the code your
+          product runs on.
+        </p>
+
+        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-3">
+          <Button size="lg" className="rounded-full text-base" asChild>
+            <Link to={APP_URL} target="_blank">
+              Get Started
+              <IconArrowUpRight className="h-5! w-5!" />
+            </Link>
+          </Button>
+          <Button
+            size="lg"
+            variant="outline"
+            className="rounded-full text-base"
+            asChild
+          >
+            <Link to="#build-in-public">Follow along</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/marketing/app/routes/_root.open-source-social-media-api._index/components/why-open-source.tsx
+++ b/marketing/app/routes/_root.open-source-social-media-api._index/components/why-open-source.tsx
@@ -1,0 +1,92 @@
+import {
+  IconCode,
+  IconPullRequest,
+  IconShieldCheck,
+} from "@central-icons/outlined";
+
+import { Badge } from "~/ui/badge";
+
+const pillars = [
+  {
+    icon: IconCode,
+    title: "Read every line",
+    description:
+      "See how we handle your tokens, your media, and your customers' OAuth grants before you trust us with them.",
+  },
+  {
+    icon: IconPullRequest,
+    title: "Watch us build",
+    description:
+      "Every fix, feature, and refactor ships through public pull requests. No hidden private branch.",
+  },
+  {
+    icon: IconShieldCheck,
+    title: "Steer the roadmap",
+    description:
+      "Open an issue, vote on a feature, send a PR. What ships next is shaped in the open, not behind a sales call.",
+  },
+];
+
+export const WhyOpenSource = () => {
+  return (
+    <div className="bg-background">
+      <div className="max-w-(--breakpoint-xl) w-full py-20 px-4 mx-auto">
+        <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-start">
+          {/* Left: founder narrative */}
+          <div className="flex flex-col gap-6">
+            <Badge variant="outline" className="self-start">
+              Why we open-sourced
+            </Badge>
+
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-[-0.03em] text-balance">
+              The infrastructure your product runs on shouldn&apos;t be a black
+              box.
+            </h2>
+
+            <div className="flex flex-col gap-4 text-base md:text-lg text-muted-foreground leading-relaxed">
+              <p>
+                Post for Me sits between your product and nine social platforms.
+                It holds your customers&apos; OAuth tokens. It moves their
+                media. It retries their failed posts at 3 a.m.
+              </p>
+              <p>
+                That&apos;s a lot of trust to extend to a closed API.
+              </p>
+              <p>
+                So we put the code in public. Every commit, every pull request,
+                every roadmap decision lives on GitHub. You can read how we
+                handle your tokens before you connect one. You can watch us fix
+                a bug the day after you report it. You can shape the next
+                release by opening an issue.
+              </p>
+              <p className="text-foreground font-medium">
+                That&apos;s what we mean by open source. Transparency to build
+                trust.
+              </p>
+            </div>
+          </div>
+
+          {/* Right: trust pillars */}
+          <div className="flex flex-col gap-4">
+            {pillars.map(({ icon: Icon, title, description }) => (
+              <div
+                key={title}
+                className="flex gap-5 p-6 rounded-2xl border bg-card"
+              >
+                <div className="flex items-center justify-center size-12 rounded-xl bg-muted shrink-0">
+                  <Icon className="size-6 text-pop" />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <h3 className="text-lg font-semibold">{title}</h3>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    {description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/marketing/app/routes/_root.open-source-social-media-api._index/route.component.tsx
+++ b/marketing/app/routes/_root.open-source-social-media-api._index/route.component.tsx
@@ -1,0 +1,15 @@
+import { BuildInPublic } from "./components/build-in-public";
+import { FinalCta } from "./components/final-cta";
+import { Hero } from "./components/hero";
+import { WhyOpenSource } from "./components/why-open-source";
+
+export function Component() {
+  return (
+    <div className="relative flex flex-col gap-0">
+      <Hero />
+      <WhyOpenSource />
+      <FinalCta />
+      <BuildInPublic />
+    </div>
+  );
+}

--- a/marketing/app/routes/_root.open-source-social-media-api._index/route.loader.tsx
+++ b/marketing/app/routes/_root.open-source-social-media-api._index/route.loader.tsx
@@ -1,0 +1,9 @@
+import { getGitHubStars } from "~/lib/.server/github";
+
+export async function loader() {
+  const stars = await getGitHubStars();
+
+  return {
+    stars,
+  };
+}

--- a/marketing/app/routes/_root.open-source-social-media-api._index/route.meta.ts
+++ b/marketing/app/routes/_root.open-source-social-media-api._index/route.meta.ts
@@ -1,0 +1,130 @@
+import type { Route } from "./+types/route";
+
+export const meta: Route.MetaFunction = () => {
+  const canonicalUrl =
+    "https://www.postforme.dev/open-source-social-media-api";
+  const ogImageUrl = "https://www.postforme.dev/og-image.png";
+  const ogImageAlt =
+    "Post for Me, the open source social media API for developers";
+  const sharedKeywords =
+    "open source social media API, open source social media scheduler, open source social posting API, social media API, transparent social media API, open source Buffer alternative";
+
+  return [
+    {
+      title: "Open Source Social Media API | Post for Me",
+    },
+    {
+      name: "description",
+      content:
+        "The open source social media API. Post to 9 platforms with one API. Every commit, PR, and roadmap decision is public on GitHub.",
+    },
+    { tagName: "link", rel: "canonical", href: canonicalUrl },
+
+    // Open Graph
+    { property: "og:type", content: "website" },
+    { property: "og:site_name", content: "Post for Me" },
+    {
+      property: "og:title",
+      content: "Open Source Social Media API | Post for Me",
+    },
+    {
+      property: "og:description",
+      content:
+        "The best social media API, and it's open source. Post to 9 platforms with one API. Every commit, every PR is public on GitHub.",
+    },
+    { property: "og:url", content: canonicalUrl },
+    { property: "og:image", content: ogImageUrl },
+    { property: "og:image:width", content: "1200" },
+    { property: "og:image:height", content: "630" },
+    { property: "og:image:alt", content: ogImageAlt },
+
+    // Twitter Card
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:site", content: "@postforme_dev" },
+    {
+      name: "twitter:title",
+      content: "Open Source Social Media API | Post for Me",
+    },
+    {
+      name: "twitter:description",
+      content:
+        "The open source social media API. Post to 9 platforms with one API. Every commit, every PR is public on GitHub.",
+    },
+    {
+      name: "twitter:image",
+      content: "https://www.postforme.dev/twitter-card.png",
+    },
+    { name: "twitter:image:alt", content: ogImageAlt },
+
+    // Structured Data (JSON-LD)
+    {
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "SoftwareSourceCode",
+            "@id": `${canonicalUrl}#source`,
+            name: "Post for Me",
+            url: canonicalUrl,
+            codeRepository: "https://github.com/DayMoonDevelopment/post-for-me",
+            programmingLanguage: ["TypeScript", "Python", "Go", "Ruby"],
+            license: "https://www.gnu.org/licenses/agpl-3.0.html",
+            description:
+              "Open source social media API for posting, scheduling, OAuth, feeds, and analytics across TikTok, Instagram, Facebook, X, LinkedIn, YouTube, Threads, Pinterest, and Bluesky.",
+            keywords: sharedKeywords,
+            author: {
+              "@type": "Organization",
+              name: "Day Moon Development",
+              url: "https://www.daymoon.dev",
+            },
+          },
+          {
+            "@type": "WebPage",
+            "@id": canonicalUrl,
+            url: canonicalUrl,
+            name: "Open Source Social Media API",
+            description:
+              "The open source social media API. Post to 9 platforms with one integration. Every commit, every pull request, and every roadmap decision is public on GitHub.",
+            isPartOf: {
+              "@id": "https://www.postforme.dev/#website",
+            },
+            publisher: {
+              "@id": "https://www.postforme.dev/#organization",
+            },
+            breadcrumb: {
+              "@id": `${canonicalUrl}#breadcrumb`,
+            },
+            mainEntity: {
+              "@id": `${canonicalUrl}#source`,
+            },
+            primaryImageOfPage: {
+              "@type": "ImageObject",
+              url: ogImageUrl,
+              width: 1200,
+              height: 630,
+            },
+            keywords: sharedKeywords,
+          },
+          {
+            "@type": "BreadcrumbList",
+            "@id": `${canonicalUrl}#breadcrumb`,
+            itemListElement: [
+              {
+                "@type": "ListItem",
+                position: 1,
+                name: "Home",
+                item: "https://www.postforme.dev",
+              },
+              {
+                "@type": "ListItem",
+                position: 2,
+                name: "Open Source Social Media API",
+                item: canonicalUrl,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ];
+};

--- a/marketing/app/routes/_root.open-source-social-media-api._index/route.ts
+++ b/marketing/app/routes/_root.open-source-social-media-api._index/route.ts
@@ -1,0 +1,3 @@
+export { Component as default } from "./route.component";
+export { loader } from "./route.loader";
+export { meta } from "./route.meta";


### PR DESCRIPTION
## Summary

New dedicated landing page at `/open-source-social-media-api` positioning Post for Me as **the best social media API, and open source**. Focus is trust and transparency — not a self-host pitch.

## Page structure

1. **Hero** — H1 *"The best social media API and open source"*, live GitHub stars badge (5-min in-memory cache, fail-open fallback), Get Started + "Follow along" CTAs.
2. **Why we open-sourced** — founder narrative around trust, with 3 pillars: Read every line / Watch us build / Steer the roadmap.
3. **Star us. Read the code. Ship the thing.** — primary Star on GitHub CTA, secondary Get Started, repeated stars badge, quiet self-host footnote.
4. **Building in public** — Discord + X cards with handles and channel-specific copy.

## Cross-linking (PFM-521)

- New `/open-source-social-media-api` entry in static sitemap loader.
- "Open Source" link added to global footer under Product.
- Homepage Open Source section rewritten with dual CTAs (landing page + Star on GitHub).
- New `OpenSourceCallout` component slotted into `compare.$path` flow — *"Post for Me is built in the open. {Competitor} isn't."* with link to the landing page.

## SEO

- Full meta tag set: title (42 chars), description (127 chars), canonical, OG (incl. `og:site_name`, `og:image:width`/`height`/`alt`), Twitter card (incl. `twitter:site`, `twitter:image:alt`).
- JSON-LD graph with three entities: `SoftwareSourceCode` (AGPL-3.0 license, code repo, languages, keywords), `WebPage` (publisher + breadcrumb + mainEntity refs, primary image dimensions, keywords), `BreadcrumbList`.
- Keyword targeting: *open source social media API*, *open source social media scheduler*, *open source social posting API*, *open source Buffer alternative*.

## Linear issues

Covers all six issues in the [Open Source Landing Page](https://linear.app/day-moon/project/open-source-landing-page-397a3f833215) project:

- PFM-514 — Add `/open-source-social-media-api` route
- PFM-515 — Build OSS landing layout
- PFM-516 — Write OSS landing page marketing copy (delivered through this PR; copy lives in the components)
- PFM-519 — GitHub stars badge integration
- PFM-520 — Add page to sitemap
- PFM-521 — Cross-link from homepage, footer, compare pages

## Notes for review

- One placeholder graphic remains: `built-in-public.tsx` doesn't have any — the only placeholder was in the deleted "What public means here" section. Hero uses an existing dot-grid CSS background, no graphic asset needed.
- License intentionally set to AGPL-3.0 in JSON-LD only (not surfaced as a badge in the UI per copy review).
- New page is rendered SSR-clean; tested manually in dev (`bun run dev`) — all sections render, all cross-links resolve, JSON-LD parses without errors.

## Test plan

- [ ] Visit `/open-source-social-media-api` — hero stars badge populates from live GitHub API (fallback `100` if rate-limited)
- [ ] Footer "Open Source" link visible on every page
- [ ] Homepage Open Source section CTAs go to the new landing page + GitHub
- [ ] Visit any `/compare/*` page — new OSS callout appears between pricing table and proposition
- [ ] View page source — meta tags + JSON-LD render in `<head>`
- [ ] `bun run typecheck` ✓ already passing
- [ ] `bun run lint` ✓ already passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)