### PR TITLE
marketing: surface vs. Late comparison in footer

### DIFF
--- a/marketing/app/components/footer.tsx
+++ b/marketing/app/components/footer.tsx
@@ -155,6 +155,7 @@ const getFooterSections = (resources: ResourcePreview[] = []) => [
       { title: "vs. Buffer", href: "/compare/buffer" },
       { title: "vs. Hootsuite", href: "/compare/hootsuite" },
       { title: "vs. Ayrshare", href: "/compare/ayrshare" },
+      { title: "vs. Late", href: "/compare/late" },
       { title: "vs. Zernio", href: "/compare/zernio" },
       { title: "vs. Upload-Post", href: "/compare/upload-post" },
       { title: "vs. Outstand", href: "/compare/outstand" },


### PR DESCRIPTION
## Summary
- The `/compare/late` page is registered in `app/lib/.server/data/comparisons.ts` but was the only registered comparison not linked from the footer.
- Adds `vs. Late → /compare/late` between Ayrshare and Zernio, matching the registration order in `comparisons.ts` so all 8 registered comparisons are surfaced.

Closes [PFM-388](https://linear.app/day-moon/issue/PFM-388/update-the-footer-to-include-comparedollarpath-pages).

## Test plan
- [ ] `bun run dev` in `marketing/`, scroll to footer on desktop and mobile (accordion), confirm new "vs. Late" link is present in the Comparisons section between Ayrshare and Zernio
- [ ] Click the link, confirm it navigates to `/compare/late` and renders without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)