### PR TITLE
fix(trigger/youtube): surface thumbnail upload errors in post details

### DIFF
--- a/trigger/posting/platforms/youtube-post-client.ts
+++ b/trigger/posting/platforms/youtube-post-client.ts
@@ -150,8 +150,19 @@ export class YouTubePostClient extends PostClient {
       if (videoId && medium.thumbnail_url) {
         try {
           await this.#uploadThumbnail(youtube, videoId, medium);
-        } catch (thumbnailError) {
+        } catch (thumbnailError: any) {
           console.error("Failed to upload thumbnail:", thumbnailError);
+          this.#responses.push({
+            thumbnailError: {
+              message: thumbnailError?.message,
+              status:
+                thumbnailError?.response?.status ?? thumbnailError?.code,
+              body:
+                thumbnailError?.response?.data ??
+                thumbnailError?.errors ??
+                null,
+            },
+          });
           // Don't fail the entire post if thumbnail upload fails
         }
       }


### PR DESCRIPTION
## Summary
First step of the PFM-450 ("YouTube Thumbnail Failing") triage.

Today, custom-thumbnail upload failures are swallowed by an empty `catch` in `postToYouTube` — the post returns `success: true`, the video has no custom thumbnail, and the only forensic trace is a `console.error` in trigger.dev logs. Support can't tell from the `social_post_results` row *why* the user's thumbnail didn't stick.

Push a structured `thumbnailError` entry onto `this.#responses` (status, message, body) so the failure surfaces in `social_post_results.details` without changing the post-success policy: we still don't fail the whole post if only the thumbnail upload fails.

```ts
this.#responses.push({
  thumbnailError: {
    message: thumbnailError?.message,
    status: thumbnailError?.response?.status ?? thumbnailError?.code,
    body: thumbnailError?.response?.data ?? thumbnailError?.errors ?? null,
  },
});
```

@Mister-MR — this is the diagnostic step from the PFM-450 investigation. Once we can see real failure reasons (image too large, channel not enabled for custom thumbnails, token race, etc.), we can decide whether to retry, pre-validate, or surface to the end user. Flagging your review of the **policy choice**: I deliberately kept the "don't fail the whole post" behavior. Open to changing that if you'd rather surface thumbnail failures as a soft warning on the post result (`details.warnings`) or hard-fail it.

Closes [PFM-450](https://linear.app/day-moon/issue/PFM-450/youtube-thumbnail-failing).

## Test plan
- [ ] Post a YouTube video with an oversized custom thumbnail (>2 MB) and confirm `social_post_results.details.responses[]` contains a `thumbnailError` entry with the YT 400 body
- [ ] Post a YouTube video with a valid thumbnail and confirm `details.responses[]` still ends with the existing `thumbnailResponse` success entry (no regression)
- [ ] Post a YouTube video with no `thumbnail_url` and confirm `responses[]` is unchanged (the catch is unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)