### PR TITLE
chore(dashboard): replace manual Vercel build with deploy hook

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -219,38 +219,22 @@ jobs:
         # fetched on demand instead of expecting it on PATH or in node_modules/.bin.
         run: bunx trigger.dev@4.4.4 deploy
 
+  # Dashboard build/deploy is owned by Vercel's own framework integration
+  # (project Settings → Git, with production auto-deploy disabled). CD just
+  # fires the production deploy hook once the API + migrations are live, so
+  # Vercel can pick up the same SHA and run its built-in React Router preset.
   deploy-dashboard:
     name: Deploy Dashboard
     needs: deploy-api
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: dashboard
-    permissions:
-      contents: read
     outputs:
       vercel: ${{ steps.vercel.outcome }}
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: dashboard/.bun-version
-      # Vercel CLI's `vercel build` spawns `bun` via child_process and only
-      # searches system PATH (not $GITHUB_PATH-injected dirs). Symlink so it resolves.
-      - name: Symlink bun for Vercel CLI
-        run: sudo ln -sf "$(which bun)" /usr/local/bin/bun
-      - run: bun install --frozen-lockfile
-      - name: Link Dashboard to Vercel project
-        run: bunx vercel link --project post-for-me-app --scope day-moon --token=$VERCEL_TOKEN --yes
-      - name: Pull Vercel environment (production)
-        run: bunx vercel pull --yes --environment=production --token=$VERCEL_TOKEN
-      - name: Build with Vercel
-        run: bunx vercel build --prod --token=$VERCEL_TOKEN
-      - name: Deploy Dashboard to Vercel
+      - name: Fire Vercel deploy hook
         id: vercel
-        run: bunx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --yes
+        run: |
+          curl -fSs -X POST \
+            "${{ secrets.VERCEL_DASHBOARD_DEPLOY_HOOK_URL }}?ref=${{ github.sha }}"
 
   deploy-marketing:
     name: Deploy Marketing

--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -1,6 +1,0 @@
-{
-  "git": {
-    "deploymentEnabled": false
-  },
-  "ignoreCommand": "exit 0"
-}


### PR DESCRIPTION
## Summary
- The current CD does `vercel build && vercel deploy --prebuilt` from a GHA runner. That path skips Vercel's framework detection (no React Router preset), which is why the function crashes at runtime trying to resolve `react-router/dist/development/index.mjs`.
- Switch to Vercel's UI-driven build by firing a **Production Deploy Hook** from CD after the API + migrations are live. CD still controls the timing; Vercel owns the build.
- Fire-and-forget: the job finishes once the hook is accepted; Slack will mark it ✅ at that point even though Vercel is still building.

## What changed
- `.github/workflows/cd.yml` — `deploy-dashboard` job is now a single `curl -X POST` to the deploy hook, with `?ref=${{ github.sha }}` so Vercel deploys the exact SHA that just passed precheck + migrations. Output (`vercel`) still emitted for the Slack `notify-final` step.
- `dashboard/vercel.json` — deleted. Its `git.deploymentEnabled: false` + `ignoreCommand: exit 0` were there to suppress Vercel's own deploys; they fight the UI config now that Vercel is back in charge.

## Required Vercel-side setup (do before merging)
1. **Project Settings → Git**: re-enable the connected GitHub repository (it's currently off because of `deploymentEnabled: false`).
2. **Project Settings → Git → Production Branch**: keep as `main`, but **turn off auto-deploy from Git for the production branch**. (Preview deploys for PRs can stay on if you want them.)
3. **Project Settings → Git → Deploy Hooks**: create a hook named e.g. `cd-production`, branch `main`. Copy the URL.
4. **GitHub repo → Settings → Secrets → Actions**: add `VERCEL_DASHBOARD_DEPLOY_HOOK_URL` = that URL.

## Test plan
- [ ] Vercel UI steps above completed and secret set
- [ ] Merge → CD runs → `Deploy Dashboard` step POSTs successfully (HTTP 2xx from hook)
- [ ] Vercel dashboard shows a new production deployment for the merge SHA
- [ ] Deployed function boots without `ERR_MODULE_NOT_FOUND` and dashboard loads end-to-end

## Notes / follow-ups (not blocking)
- Same architecture would clean up `deploy-marketing` (which works today only because its lockfile happens to be on a good react-router version). Worth doing in a follow-up.
- If you ever want real "deploy live" status in Slack instead of "hook fired", we can add a polling step on `GET /v6/deployments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)