### PR TITLE
chore(cd): marketing → Vercel deploy hook; disable dashboard CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -219,71 +219,36 @@ jobs:
         # fetched on demand instead of expecting it on PATH or in node_modules/.bin.
         run: bunx trigger.dev@4.4.4 deploy
 
+  # Dashboard CD is temporarily disabled while we migrate it to the same
+  # Vercel-managed deploy-hook flow that marketing uses. Until then,
+  # deploy the dashboard manually from the Vercel dashboard.
   deploy-dashboard:
     name: Deploy Dashboard
     needs: deploy-api
+    if: false
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: dashboard
-    permissions:
-      contents: read
     outputs:
       vercel: ${{ steps.vercel.outcome }}
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: dashboard/.bun-version
-      # Vercel CLI's `vercel build` spawns `bun` via child_process and only
-      # searches system PATH (not $GITHUB_PATH-injected dirs). Symlink so it resolves.
-      - name: Symlink bun for Vercel CLI
-        run: sudo ln -sf "$(which bun)" /usr/local/bin/bun
-      - run: bun install --frozen-lockfile
-      - name: Link Dashboard to Vercel project
-        run: bunx vercel link --project post-for-me-app --scope day-moon --token=$VERCEL_TOKEN --yes
-      - name: Pull Vercel environment (production)
-        run: bunx vercel pull --yes --environment=production --token=$VERCEL_TOKEN
-      - name: Build with Vercel
-        run: bunx vercel build --prod --token=$VERCEL_TOKEN
-      - name: Deploy Dashboard to Vercel
-        id: vercel
-        run: bunx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --yes
+      - id: vercel
+        run: echo "dashboard CD disabled"
 
+  # Marketing build/deploy is owned by Vercel's own framework integration
+  # (project Settings → Git, with production auto-deploy disabled). CD just
+  # fires the production deploy hook once the API + migrations are live, so
+  # Vercel can pick up the same SHA and run its built-in React Router preset.
   deploy-marketing:
     name: Deploy Marketing
     needs: deploy-api
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: marketing
-    permissions:
-      contents: read
     outputs:
       vercel: ${{ steps.vercel.outcome }}
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: marketing/.bun-version
-      # Vercel CLI's `vercel build` spawns `bun` via child_process and only
-      # searches system PATH (not $GITHUB_PATH-injected dirs). Symlink so it resolves.
-      - name: Symlink bun for Vercel CLI
-        run: sudo ln -sf "$(which bun)" /usr/local/bin/bun
-      - run: bun install --frozen-lockfile
-      - name: Link Marketing to Vercel project
-        run: bunx vercel link --project post-for-me-marketing --scope day-moon --token=$VERCEL_TOKEN --yes
-      - name: Pull Vercel environment (production)
-        run: bunx vercel pull --yes --environment=production --token=$VERCEL_TOKEN
-      - name: Build with Vercel
-        run: bunx vercel build --prod --token=$VERCEL_TOKEN
-      - name: Deploy Marketing to Vercel
+      - name: Fire Vercel deploy hook
         id: vercel
-        run: bunx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --yes
+        run: |
+          curl -fSs -X POST \
+            "${{ secrets.VERCEL_MARKETING_DEPLOY_HOOK_URL }}?ref=${{ github.sha }}"
 
   notify-final:
     name: Notify Slack — Final

--- a/marketing/vercel.json
+++ b/marketing/vercel.json
@@ -1,8 +1,4 @@
 {
-  "git": {
-    "deploymentEnabled": false
-  },
-  "ignoreCommand": "exit 0",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
Scoped first pass: move **marketing** to a Vercel-managed build (triggered via deploy hook from CD), and **explicitly disable dashboard CD** for the time being. Dashboard stays manual via the Vercel UI until we're confident the hook flow works.

## Changes
### Marketing — switch to deploy hook
- `.github/workflows/cd.yml` → `deploy-marketing`: dropped the GHA-side `vercel build && vercel deploy --prebuilt` chain. Replaced with a single `curl -X POST <hook>?ref=${{ github.sha }}`, still `needs: deploy-api`. The `vercel` output (used by `notify-final`) is preserved.
- `marketing/vercel.json`: removed `git.deploymentEnabled: false` and `ignoreCommand: exit 0` so Vercel's UI config is back in charge. Security headers untouched.

### Dashboard — disabled for now
- `.github/workflows/cd.yml` → `deploy-dashboard`: collapsed to a stub with `if: false`. Job is skipped on every run; `notify-final` will render its slot as ⏸️ (the `status()` helper already maps `skipped` → ⏸️). Deploy dashboard manually from the Vercel UI for now.

## Required Vercel + GitHub setup (do these before merging)
1. **Vercel marketing project → Settings → Git**: re-enable the connected GitHub repo. Turn **off** auto-deploy for the production branch (keep preview deploys on if you want PR previews).
2. **Vercel marketing project → Settings → Git → Deploy Hooks**: create a hook named e.g. `cd-production`, branch `main`. Copy the URL.
3. **GitHub repo → Settings → Secrets and variables → Actions**: add `VERCEL_MARKETING_DEPLOY_HOOK_URL` with that URL as the value.

## Test plan
- [ ] Vercel UI bits done + secret added
- [ ] Merge → CD runs → `Deploy Marketing` POSTs the hook (2xx)
- [ ] Vercel marketing project shows a new production deployment for the merge SHA
- [ ] Marketing site loads end-to-end after Vercel finishes building
- [ ] `Deploy Dashboard` job shows as skipped; Slack thread renders dashboard slot as ⏸️

## Follow-ups (not blocking)
- Once we're happy with marketing, apply the same shape to dashboard (and re-enable the job). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)