### PR TITLE
chore(cd): switch dashboard to Vercel deploy hook

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -219,19 +219,22 @@ jobs:
         # fetched on demand instead of expecting it on PATH or in node_modules/.bin.
         run: bunx trigger.dev@4.4.4 deploy
 
-  # Dashboard CD is temporarily disabled while we migrate it to the same
-  # Vercel-managed deploy-hook flow that marketing uses. Until then,
-  # deploy the dashboard manually from the Vercel dashboard.
+  # Dashboard build/deploy is owned by Vercel's own framework integration
+  # (project Settings → Git, with production auto-deploy disabled). CD just
+  # fires the production deploy hook once the API + migrations are live, so
+  # Vercel can pick up the same SHA and run its built-in React Router preset.
   deploy-dashboard:
     name: Deploy Dashboard
     needs: deploy-api
-    if: false
     runs-on: ubuntu-latest
     outputs:
       vercel: ${{ steps.vercel.outcome }}
     steps:
-      - id: vercel
-        run: echo "dashboard CD disabled"
+      - name: Fire Vercel deploy hook
+        id: vercel
+        run: |
+          curl -fSs -X POST \
+            "${{ secrets.VERCEL_DASHBOARD_DEPLOY_HOOK_URL }}?ref=${{ github.sha }}"
 
   # Marketing build/deploy is owned by Vercel's own framework integration
   # (project Settings → Git, with production auto-deploy disabled). CD just

--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -1,6 +1,0 @@
-{
-  "git": {
-    "deploymentEnabled": false
-  },
-  "ignoreCommand": "exit 0"
-}


### PR DESCRIPTION
## Summary
Mirror of #222 for the dashboard, now that the marketing deploy-hook flow has been verified working.

## Changes
- `.github/workflows/cd.yml` → `deploy-dashboard`: replaced the stubbed `if: false` job with a single `curl -X POST <hook>?ref=${{ github.sha }}`. Still `needs: deploy-api` so migrations + API gate it. `vercel` output preserved for `notify-final`.
- `dashboard/vercel.json`: deleted. Its `git.deploymentEnabled: false` + `ignoreCommand: exit 0` were there to suppress Vercel's own deploys; they fight the UI config now that Vercel is back in charge.

## Required Vercel + GitHub setup (before merging)
1. **Vercel dashboard project → Settings → Git**: re-enable the connected GitHub repo. Turn **off** auto-deploy for the production branch (keep preview deploys on if you want PR previews).
2. **Vercel dashboard project → Settings → Git → Deploy Hooks**: create a hook named e.g. `cd-production`, branch `main`. Copy the URL.
3. **GitHub repo → Settings → Secrets and variables → Actions**: add `VERCEL_DASHBOARD_DEPLOY_HOOK_URL` with that URL.

## Test plan
- [ ] Vercel UI bits done + secret added
- [ ] Merge → CD runs → `Deploy Dashboard` POSTs the hook (2xx)
- [ ] Vercel dashboard project shows a new production deployment for the merge SHA
- [ ] Deployed function boots without `ERR_MODULE_NOT_FOUND` and the dashboard loads end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)