### PR TITLE
fix(dashboard): bundle next-themes into SSR build to dedupe React

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -27,7 +27,13 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
     ssr: {
-      noExternal: ["posthog-js", "posthog-js/react"],
+      // next-themes must be bundled, not externalized: on Vercel the deployed
+      // function has both /var/task/node_modules and /var/task/dashboard/node_modules,
+      // so an externalized next-themes resolves React from the root tree while
+      // react-dom uses dashboard's local tree — two React instances, useContext
+      // returns null, SSR throws. Bundling pins it to the same React the SSR
+      // entry imports.
+      noExternal: ["posthog-js", "posthog-js/react", "next-themes"],
     },
     server: {
       ...(allowedHosts ? { allowedHosts } : {}),


### PR DESCRIPTION
## Summary
The new deploy-hook flow surfaced an SSR crash on the dashboard's first render:

\`\`\`
TypeError: Cannot read properties of null (reading 'useContext')
    at exports.useContext (/var/task/node_modules/.bun/react@19.2.1/node_modules/react/cjs/react.production.js:489)
    at z (file:///var/task/node_modules/.bun/next-themes@.../node_modules/next-themes/dist/index.mjs:1:704)
    at Toaster (file:///var/task/dashboard/build/server/index.js:111)
\`\`\`

## Root cause
Vercel's deployed function has two \`node_modules\` trees:

- \`/var/task/node_modules/\` — root-level (Vercel installs at the repo root because there's a root \`package.json\`)
- \`/var/task/dashboard/node_modules/\` — dashboard's local install

When \`next-themes\` was externalized in the SSR bundle, Node's runtime resolver found \`next-themes\` in the **root** tree and, from there, resolved \`react\` from the same root tree. Meanwhile \`react-dom\` (imported directly by the bundle from \`/var/task/dashboard/build/server/index.js\`) resolved to dashboard's **local** React. Two React instances, two dispatchers, \`useContext()\` returns null on the first hook call. Toaster crashes.

## Fix
Add \`next-themes\` to \`dashboard/vite.config.ts\` \`ssr.noExternal\`. That inlines next-themes into \`build/server/index.js\`, so its \`import React from "react"\` is resolved at *build* time and bound to the same React the bundle imports. No more cross-tree mismatch. Bundle grows ~2.5KB.

## Why marketing didn't hit this
Marketing has \`next-themes\` in deps but no code that actually imports it at runtime, so its SSR bundle never loaded it. The same underlying two-tree problem exists on the marketing Vercel project — it's just dormant. Worth noting for the future.

## Follow-up (not blocking)
The real root cause is the two-\`node_modules\`-trees layout on Vercel. Cleanly fixing it (Vercel project Root Directory settings, removing the root \`package.json\`, or moving to bun workspaces) would prevent the next variant of this same bug from biting. Out of scope for this hotfix.

## Test plan
- [x] \`bun run build\` succeeds; \`next-themes\` no longer appears as an externalized import in \`build/server/index.js\`
- [ ] Merge → CD fires the dashboard deploy hook → Vercel builds → SSR renders without the \`useContext\` crash
- [ ] Dashboard loads end-to-end and the Toaster works

🤖 Generated with [Claude Code](https://claude.com/claude-code)