### PR TITLE
fix(dashboard): drop unused next-themes; hardcode Sonner theme

### DIFF
--- a/dashboard/app/ui/sonner.tsx
+++ b/dashboard/app/ui/sonner.tsx
@@ -1,14 +1,11 @@
-import { useTheme } from "next-themes";
 import { Toaster as Sonner } from "sonner";
 
 import type { ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="system"
       className="toaster group"
       style={
         {

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -42,7 +42,6 @@
         "lodash": "^4.17.21",
         "loops": "^5.0.1",
         "lucide-react": "^0.522.0",
-        "next-themes": "^0.4.6",
         "posthog-js": "^1.255.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1244,8 +1243,6 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
-
-    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -52,7 +52,6 @@
     "lodash": "^4.17.21",
     "loops": "^5.0.1",
     "lucide-react": "^0.522.0",
-    "next-themes": "^0.4.6",
     "posthog-js": "^1.255.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
## Summary
Replaces #224 with a cleaner fix for the same SSR crash:

\`\`\`
TypeError: Cannot read properties of null (reading 'useContext')
    at exports.useContext (/var/task/node_modules/.bun/react@19.2.1/.../react.production.js:489)
    at z (.../next-themes/dist/index.mjs:1:704)
    at Toaster (.../dashboard/build/server/index.js:111)
\`\`\`

## Why this is the right shape
\`next-themes\` was imported in exactly one place — \`app/ui/sonner.tsx\` — and there's **no \`ThemeProvider\` mounted anywhere** in the dashboard. \`useTheme()\` therefore always returned the default \`"system"\` value, which is what was being forwarded to \`<Sonner>\`. The whole import was dead weight that happened to crash on Vercel because Vercel's function ends up with two \`node_modules\` trees (\`/var/task/node_modules\` and \`/var/task/dashboard/node_modules\`) and \`next-themes\` resolved a different React than \`react-dom\` did.

Rather than bundling a dep that wasn't doing anything (the previous PR's approach), this PR just deletes it. Smaller diff, smaller bundle, one fewer dep, no SSR crash.

## Changes
- \`dashboard/app/ui/sonner.tsx\`: drop \`useTheme()\` and hardcode \`theme="system"\` (preserves prior behavior exactly).
- \`dashboard/package.json\`: remove \`next-themes\`.
- \`dashboard/bun.lock\`: regenerated with bun 1.3.3 (matches \`dashboard/.bun-version\` to keep CI's frozen-lockfile install happy).

## Test plan
- [x] \`bun install --frozen-lockfile\` (bun 1.3.3) — no changes
- [x] \`bun run typecheck\` passes
- [x] \`bun run build\` passes
- [ ] Merge → CD fires dashboard deploy hook → SSR renders without the \`useContext\` crash
- [ ] Dashboard loads end-to-end; Toaster still renders (now always in "system" mode, which it was already)

## Follow-up (not blocking)
The underlying two-\`node_modules\`-trees layout on Vercel is still there — any future React-context-using dep loaded at SSR time could re-trigger the same shape of bug. Real fix would be Vercel project Root Directory settings, removing the repo-root \`package.json\`, or moving to bun workspaces. Out of scope for this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)