### PR TITLE
fix(marketing): align /compare index layout with site standards

### DIFF
--- a/marketing/app/routes/_root.compare._index/route.component.tsx
+++ b/marketing/app/routes/_root.compare._index/route.component.tsx
@@ -9,18 +9,18 @@ export function Component() {
   const data = useLoaderData<Route.ComponentProps["loaderData"]>();
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
-      <div className="text-center mb-16">
-        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+    <div className="max-w-(--breakpoint-lg) w-full mx-auto px-6 py-16 md:py-24">
+      <div className="max-w-3xl mb-16">
+        <h1 className="text-4xl md:text-6xl font-semibold tracking-[-0.03em]">
           Compare Post for Me
         </h1>
-        <p className="mt-6 text-lg leading-8 text-muted-foreground">
+        <p className="mt-6 text-lg md:text-xl text-muted-foreground leading-relaxed">
           See how Post for Me stacks up against other social media API solutions.
           Find the right tool for your development needs.
         </p>
       </div>
 
-      <div className="flex flex-col gap-0 w-full max-w-lg mx-auto">
+      <div className="flex flex-col gap-0 w-full">
         {Object.entries(data.comparisons).map(([slug, comparison]) => (
           <Link
             key={slug}


### PR DESCRIPTION
## Summary
- The comparison list on `/compare` was constrained to `max-w-lg`, rendering as a narrow centered column inside a `max-w-4xl` container — visually misaligned with the heading and the rest of the marketing site.
- Switched the page to the site's standard `max-w-(--breakpoint-lg)` container + `px-6` (matching `_root.solutions._index`) and dropped the `max-w-lg` so the list fills the container.
- Updated the heading typography to match other landing pages (`text-4xl md:text-6xl font-semibold tracking-[-0.03em]`).

## Test plan
- [ ] Visit `/compare` and confirm the list spans the same width as the heading and matches the layout used on `/solutions`.
- [ ] Spot-check responsive behavior at mobile, md, and lg breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)