### PR TITLE
fix(marketing): consolidate "social media posting api" canonical (PFM-554)

### DIFF
--- a/marketing/app/routes/_root._index/components/hero.tsx
+++ b/marketing/app/routes/_root._index/components/hero.tsx
@@ -37,11 +37,15 @@ export const Hero = () => {
           <span>in hours, not weeks.</span>
         </h1>
         <p className="mt-6 md:text-lg text-balance">
-          Quickly integrate social media platforms directly into your product to
-          power <span className="font-bold">posting</span>,{" "}
+          Quickly integrate social media platforms directly into your product
+          with the unified{" "}
+          <Link to="/social-media/posting" highlight>
+            social media posting API
+          </Link>
+          . Power <span className="font-bold">posting</span>,{" "}
           <span className="font-bold">feeds</span>,{" "}
           <span className="font-bold">analytics</span>, and more through a
-          single, simple API.
+          single, simple endpoint.
         </p>
         <div className="mt-12 flex items-center justify-center gap-4">
           <Button size="lg" className="rounded-full text-base" asChild>

--- a/marketing/app/routes/_root.blog._index/route.component.tsx
+++ b/marketing/app/routes/_root.blog._index/route.component.tsx
@@ -25,7 +25,14 @@ export default function BlogIndex() {
         </h1>
         <p className="text-xl text-muted-foreground max-w-3xl">
           Technical guides, integration tutorials, and insights for developers
-          building social media automation.
+          building social media automation on top of our{" "}
+          <Link
+            to="/social-media/posting"
+            className="text-primary hover:underline"
+          >
+            social media posting API
+          </Link>
+          .
         </p>
       </div>
 

--- a/marketing/app/routes/_root.developers._index/components/header.tsx
+++ b/marketing/app/routes/_root.developers._index/components/header.tsx
@@ -32,9 +32,12 @@ export const Header = () => {
       <div className="flex flex-col gap-6 pt-4">
         <SocialIconsRow iconClassName="size-6" className="gap-3 flex-wrap" />
         <p className="text-lg md:text-xl text-muted-foreground">
-          A unified API that simplifies posting across all major social
-          platforms. One integration, all platform customizations, unlimited
-          possibilities.
+          Our{" "}
+          <Link to="/social-media/posting" highlight>
+            social media posting API
+          </Link>{" "}
+          exposes one unified endpoint for every major platform. One
+          integration, all platform customizations, unlimited possibilities.
         </p>
       </div>
     </div>

--- a/marketing/app/routes/_root.integrations._index/route.component.tsx
+++ b/marketing/app/routes/_root.integrations._index/route.component.tsx
@@ -56,7 +56,14 @@ export function Component() {
               Platform Integrations
             </h1>
             <p className="mt-6 text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Integrate posting, feeds, and analytics across TikTok, Facebook,
+              These integrations all plug into our{" "}
+              <Link
+                to="/social-media/posting"
+                className="text-primary hover:underline"
+              >
+                social media posting API
+              </Link>{" "}
+              — posting, feeds, and analytics across TikTok, Facebook,
               Instagram, X, LinkedIn, Pinterest, Bluesky, Threads, and YouTube.
               One REST API replaces months of platform-by-platform integration
               work.

--- a/marketing/app/routes/_root.pricing._index/route.component.tsx
+++ b/marketing/app/routes/_root.pricing._index/route.component.tsx
@@ -34,6 +34,18 @@ export function Component() {
         without surprises.
       </h1>
 
+      <p className="mt-6 max-w-xl text-center text-lg text-muted-foreground">
+        Usage-based pricing for the{" "}
+        <Link
+          to="/social-media/posting"
+          className="text-primary hover:underline"
+        >
+          social media posting API
+        </Link>
+        . Pick a tier by monthly post volume — every plan ships with unlimited
+        social accounts, projects, and team members.
+      </p>
+
       <div className="my-12 sm:mt-16 max-w-(--breakpoint-sm) mx-auto">
         <div className="border rounded-lg p-6 mx-auto">
           <div className="flex flex-row gap-4 items-start justify-between">

--- a/marketing/app/routes/_root.social-media.posting._index/route.component.tsx
+++ b/marketing/app/routes/_root.social-media.posting._index/route.component.tsx
@@ -173,15 +173,17 @@ export function Component() {
           <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-3">
             <div className="lg:col-span-2">
               <Badge variant="pop" className="mb-6">
-                Social Media Posting
+                Social Media Posting API
               </Badge>
               <h1 className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-[-0.03em] text-balance">
-                Post to every major social media platform through one API
+                The Social Media Posting API for every major platform
               </h1>
               <p className="mt-6 text-lg text-muted-foreground leading-relaxed text-balance">
-                Post text, images, and video to 9 platforms in a single call.
-                Schedule for later, save as draft, or publish now. Media
-                processing and platform-specific formatting handled for you.
+                Post for Me is a unified social media posting API that publishes
+                text, images, and video to 9 platforms in a single call.
+                Schedule for later, save as draft, or publish now. The social
+                media posting API handles media processing and platform-specific
+                formatting for you.
               </p>
               <p className="mt-3 text-base italic text-muted-foreground/80">
                 No platform credentials required to get started.

--- a/marketing/app/routes/_root.social-media.posting._index/route.meta.ts
+++ b/marketing/app/routes/_root.social-media.posting._index/route.meta.ts
@@ -2,9 +2,10 @@ import type { Route } from "./+types/route";
 
 export const meta: Route.MetaFunction = () => {
   const canonicalUrl = "https://www.postforme.dev/social-media/posting";
-  const title = "Social Media Posting API — Post for Me";
+  const title =
+    "Social Media Posting API — Post to 9 Platforms with One Endpoint | Post for Me";
   const description =
-    "Post text, images, and video to TikTok, Instagram, Facebook, X, LinkedIn, and more through one API. Schedule and customize per platform.";
+    "A unified social media posting API for TikTok, Facebook, Instagram, X, LinkedIn, Pinterest, Bluesky, Threads, and YouTube. One endpoint, nine platforms, $10/mo to start.";
 
   return [
     { title },
@@ -52,9 +53,45 @@ export const meta: Route.MetaFunction = () => {
         name: title,
         description,
         url: canonicalUrl,
-        about: { "@id": "https://www.postforme.dev/#product" },
+        about: { "@id": `${canonicalUrl}/#software` },
         isPartOf: { "@id": "https://www.postforme.dev/#website" },
         breadcrumb: { "@id": `${canonicalUrl}/#breadcrumb` },
+      },
+    },
+
+    // SoftwareApplication structured data — targets "social media posting API"
+    {
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "@id": `${canonicalUrl}/#software`,
+        name: "Post for Me — Social Media Posting API",
+        url: canonicalUrl,
+        description:
+          "Post for Me is a social media posting API that publishes text, images, and video to TikTok, Facebook, Instagram, X, LinkedIn, Pinterest, Bluesky, Threads, and YouTube through one unified endpoint. The social media posting API handles scheduling, drafts, multi-account delivery, and per-platform customization.",
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "Web",
+        keywords:
+          "social media posting API, schedule social media posts API, post to multiple platforms API, cross-platform posting, TikTok posting API, Instagram posting API, Facebook posting API, X posting API, LinkedIn posting API, YouTube posting API, Pinterest posting API, Threads posting API, Bluesky posting API, social media automation API",
+        featureList: [
+          "Post to 9 platforms through one social media posting API",
+          "Captions, images, video, and thumbnails",
+          "Scheduled posting with timezone handling",
+          "Draft mode with TikTok app review",
+          "Multi-account posting in a single call",
+          "Per-platform customization (YouTube titles, Instagram reels, Pinterest boards, X polls, LinkedIn pages)",
+        ],
+        offers: {
+          "@type": "AggregateOffer",
+          priceCurrency: "USD",
+          lowPrice: "10",
+          highPrice: "1000",
+          offerCount: "8",
+          availability: "https://schema.org/InStock",
+          description: "Monthly subscription tiers based on post volume",
+          url: "https://www.postforme.dev/pricing",
+        },
+        provider: { "@id": "https://www.postforme.dev/#organization" },
       },
     },
 


### PR DESCRIPTION
## Summary

GSC last 7d showed "social media posting api" impressing on 5 URLs (`/`, `/blog`, `/developers`, `/integrations`, `/pricing`) — classic cannibalization. This consolidates the signal onto `/social-media/posting` as the canonical page and routes the other contenders to it.

**Canonical page (`/social-media/posting`)**
- Retargeted `<title>` to lead with "Social Media Posting API"
- Updated H1 to "The Social Media Posting API for every major platform"
- Reworked first paragraph to use the phrase twice in natural prose
- Updated `<meta name="description">` to lead with the phrase
- Added `SoftwareApplication` JSON-LD with the phrase in `description`, `keywords`, and `featureList`

**Internal links from the 4 competing pages** (all use exact anchor text "social media posting API" → `/social-media/posting`):
- `/` — hero subtitle
- `/blog` — index subtitle
- `/developers` — header description
- `/integrations` — hero subtitle (ticket-suggested lead-in)
- `/pricing` — new subtitle under H1

Refs: [PFM-554](https://linear.app/day-moon/issue/PFM-554/fix-keyword-cannibalization-on-social-media-posting-api), [PFM-351](https://linear.app/day-moon/issue/PFM-351/social-mediaposting-marketing-page) (parent page)

## Test plan

- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean on changed files
- [ ] Visually verify each of `/`, `/blog`, `/developers`, `/integrations`, `/pricing` renders the in-body link with the exact anchor text "social media posting API"
- [ ] Visually verify `/social-media/posting` hero shows the new badge/H1/lead copy
- [ ] View page source on `/social-media/posting`: `<title>`, `<meta name="description">`, and `SoftwareApplication` JSON-LD all contain the phrase
- [ ] After deploy: submit `/social-media/posting` to GSC URL inspection
- [ ] Set calendar reminder for 2026-06-16 to re-check the GSC query

🤖 Generated with [Claude Code](https://claude.com/claude-code)