### PR TITLE
fix: validate chunk integrity in YouTube resumable upload

### DIFF
--- a/trigger/posting/platforms/youtube-post-client.ts
+++ b/trigger/posting/platforms/youtube-post-client.ts
@@ -323,14 +323,37 @@ export class YouTubePostClient extends PostClient {
           }
 
           const chunkBuf = Buffer.from(await fileRes.arrayBuffer());
+          const actualChunkLen = chunkBuf.length;
+          const isFinalChunk = endExclusive === fileSize;
 
-          const contentRange = `bytes ${nextStart}-${endInclusive}/${fileSize}`;
+          // Guard: intermediate chunks must be exactly the declared size.
+          // A short read here means the storage layer closed the connection early;
+          // throw so the outer retry loop can re-fetch from the correct offset.
+          if (!isFinalChunk && actualChunkLen !== chunkLen) {
+            throw new Error(
+              `Storage returned ${actualChunkLen} bytes but expected ${chunkLen} bytes for range ${range} (non-final chunk); video would be truncated`,
+            );
+          }
+
+          // For the final chunk the actual length may legitimately be <= chunkLen,
+          // but it must still be positive and must not exceed the declared size.
+          if (isFinalChunk && (actualChunkLen <= 0 || actualChunkLen > chunkLen)) {
+            throw new Error(
+              `Storage returned unexpected ${actualChunkLen} bytes for final chunk (expected 1–${chunkLen} bytes)`,
+            );
+          }
+
+          // Use the actual received length for both headers so what we declare
+          // to YouTube exactly matches what we send.
+          const actualEndInclusive = nextStart + actualChunkLen - 1;
+          const contentRange = `bytes ${nextStart}-${actualEndInclusive}/${fileSize}`;
+
           const res = await this.#fetchWithRetry(uploadUrl, {
             method: "PUT",
             headers: {
               Authorization: `Bearer ${accessToken}`,
               "Content-Type": mimeType,
-              "Content-Length": String(chunkLen),
+              "Content-Length": String(actualChunkLen),
               "Content-Range": contentRange,
             },
             body: chunkBuf,
@@ -372,11 +395,21 @@ export class YouTubePostClient extends PostClient {
 
           if (res.ok) {
             const data = (await res.json()) as youtube_v3.Schema$Video;
+
+            // Verify YouTube acknowledged the full file before declaring success.
+            const bytesConfirmed = nextStart + actualChunkLen;
+            if (bytesConfirmed !== fileSize) {
+              throw new Error(
+                `YouTube upload completed but only ${bytesConfirmed} of ${fileSize} bytes were sent; video would be truncated`,
+              );
+            }
+
             this.#responses.push({
               resumableComplete: {
                 status: res.status,
                 contentRange,
                 videoId: data?.id,
+                bytesConfirmed,
               },
             });
             return data;


### PR DESCRIPTION
## Problem

Users reported videos being uploaded with a few seconds missing from the end. The root cause was a mismatch between the declared chunk size sent to YouTube and the actual bytes received from storage.

### Root cause

In `#uploadResumableChunks`, after fetching each chunk from storage via a Range request, the code constructed `Content-Length` and `Content-Range` headers using the *expected* chunk size (`chunkLen`) rather than the *actual* buffered byte count. If the storage server closed the connection early (returning fewer bytes than requested), YouTube was told it was receiving more data than was actually sent — resulting in truncated video content with no error raised.

## Changes (`trigger/posting/platforms/youtube-post-client.ts`)

**1. Chunk size validation after buffering**
- **Intermediate chunks** — must be exactly `chunkLen`. A short read now throws immediately, triggering the existing retry loop which re-fetches from the correct offset.
- **Final chunk** — allowed to be shorter (it's the remainder), but validated to be `> 0` and `<= chunkLen`.

**2. Headers derived from actual byte count**
`Content-Length` and `Content-Range` are now built from `actualChunkLen` / `actualEndInclusive` so what YouTube is told it's receiving exactly matches what is sent.

**3. Post-completion byte accounting**
After YouTube returns 200/201, the code verifies `nextStart + actualChunkLen === fileSize` before returning the video object. If fewer total bytes were sent than declared, the upload throws instead of silently returning a truncated result.