### PR TITLE
feat(dashboard): track user-lifecycle conversion events in PostHog

### DIFF
--- a/.agents/skills/conversion-tracking/SKILL.md
+++ b/.agents/skills/conversion-tracking/SKILL.md
@@ -18,6 +18,11 @@ description: >-
 
 Post for Me sources every paid-lifecycle event from **Stripe webhooks** (not in-app actions) and ships them to PostHog, which forwards conversion events to **Meta Ads** and **Google Ads** via destinations. The whole funnel — discovery → signup → conversion → upgrades → cancellation — runs through this pipeline.
 
+There are **two classes of tracked events**, and the distinction governs where they fire:
+
+- **Paid-lifecycle events** (`customer_converted`, `subscription_*`) — sourced from the **Stripe webhook**, never from in-app handlers. The webhook is the honest signal (it fires regardless of source: UI, API, support agent, dunning). Live in `subscription-lifecycle-tracking.ts`.
+- **User-lifecycle events** (`user_signed_up`, `team_created`, `project_created`/`_deleted`, `team_member_invited`/`_joined`/`_removed`) — sourced from **in-app route actions**, because that's where the user intent actually happens (there's no webhook for "user created a project"). Consolidated in `tracking/.server/lifecycle-tracking.ts`.
+
 Tracking code is centralized in `app/tracking/` (browser) and `app/tracking/.server/` (server) in both `dashboard/` and `marketing/`. Route-specific firing happens in route files but always imports from the namespace. Each app's `tracking/README.md` is the tour map — read it before adding things.
 
 ## The attribution model — never violate this
@@ -28,21 +33,25 @@ Tracking code is centralized in `app/tracking/` (browser) and `app/tracking/.ser
 - **PostHog group `team` = the billing entity**, keyed by `teams.id`.
   - Browser: `posthog.group("team", team.id, …)`.
   - Server: `setTeamGroupProperties(team.id, …)` *and* `teamId: team.id` on `captureServerEvent`.
+- **PostHog group `project` = a project**, keyed by `projects.id`. A user acts on behalf of one project at a time.
+  - Browser: `posthog.group("project", project.id, …)` (fires only on project-scoped routes).
+  - Server: `setProjectGroupProperties(project.id, …)` *and* `projectId: project.id` on `captureServerEvent`. Project-scoped events attach **both** the `team` and `project` groups.
+  - Two group types are defined (`team`, `project`); PostHog allows up to 5. Don't add a third without a reason.
 - **All billing reporting is group-aggregated** (unique teams), not unique users. A user can be in many teams — group analytics handles it naturally.
 - **PostHog has no person-less events.** You always pass a `distinctId`. For server-sourced billing events that's the team owner. The person is plumbing; the `team` group is the reporting unit.
 
 ## Hard rules for any new tracked event
 
-1. **Paid-lifecycle events come from the Stripe webhook**, never from in-app button handlers. The webhook fires regardless of source — UI, API, automated flow, support agent in Stripe — and that's what makes the signal honest. The webhook lives at `dashboard/app/routes/api.stripe.webhook/`; analytics for subscription events lives in `.server/subscription-lifecycle-tracking.ts` adjacent to it.
-2. **Dedupe deterministically.** Use `deterministicUuid("<event_name>:<stable_entity_id>")` as the `dedupeKey`. PostHog dedupes by `uuid`, so duplicate emission and replays are idempotent. Never use a random UUID.
+1. **Paid-lifecycle events come from the Stripe webhook**, never from in-app button handlers. The webhook fires regardless of source — UI, API, automated flow, support agent in Stripe — and that's what makes the signal honest. The webhook lives at `dashboard/app/routes/api.stripe.webhook/`; analytics for subscription events lives in `.server/subscription-lifecycle-tracking.ts` adjacent to it. **User-lifecycle events** (signup, team/project/membership) are the exception: they fire from the in-app route action that performs the mutation, via `tracking/.server/lifecycle-tracking.ts` (fire-and-forget). There's no webhook for them, and the in-app action *is* the honest source.
+2. **Dedupe deterministically.** Use `deterministicUuid("<event_name>:<stable_entity_id>")` as the event's `uuid` — derived from IDs we own (`user.id`, `subscription.id`, `team.id`, …), never a random UUID. **Caveat (verified against the project):** PostHog does **not** drop duplicate-`uuid` rows at ingestion or query time — its uuid dedup is an eventual ClickHouse merge, not an upsert. So re-emitting an event **adds a duplicate row** that `count()` sees; a re-run is *not* silently idempotent. The deterministic uuid's real payoff is that duplicates are **collapsible after the fact**: `count(DISTINCT uuid)` (or `DISTINCT <entity_id>`) always yields the true count. Practical rule: the live webhook fires once per event so this rarely bites; for the backfill, prefer not to re-emit (run once / resume after a crash) and **always analyze on `DISTINCT uuid`**.
 3. **Stamp the source system's time.** Webhook events: `new Date(event.created * 1000)`. Real-time events (signup, cron decisions): default to now. Never let PostHog use ingestion time — retries and resends would land at the wrong moment.
-4. **Attach the `team` group** when the event is about a team or its billing (`teamId: team.id` on `captureServerEvent`, `groups: { team: … }` if calling `posthog.capture` directly).
+4. **Attach the `team` group** when the event is about a team or its billing (`teamId: team.id` on `captureServerEvent`). **Also attach the `project` group** (`projectId: project.id`) when the event is about a specific project. Project-scoped events carry both.
 5. **Wrap analytics in try/catch at the call site.** `captureServerEvent` already swallows errors, but the helper that *prepares* the call (resolves team, reads metadata, computes properties) can still throw — keep it from taking down the surrounding webhook/cron handler.
 6. **`system_triggered: true` marks automation; absence implies human-driven.** Only set the flag on events fired by the system (cron, scheduled tasks). Don't require it on every event — the failure mode would be silent mislabeling.
 7. **No cross-sibling imports.** `dashboard/` and `trigger/` keep **vendored copies** of `tracking/.server/posthog.ts`. Keep them in sync by hand. Don't introduce a shared package or workspace alias.
 8. **Pick the right property home — person / group / event:**
    - **Person properties**: identity / matching data (`email`, `first_name`, `last_name`, `gclid`, `fbclid`, `fbc`, `fbp`, `utm_*`). Set via `posthog.identify` browser-side. *Meta/Google destinations primarily read these.*
-   - **Group properties**: current team state (`subscription_status`, `is_active`, `plan_post_limit`, `cancel_at_period_end`). Refresh on every relevant event so "is this team active?" is self-healing.
+   - **Group properties**: current team state (`subscription_status`, `is_active`, `plan_post_limit`, `cancel_at_period_end`, `member_count`, `project_count`). Refresh on every relevant event so "is this team active?" / "how big is it?" is self-healing. `groupIdentify` **merges**, so `refreshTeamShape()` (counts) and the subscription tracker (billing state) update disjoint keys without clobbering each other.
    - **Event properties**: the moment-of-event details (`from_post_limit` / `to_post_limit`, `price`, `currency`, `$current_url`, `$raw_user_agent`, `subscription_id`).
 
 ## Server-side event shape — copy this, don't reinvent
@@ -68,6 +77,16 @@ await captureServerEvent({
 });
 ```
 
+## User-lifecycle events (team / project / membership)
+
+These fire from in-app route actions via `tracking/.server/lifecycle-tracking.ts`. Use its helpers (`trackTeamCreated`, `trackProjectCreated`, `trackProjectDeleted`, `trackTeamMemberInvited`, `trackTeamMemberJoined`, `trackTeamMemberRemoved`, `refreshTeamShape`) rather than calling `captureServerEvent` from the route directly — that's the user-lifecycle analog of `subscription-lifecycle-tracking.ts`. Each helper is best-effort and is invoked fire-and-forget (`void helper(...).catch(...)`) so analytics can't slow or break the action.
+
+- **`role` is derived, never stored.** There's no `role` column on `team_users`. The team's `created_by` is the `owner`; everyone else is a `member` — `roleForTeam(team.created_by, userId)`. If a real roles system lands later, replace the derivation everywhere, don't add ad-hoc role columns.
+- **Signup splits invited vs organic.** Every new user gets a personal auto-team + default project from DB triggers. An **invited** user (`user_metadata.source.type === "invite"`) is attributed to the team they joined (`role: member`); an **organic** user to their personal team (`role: owner`). The live path skips invited users' throwaway personal teams for `team_created`/`project_created`; the backfill replays the whole table (dedupe keeps it idempotent).
+- **Joined = seat activation.** `team_member_joined` fires when an existing user is added (immediate) or an invited new user first authenticates — not at invite time. The team creator's own seat is covered by `team_created`, not a join event.
+- **Counts are self-healing.** `refreshTeamShape()` recomputes `member_count`/`project_count` after every membership/project change.
+- **Auto-created default projects count as user-driven.** We're moving away from auto-creating projects; until then, treat the trigger-created default project as if the user made it (fire `project_created` for it) so the activation signal stays continuous.
+
 ## Plans are ordered by post limit, not tier index
 
 A higher `plan_post_limit` is a higher plan. When emitting upgrade/downgrade direction, compare `to_post_limit > from_post_limit`. Do **not** introduce tier indices or new ordinal columns — `plan_post_limit` is monotonic across `PRICING_TIERS` and is the natural ordering.
@@ -79,21 +98,26 @@ Server-side events fired from the Stripe webhook have **no browser context** —
 ## Where pieces live
 
 - `<app>/app/tracking/` — browser-safe namespace: `posthog-provider`, `posthog-identifier`, `pixels`, individual pixel components, `attribution` (browser cookie reader).
-- `<app>/app/tracking/.server/` — server-only: `posthog.ts` (capture + group helpers), `attribution.ts` (request cookie reader).
+- `<app>/app/tracking/.server/` — server-only: `posthog.ts` (capture + team/project group helpers), `lifecycle-tracking.ts` (team/project/membership event helpers + `refreshTeamShape` + `roleForTeam`), `attribution.ts` (request cookie reader).
 - `<app>/app/tracking/README.md` — what's where, what calls it.
 - Route-level emission stays in `routes/` but imports from `~/tracking/.server/...`:
   - Stripe webhook → `routes/api.stripe.webhook/.server/subscription-lifecycle-tracking.ts`
-  - OTP verify → `routes/_auth.sign-in.otp.verify._index/route.action.ts`
+  - OTP verify (signup + invited-user join) → `routes/_auth.sign-in.otp.verify._index/route.action.ts`
+  - Team create → `routes/api.teams.new/route.action.ts`
+  - Project create / delete → `routes/_protected.$teamId.new._index/route.action.ts`, `routes/_protected.$teamId.$projectId.delete._index/route.action.ts`
+  - Member invite / remove → `routes/_protected.$teamId.members.add._index/route.action.ts`, `routes/_protected.$teamId.members.remove._index/route.action.ts`
   - Checkout metadata stamping → `routes/_protected.$teamId.billing._index/route.loader.ts`
-  - PostHog identifier mount → `routes/_protected.$teamId/route.component.tsx`
+  - PostHog identifier mount (team + project groups) → `routes/_protected.$teamId/route.component.tsx`
+- **Backfill** (`backfill/`, local-only, gitignored) replays history into PostHog. Tasks: `group-state`, `signups`, `teams-created`, `projects`, `team-members`, `conversions`, `plan-changes`. Add a task + register it in `run.ts` whenever you add a backfillable event. See `backfill/README.md`.
 
-If you're adding a new subscription-lifecycle event, the analytics belongs in `subscription-lifecycle-tracking.ts`. Don't sprinkle `captureServerEvent` calls in unrelated route handlers — the consolidation is intentional.
+If you're adding a new **subscription**-lifecycle event, the analytics belongs in `subscription-lifecycle-tracking.ts`. If you're adding a new **user**-lifecycle event (team/project/membership/signup), it belongs in `lifecycle-tracking.ts`. Either way, don't sprinkle `captureServerEvent` calls across unrelated route handlers — the consolidation is intentional.
 
 ## Checklist for adding a new tracked event
 
 - [ ] Event name is **snake_case, action-oriented** (`customer_converted`, not `userConvertedToCustomer`).
 - [ ] `distinctId` resolves to a real `auth.users` id (browser: `user.id`; server: `teams.created_by`).
-- [ ] `teamId` is passed when the event is team-scoped.
+- [ ] `teamId` is passed when the event is team-scoped; `projectId` too when it's project-scoped.
+- [ ] Subscription event → `subscription-lifecycle-tracking.ts`; user-lifecycle (team/project/membership/signup) → `lifecycle-tracking.ts`. Not sprinkled in the route handler.
 - [ ] `dedupeKey` is `deterministicUuid("<event_name>:<stable_entity_id>")`.
 - [ ] `timestamp` reflects when the event *occurred*, not when it was ingested.
 - [ ] Properties include `team_id`, `stripe_customer_id` (if billing), `subscription_id` (if subscription-related).
@@ -101,6 +125,7 @@ If you're adding a new subscription-lifecycle event, the analytics belongs in `s
 - [ ] Call site is `try {…} catch {…}` so analytics failures can't take down the handler.
 - [ ] `system_triggered: true` is set **only** if the event was fired by automation (cron/scheduled task).
 - [ ] `references/event-catalog.md` updated as part of the same PR.
+- [ ] If the event is backfillable from existing data, add/extend a `backfill/` task and register it in `run.ts`.
 - [ ] If the event should reach Meta/Google: confirm the destination's "Match events" filter includes it, and check `references/destination-mappings.md` for what properties each destination reads.
 
 ## Anti-patterns — refuse these
@@ -112,6 +137,8 @@ If you're adding a new subscription-lifecycle event, the analytics belongs in `s
 - Using a random `uuid` as the dedupe key. PostHog dedup requires determinism; randoms allow doubles.
 - Cross-sibling imports — vendor the helper into each sibling instead.
 - Adding new tier-ordinal columns or indices. Use `plan_post_limit` for ordering.
+- Inventing a `role` column / table to populate the `role` property. It's derived from `teams.created_by` (`roleForTeam`). Schema changes for analytics are out of scope here.
+- Firing `team_member_joined` at invite time. It's a seat-*activation* signal (existing user added, or invited user's first auth) — invite time is `team_member_invited`.
 
 ## When to escalate to the user
 

--- a/.agents/skills/conversion-tracking/references/destination-mappings.md
+++ b/.agents/skills/conversion-tracking/references/destination-mappings.md
@@ -49,7 +49,8 @@ If you want a new event to reach Meta or Google for conversion measurement:
 
 ## Things that are intentionally not destinations
 
-- A separate destination for `user_signed_up` → Meta `CompleteRegistration` could be added later if the upper-funnel signal is wanted. No code change needed; just a new PostHog destination.
+- A separate destination for `user_signed_up` → Meta `CompleteRegistration` could be added later if the upper-funnel signal is wanted. No code change needed; just a new PostHog destination. (`user_signed_up` now carries `team_id`/`role`/`invited_by`, so a destination could even segment paid-team vs free-team registrations.)
+- The other **user-lifecycle** events (`team_created`, `project_created`/`_deleted`, `team_member_*`) are product/activation analytics, **not** ad-conversion signals — they're not wired to Meta/Google and shouldn't be without a deliberate decision (they have no `price`/`currency` and aren't conversions).
 - Browser pixel `fbq('track', 'Subscribe')` / `gtag('event', 'conversion')` — deliberately not fired to avoid dedup work. The PostHog destination is the single source for conversions.
 
 ## Reminders for maintaining destinations

--- a/.agents/skills/conversion-tracking/references/event-catalog.md
+++ b/.agents/skills/conversion-tracking/references/event-catalog.md
@@ -8,8 +8,13 @@ Authoritative list of currently tracked PostHog events. **Update this file in th
 |---|---|---|
 | `posthog.identify(user.id, …)` | `dashboard/app/tracking/posthog-identifier.tsx` | `email`, `created_at`, `first_name`, `last_name`, `gclid`, `fbclid`, `fbc`, `fbp`, `utm_*` |
 | `posthog.group("team", team.id, …)` | same | `name`, `stripe_customer_id`, `billing_email` |
+| `posthog.group("project", project.id, …)` | same (fires only on project-scoped routes) | `name`, `team_id` |
 
 PostHog SDK also auto-captures `$initial_referrer`, `$initial_utm_*`, `$initial_gclid`, `$initial_fbclid` as person properties on the first identified pageview.
+
+### Group types
+
+Two PostHog group types are defined: **`team`** (the billing entity, keyed by `teams.id`) and **`project`** (keyed by `projects.id`). A user acts on behalf of one project at a time; project-scoped events/pageviews attach both groups so they roll up to the team *and* the project. PostHog allows up to 5 group types — adding more (e.g. `social_account`) is possible but coordinate first.
 
 ## Lifecycle events
 
@@ -20,10 +25,89 @@ PostHog SDK also auto-captures `$initial_referrer`, `$initial_utm_*`, `$initial_
 | Fires | First-time signup (account `created_at` < 60s ago) |
 | Source | `dashboard/app/routes/_auth.sign-in.otp.verify._index/route.action.ts` |
 | distinct_id | `user.id` |
-| team group | The auto-created team where `teams.created_by = user.id` |
-| properties | `email` |
+| team group | **Invited user** (`user_metadata.source.type === "invite"`): the team they were invited to (`source.team`). **Organic**: the personal team auto-created at signup (`teams.created_by = user.id`). |
+| properties | `email`, `team_id`, `role` (`owner` organic / `member` invited), `invited_by` (invited only) |
 | timestamp | now |
 | dedupe | `user_signed_up:<user.id>` |
+
+`role` is **derived**, not stored — there is no `role` column on `team_users`. The team's `created_by` is the `owner`; everyone else is a `member`. See `roleForTeam()` in `tracking/.server/lifecycle-tracking.ts`. If a real roles system is ever added, replace the derivation with a column read everywhere it's used.
+
+## Team & project lifecycle events
+
+These are **user-lifecycle** events: they fire from in-app route actions (not the Stripe webhook), via `dashboard/app/tracking/.server/lifecycle-tracking.ts`. Each is wrapped fire-and-forget at the call site so a tracking failure can't break the action.
+
+### `team_created`
+
+| | |
+|---|---|
+| Fires | A team (billing unit) comes into existence — organic signup's auto-team, or explicit "create team" |
+| Source | OTP verify (`creation_context: "signup"`) + `routes/api.teams.new/route.action.ts` (`creation_context: "manual"`) |
+| distinct_id | `team.created_by` (the owner) |
+| team group | `team.id` |
+| properties | `team_id`, `created_by_user_id`, `creation_context`, `plan_name` (null at creation) |
+| dedupe | `team_created:<team.id>` |
+| Note | Live skips invited users' throwaway personal auto-teams; the backfill replays the whole table (dedupe keeps it idempotent). Also seeds `member_count`/`project_count` on the group. |
+
+### `project_created`
+
+| | |
+|---|---|
+| Fires | A project is created — explicit project creation, **and** the default project auto-created with a team (treated as user-driven onboarding) |
+| Source | `routes/_protected.$teamId.new._index/route.action.ts`, plus OTP verify + `api.teams.new` for the default project |
+| distinct_id | acting user (`created_by`) |
+| groups | `team` (`team_id`) **and** `project` (`project.id`) |
+| properties | `project_id`, `project_name`, `team_id` |
+| dedupe | `project_created:<project.id>` |
+| Note | Refreshes the team group's `project_count`; sets `project` group props (`name`, `team_id`). |
+
+### `project_deleted`
+
+| | |
+|---|---|
+| Fires | A project is hard-deleted (may signal disengagement) |
+| Source | `routes/_protected.$teamId.$projectId.delete._index/route.action.ts` |
+| distinct_id | acting user |
+| groups | `team` + `project` |
+| properties | `project_id`, `team_id` |
+| dedupe | `project_deleted:<project.id>` |
+| Note | Live-only — projects are hard-deleted, so there's no row to backfill. Refreshes `project_count`. |
+
+### `team_member_invited`
+
+| | |
+|---|---|
+| Fires | An invite is sent (per invitee) |
+| Source | `routes/_protected.$teamId.members.add._index/route.action.ts` |
+| distinct_id | invitee `user.id` (so it pairs with `team_member_joined`) |
+| team group | `team.id` |
+| properties | `team_id`, `role` (`member`), `inviter_user_id`, `invitee_email`, `is_new_user` |
+| dedupe | `team_member_invited:<team_id>:<invitee_user_id>` |
+
+### `team_member_joined`
+
+| | |
+|---|---|
+| Fires | A seat becomes active — an already-existing user is added (immediate) or an invited new user authenticates for the first time |
+| Source | members.add (existing users) + OTP verify (invited new users) |
+| distinct_id | the joining `user.id` |
+| team group | `team.id` |
+| properties | `team_id`, `role`, `invited_by` |
+| dedupe | `team_member_joined:<team_id>:<user_id>` |
+| Note | The team creator's own seat is **not** tracked here — it's covered by `team_created`. Refreshes `member_count`. |
+
+### `team_member_removed`
+
+| | |
+|---|---|
+| Fires | A member is removed (seat loss often precedes churn) |
+| Source | `routes/_protected.$teamId.members.remove._index/route.action.ts` |
+| distinct_id | the removed `user.id` |
+| team group | `team.id` |
+| properties | `team_id`, `role`, `removed_by_user_id`, `is_self_removal` |
+| dedupe | `team_member_removed:<team_id>:<user_id>` |
+| Note | Live-only (no historical record once the row is gone). Dedupe is `team:user`, so remove→re-invite→remove of the same user collapses to one event. Refreshes `member_count`. |
+
+## Subscription lifecycle events (Stripe webhook)
 
 ### `customer_converted`
 
@@ -107,6 +191,21 @@ PostHog SDK also auto-captures `$initial_referrer`, `$initial_utm_*`, `$initial_
 | `plan_price` | Dollar amount of the current plan |
 | `is_active` | `subscription_status` is `active` or `trialing` |
 | `cancel_at_period_end` | Whether the sub is set to cancel at period end |
+| `member_count` | Number of `team_users` rows for the team. Refreshed on team creation + member join/remove. |
+| `project_count` | Number of `projects` for the team. Refreshed on team creation + project create/delete. |
+| `created_at` | The team's real `teams.created_at`. Set so groups can be filtered by actual creation date — PostHog's own group "created" timestamp is just when the group was first registered (≈ backfill date for historical teams). |
+
+`member_count` / `project_count` are refreshed via `refreshTeamShape()` in `tracking/.server/lifecycle-tracking.ts`. `groupIdentify` **merges** properties, so refreshing the shape never clobbers the billing-state props the subscription tracker sets (and vice versa).
+
+## Project group properties
+
+| Property | Meaning |
+|---|---|
+| `name` | Project display name |
+| `team_id` | The team the project belongs to |
+| `created_at` | The project's real `projects.created_at` (server-side only) — same rationale as the team group's `created_at`. |
+
+Set browser-side (`posthog-identifier.tsx`) and server-side on `project_created` (`setProjectGroupProperties`).
 
 ## Person properties (set via identify, primarily for ad destinations)
 

--- a/dashboard/app/routes/_auth.sign-in.otp.verify._index/route.action.ts
+++ b/dashboard/app/routes/_auth.sign-in.otp.verify._index/route.action.ts
@@ -1,6 +1,13 @@
 import { redirect } from "react-router";
 import { syncUserToLoops } from "~/lib/.server/loops";
 import { captureServerEvent, deterministicUuid } from "~/tracking/.server/posthog";
+import {
+  TEAM_ROLE_OWNER,
+  roleForTeam,
+  trackProjectCreated,
+  trackTeamCreated,
+  trackTeamMemberJoined,
+} from "~/tracking/.server/lifecycle-tracking";
 import { withSupabase } from "~/lib/.server/supabase";
 
 // verifyOtp doesn't tell us whether the user was just created, so we treat a
@@ -58,11 +65,59 @@ export const action = withSupabase(async ({ supabase, supabaseServiceRole, reque
 
       if (isNewUser) {
         void (async () => {
-          // Signup auto-creates a team (created_by = user.id); attach it so we
-          // know which team the user signed up under — they may later join others.
-          const { data: signupTeam } = await supabaseServiceRole
+          // Invited users carry `source` metadata pointing at the team they were
+          // invited to; organic signups don't. The DB auto-creates a personal
+          // team + default project for *every* new user via triggers, but for an
+          // invited user that personal team is a throwaway artifact — we attribute
+          // their signup to the team they actually joined instead.
+          const source = (
+            user.user_metadata as
+              | { source?: { type?: string; team?: string; invited_by?: string } }
+              | undefined
+          )?.source;
+          const invitedTeamId =
+            source?.type === "invite" && typeof source.team === "string"
+              ? source.team
+              : null;
+
+          if (invitedTeamId) {
+            const { data: invitedTeam } = await supabaseServiceRole
+              .from("teams")
+              .select("id, created_by")
+              .eq("id", invitedTeamId)
+              .maybeSingle();
+
+            const role = roleForTeam(invitedTeam?.created_by, user.id);
+            const invitedBy = source?.invited_by ?? null;
+
+            await captureServerEvent({
+              distinctId: user.id,
+              event: "user_signed_up",
+              teamId: invitedTeamId,
+              properties: {
+                email: user.email,
+                team_id: invitedTeamId,
+                role,
+                invited_by: invitedBy,
+              },
+              dedupeKey: deterministicUuid(`user_signed_up:${user.id}`),
+            });
+
+            // Seat activation: the invited user authenticated for the first time.
+            await trackTeamMemberJoined({
+              supabase: supabaseServiceRole,
+              teamId: invitedTeamId,
+              userId: user.id,
+              role,
+              invitedBy,
+            });
+            return;
+          }
+
+          // Organic signup: a personal team + default project were auto-created.
+          const { data: personalTeam } = await supabaseServiceRole
             .from("teams")
-            .select("id")
+            .select("id, name, created_by, created_at")
             .eq("created_by", user.id)
             .order("created_at", { ascending: true })
             .limit(1)
@@ -71,12 +126,47 @@ export const action = withSupabase(async ({ supabase, supabaseServiceRole, reque
           await captureServerEvent({
             distinctId: user.id,
             event: "user_signed_up",
-            teamId: signupTeam?.id ?? undefined,
-            properties: { email: user.email },
+            teamId: personalTeam?.id ?? undefined,
+            properties: {
+              email: user.email,
+              team_id: personalTeam?.id ?? null,
+              role: TEAM_ROLE_OWNER,
+            },
             dedupeKey: deterministicUuid(`user_signed_up:${user.id}`),
           });
+
+          if (personalTeam) {
+            await trackTeamCreated({
+              supabase: supabaseServiceRole,
+              team: {
+                id: personalTeam.id,
+                name: personalTeam.name,
+                // We filtered on created_by = user.id, so this is the user.
+                created_by: personalTeam.created_by ?? user.id,
+                created_at: personalTeam.created_at,
+              },
+              creationContext: "signup",
+            });
+
+            // Treat the auto-created default project as a user-driven creation —
+            // it's part of onboarding. (Auto-creation is going away; tracking it
+            // as if the user made it keeps the activation signal continuous.)
+            const { data: projects } = await supabaseServiceRole
+              .from("projects")
+              .select("id, name, team_id, created_at")
+              .eq("team_id", personalTeam.id)
+              .order("created_at", { ascending: true });
+
+            for (const project of projects ?? []) {
+              await trackProjectCreated({
+                supabase: supabaseServiceRole,
+                project,
+                actorUserId: user.id,
+              });
+            }
+          }
         })().catch((err) => {
-          console.error("Failed to capture user_signed_up:", err);
+          console.error("Failed to capture signup lifecycle events:", err);
         });
       }
 

--- a/dashboard/app/routes/_protected.$teamId.$projectId.delete._index/route.action.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.delete._index/route.action.ts
@@ -2,68 +2,80 @@ import { redirect, data } from "react-router";
 
 import { withSupabase } from "~/lib/.server/supabase";
 import { currentUserIsInTeam } from "~/lib/.server/current-user-is-in-team.request";
+import { trackProjectDeleted } from "~/tracking/.server/lifecycle-tracking";
 
 import { CONFIRMATION_KEY } from "./route.constants";
 
-export const action = withSupabase(async ({ supabase, params, request }) => {
-  const { teamId, projectId } = params;
+export const action = withSupabase(
+  async ({ supabase, supabaseServiceRole, params, request }) => {
+    const { teamId, projectId } = params;
 
-  if (!teamId || !projectId) {
-    return data({
-      success: false,
-      errors: { general: "Missing team code or project code." },
+    if (!teamId || !projectId) {
+      return data({
+        success: false,
+        errors: { general: "Missing team code or project code." },
+      });
+    }
+
+    const formData = await request.formData();
+    const confirmation = formData.get("confirmation");
+
+    if (confirmation !== CONFIRMATION_KEY) {
+      return data({
+        success: false,
+        errors: { general: `You must type '${CONFIRMATION_KEY}' to confirm.` },
+      });
+    }
+
+    const [isInTeam, currentUser] = await currentUserIsInTeam(
+      { teamId: teamId },
+      supabase
+    );
+
+    if (!isInTeam || !currentUser) return redirect("/");
+
+    const { data: project } = await supabase
+      .from("projects")
+      .select("id, team_id, created_by")
+      .eq("id", projectId)
+      .eq("team_id", teamId)
+      .single();
+
+    if (!project) {
+      return data({ success: false, errors: { general: "Project not found." } });
+    }
+
+    if (project.created_by !== currentUser.id) {
+      return data({
+        success: false,
+        errors: { general: "Only the project owner can delete the project." },
+      });
+    }
+
+    const deleteResult = await supabase
+      .from("projects")
+      .delete()
+      .eq("id", project.id);
+
+    if (deleteResult.error) {
+      console.error(deleteResult.error);
+      return data({
+        success: false,
+        errors: { general: "Something went wrong deleting the project." },
+      });
+    }
+
+    // Project deletion may signal disengagement. Fire-and-forget.
+    void trackProjectDeleted({
+      supabase: supabaseServiceRole,
+      project: { id: project.id, team_id: project.team_id },
+      actorUserId: currentUser.id,
+    }).catch((err) => {
+      console.error("Failed to capture project_deleted:", err);
     });
+
+    return redirect(
+      `/${teamId}?toast=Project deleted successfully&toast_type=success`
+    );
   }
-
-  const formData = await request.formData();
-  const confirmation = formData.get("confirmation");
-
-  if (confirmation !== CONFIRMATION_KEY) {
-    return data({
-      success: false,
-      errors: { general: `You must type '${CONFIRMATION_KEY}' to confirm.` },
-    });
-  }
-
-  const [isInTeam, currentUser] = await currentUserIsInTeam(
-    { teamId: teamId },
-    supabase
-  );
-
-  if (!isInTeam || !currentUser) return redirect("/");
-
-  const { data: project } = await supabase
-    .from("projects")
-    .select("id, team_id, created_by")
-    .eq("id", projectId)
-    .eq("team_id", teamId)
-    .single();
-
-  if (!project) {
-    return data({ success: false, errors: { general: "Project not found." } });
-  }
-
-  if (project.created_by !== currentUser.id) {
-    return data({
-      success: false,
-      errors: { general: "Only the project owner can delete the project." },
-    });
-  }
-
-  const deleteResult = await supabase
-    .from("projects")
-    .delete()
-    .eq("id", project.id);
-
-  if (deleteResult.error) {
-    console.error(deleteResult.error);
-    return data({
-      success: false,
-      errors: { general: "Something went wrong deleting the project." },
-    });
-  }
-
-  return redirect(
-    `/${teamId}?toast=Project deleted successfully&toast_type=success`
-  );
-});
+);

--- a/dashboard/app/routes/_protected.$teamId.members.add._index/route.action.ts
+++ b/dashboard/app/routes/_protected.$teamId.members.add._index/route.action.ts
@@ -4,15 +4,28 @@ import { withSupabase } from "~/lib/.server/supabase";
 
 import { sendInviteEmail } from "~/lib/.server/send-invite-email.request";
 import { currentUserIsInTeam } from "~/lib/.server/current-user-is-in-team.request";
+import {
+  TEAM_ROLE_MEMBER,
+  trackTeamMemberInvited,
+  trackTeamMemberJoined,
+} from "~/tracking/.server/lifecycle-tracking";
 
 import type { Database } from "~/lib/.server/database.types";
 import type { SupabaseClient } from "@supabase/supabase-js";
+
+/** Result of adding one invitee, used to drive the membership tracking events. */
+type AddedMember = {
+  userId: string;
+  email: string;
+  /** True when the invitee's auth account was just created by this invite. */
+  isNewUser: boolean;
+};
 
 async function upsertUserByEmail(
   { email, teamId }: { email: string; teamId: string },
   supabase: SupabaseClient<Database>,
   supabaseServiceRole: SupabaseClient<Database>
-) {
+): Promise<{ userId: string | null; isNewUser: boolean }> {
   const [user, newUser] = await Promise.all([
     supabase.auth.getUser(),
     supabaseServiceRole
@@ -27,7 +40,7 @@ async function upsertUserByEmail(
   }
 
   if (!newUser.data) {
-    return supabaseServiceRole.auth.admin.createUser({
+    const created = await supabaseServiceRole.auth.admin.createUser({
       email,
       user_metadata: {
         source: {
@@ -37,40 +50,49 @@ async function upsertUserByEmail(
         },
       },
     });
+    return { userId: created.data?.user?.id ?? null, isNewUser: true };
   }
 
-  return supabaseServiceRole.auth.admin.getUserById(newUser.data.id);
+  const fetched = await supabaseServiceRole.auth.admin.getUserById(
+    newUser.data.id
+  );
+  return { userId: fetched.data?.user?.id ?? null, isNewUser: false };
 }
 
 async function addUserToTeam(
   { teamId, email }: { teamId: string; email: string },
   supabase: SupabaseClient<Database>,
-  supabaseServiceRole: SupabaseClient
-) {
-  const newUser = await upsertUserByEmail(
+  supabaseServiceRole: SupabaseClient<Database>
+): Promise<AddedMember | null> {
+  const { userId, isNewUser } = await upsertUserByEmail(
     { email, teamId },
     supabase,
     supabaseServiceRole
   );
 
-  if (!newUser.data?.user) {
+  if (!userId) {
     throw new Error("User not found");
   }
 
   const record = await supabase.from("team_users").upsert({
     team_id: teamId,
-    user_id: newUser.data.user.id,
+    user_id: userId,
   });
 
-  if (!record.error) {
-    try {
-      await sendInviteEmail(email);
-    } catch (error) {
-      console.error("Failed to send invite email:", error);
-    }
+  // Preserve the existing behavior: a failed upsert doesn't throw — we just
+  // skip the email and (now) the tracking for that invitee.
+  if (record.error) {
+    console.error("Failed to add user to team:", record.error);
+    return null;
   }
 
-  return record;
+  try {
+    await sendInviteEmail(email);
+  } catch (error) {
+    console.error("Failed to send invite email:", error);
+  }
+
+  return { userId, email, isNewUser };
 }
 
 export const action = withSupabase(
@@ -92,11 +114,40 @@ export const action = withSupabase(
       return redirect("/");
     }
 
-    await Promise.all(
+    const added = await Promise.all(
       emails.map((email) =>
         addUserToTeam({ teamId, email }, supabase, supabaseServiceRole)
       )
     );
+
+    // Track each invite. Brand-new invitees fire `team_member_joined` when they
+    // first authenticate (handled in the OTP-verify action); already-existing
+    // users are active immediately, so we fire it here. Fire-and-forget.
+    void (async () => {
+      for (const member of added) {
+        if (!member) continue;
+
+        await trackTeamMemberInvited({
+          teamId,
+          inviteeUserId: member.userId,
+          inviteeEmail: member.email,
+          inviterUserId: currentUser.id,
+          isNewUser: member.isNewUser,
+        });
+
+        if (!member.isNewUser) {
+          await trackTeamMemberJoined({
+            supabase: supabaseServiceRole,
+            teamId,
+            userId: member.userId,
+            role: TEAM_ROLE_MEMBER,
+            invitedBy: currentUser.id,
+          });
+        }
+      }
+    })().catch((err) => {
+      console.error("Failed to capture team membership events:", err);
+    });
 
     return redirect(`../?toast=Invited users to the team&toast_type=success`);
   }

--- a/dashboard/app/routes/_protected.$teamId.members.remove._index/route.action.ts
+++ b/dashboard/app/routes/_protected.$teamId.members.remove._index/route.action.ts
@@ -3,68 +3,86 @@ import { data, redirect } from "react-router";
 import { withSupabase } from "~/lib/.server/supabase";
 
 import { currentUserIsInTeam } from "~/lib/.server/current-user-is-in-team.request";
+import {
+  roleForTeam,
+  trackTeamMemberRemoved,
+} from "~/tracking/.server/lifecycle-tracking";
 
-export const action = withSupabase(async ({ supabase, params, request }) => {
-  const { teamId } = params;
-  const formData = await request.formData();
-  const userIdToDelete = formData.get("userId") as string;
+export const action = withSupabase(
+  async ({ supabase, supabaseServiceRole, params, request }) => {
+    const { teamId } = params;
+    const formData = await request.formData();
+    const userIdToDelete = formData.get("userId") as string;
 
-  if (!teamId) {
-    throw new Error("Team code is required");
-  }
+    if (!teamId) {
+      throw new Error("Team code is required");
+    }
 
-  if (!userIdToDelete) {
-    return data({
-      success: false,
-      errors: {
-        general: "There was an error removing the user from the team",
-        userId: "User ID is required",
-      },
+    if (!userIdToDelete) {
+      return data({
+        success: false,
+        errors: {
+          general: "There was an error removing the user from the team",
+          userId: "User ID is required",
+        },
+      });
+    }
+
+    const [isInTeam, currentUser] = await currentUserIsInTeam(
+      { teamId },
+      supabase
+    );
+
+    if (!isInTeam || !currentUser) {
+      return redirect("/");
+    }
+
+    const teamUser = await supabase
+      .from("team_users")
+      .select("team_id, team:teams!team_id(created_by), user:users!user_id(id, email)")
+      .eq("team_id", teamId)
+      .eq("user_id", userIdToDelete)
+      .single();
+
+    if (!teamUser.data) {
+      throw new Error("Not found");
+    }
+
+    const deleteReq = await supabase
+      .from("team_users")
+      .delete()
+      .eq("team_id", teamUser.data.team_id)
+      .eq("user_id", userIdToDelete);
+
+    if (deleteReq.error) {
+      return data({
+        success: true,
+        errors: {
+          general: "There was an error removing the user from the team",
+        },
+      });
+    }
+
+    // Seat loss often precedes churn. Fire-and-forget.
+    void trackTeamMemberRemoved({
+      supabase: supabaseServiceRole,
+      teamId,
+      removedUserId: userIdToDelete,
+      removedByUserId: currentUser.id,
+      role: roleForTeam(teamUser.data.team?.created_by, userIdToDelete),
+      isSelfRemoval: userIdToDelete === currentUser.id,
+    }).catch((err) => {
+      console.error("Failed to capture team_member_removed:", err);
     });
-  }
 
-  const [isInTeam, currentUser] = await currentUserIsInTeam(
-    { teamId },
-    supabase
-  );
+    if (userIdToDelete === currentUser.id) {
+      return redirect(
+        "/?toast=You have been removed from the team&toast_type=success"
+      );
+    }
 
-  if (!isInTeam || !currentUser) {
-    return redirect("/");
-  }
-
-  const teamUser = await supabase
-    .from("team_users")
-    .select("team_id, user:users!user_id(id, email)")
-    .eq("team_id", teamId)
-    .eq("user_id", userIdToDelete)
-    .single();
-
-  if (!teamUser.data) {
-    throw new Error("Not found");
-  }
-
-  const deleteReq = await supabase
-    .from("team_users")
-    .delete()
-    .eq("team_id", teamUser.data.team_id)
-    .eq("user_id", userIdToDelete);
-
-  if (deleteReq.error) {
-    return data({
-      success: true,
-      errors: {
-        general: "There was an error removing the user from the team",
-      },
-    });
-  }
-
-  if (userIdToDelete === currentUser.id) {
     return redirect(
-      "/?toast=You have been removed from the team&toast_type=success"
+      `../?toast=${teamUser.data.user.email} was removed from the team&toast_type=success`
     );
   }
-
-  return redirect(
-    `../?toast=${teamUser.data.user.email} was removed from the team&toast_type=success`
-  );
-});
+);

--- a/dashboard/app/routes/_protected.$teamId.new._index/route.action.ts
+++ b/dashboard/app/routes/_protected.$teamId.new._index/route.action.ts
@@ -2,6 +2,7 @@ import { redirect, data } from "react-router";
 
 import { withSupabase } from "~/lib/.server/supabase";
 import { currentUserIsInTeam } from "~/lib/.server/current-user-is-in-team.request";
+import { trackProjectCreated } from "~/tracking/.server/lifecycle-tracking";
 
 export const action = withSupabase(
   async ({ supabase, supabaseServiceRole, params, request }) => {
@@ -45,6 +46,20 @@ export const action = withSupabase(
         errors: { general: "Something went wrong creating the project." },
       });
     }
+
+    // Project creation is a strong activation signal. Fire-and-forget.
+    void trackProjectCreated({
+      supabase: supabaseServiceRole,
+      project: {
+        id: project.data.id,
+        name: project.data.name,
+        team_id: project.data.team_id,
+        created_at: project.data.created_at,
+      },
+      actorUserId: currentUser.id,
+    }).catch((err) => {
+      console.error("Failed to capture project_created:", err);
+    });
 
     return redirect(
       `/${teamId}/${project.data.id}?toast=Project created successfully&toast_type=success`

--- a/dashboard/app/routes/api.teams.new/route.action.ts
+++ b/dashboard/app/routes/api.teams.new/route.action.ts
@@ -1,5 +1,9 @@
 import { redirect, data } from "react-router";
 import { withSupabase } from "~/lib/.server/supabase";
+import {
+  trackProjectCreated,
+  trackTeamCreated,
+} from "~/tracking/.server/lifecycle-tracking";
 
 export const action = withSupabase(
   async ({ request, supabase, supabaseServiceRole }) => {
@@ -36,7 +40,39 @@ export const action = withSupabase(
       });
     }
 
-    const teamId = result.data.id;
+    const team = result.data;
+    const teamId = team.id;
+
+    // Track team creation + the default project the DB trigger creates with it.
+    // Fire-and-forget so analytics can't slow or break team creation.
+    void (async () => {
+      await trackTeamCreated({
+        supabase: supabaseServiceRole,
+        team: {
+          id: team.id,
+          name: team.name,
+          created_by: team.created_by ?? userData.user.id,
+          created_at: team.created_at,
+        },
+        creationContext: "manual",
+      });
+
+      const { data: projects } = await supabaseServiceRole
+        .from("projects")
+        .select("id, name, team_id, created_at")
+        .eq("team_id", teamId)
+        .order("created_at", { ascending: true });
+
+      for (const project of projects ?? []) {
+        await trackProjectCreated({
+          supabase: supabaseServiceRole,
+          project,
+          actorUserId: userData.user.id,
+        });
+      }
+    })().catch((err) => {
+      console.error("Failed to capture team_created lifecycle events:", err);
+    });
 
     // Return success data instead of redirecting
     return data({

--- a/dashboard/app/tracking/.server/lifecycle-tracking.ts
+++ b/dashboard/app/tracking/.server/lifecycle-tracking.ts
@@ -1,0 +1,311 @@
+import {
+  captureServerEvent,
+  deterministicUuid,
+  setProjectGroupProperties,
+  setTeamGroupProperties,
+} from "./posthog";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "~/lib/.server/database.types";
+
+/**
+ * User-lifecycle (non-billing) PostHog events: team / project / membership
+ * moments that originate from in-app user actions rather than the Stripe
+ * webhook. Paid-lifecycle events still live in
+ * `routes/api.stripe.webhook/.server/subscription-lifecycle-tracking.ts` and
+ * must be sourced from Stripe — keep that split intact.
+ *
+ * Every export here is best-effort and may throw (the count/lookup queries can
+ * fail); call sites wrap them in `try/catch` (fire-and-forget) so a tracking
+ * failure can never take down the surrounding route action.
+ */
+
+// We have no `role` column on `team_users` — the team's `created_by` is the
+// owner and everyone else is a member. Derive it rather than inventing schema.
+// If a real roles system lands later, replace `roleForTeam` with a column read.
+export const TEAM_ROLE_OWNER = "owner";
+export const TEAM_ROLE_MEMBER = "member";
+export type TeamRole = typeof TEAM_ROLE_OWNER | typeof TEAM_ROLE_MEMBER;
+
+export function roleForTeam(
+  teamCreatedBy: string | null | undefined,
+  userId: string,
+): TeamRole {
+  return teamCreatedBy === userId ? TEAM_ROLE_OWNER : TEAM_ROLE_MEMBER;
+}
+
+type ServiceClient = SupabaseClient<Database>;
+
+/**
+ * Count a team's current shape: how many members and projects it has. Used to
+ * keep `member_count` / `project_count` on the `team` group fresh so churned
+ * teams can be segmented by size.
+ */
+async function countTeamShape(
+  supabase: ServiceClient,
+  teamId: string,
+): Promise<{ memberCount: number; projectCount: number }> {
+  const [members, projects] = await Promise.all([
+    supabase
+      .from("team_users")
+      .select("user_id", { count: "exact", head: true })
+      .eq("team_id", teamId),
+    supabase
+      .from("projects")
+      .select("id", { count: "exact", head: true })
+      .eq("team_id", teamId),
+  ]);
+
+  return {
+    memberCount: members.count ?? 0,
+    projectCount: projects.count ?? 0,
+  };
+}
+
+/**
+ * Refresh `member_count` / `project_count` (and optionally `name`) on the team
+ * group. `groupIdentify` merges, so this never clobbers the billing-state props
+ * the subscription tracker sets.
+ */
+export async function refreshTeamShape(
+  supabase: ServiceClient,
+  teamId: string,
+  extra?: Record<string, unknown>,
+): Promise<void> {
+  const { memberCount, projectCount } = await countTeamShape(supabase, teamId);
+  await setTeamGroupProperties(teamId, {
+    member_count: memberCount,
+    project_count: projectCount,
+    ...extra,
+  });
+}
+
+/**
+ * Fire `team_created` when a team (billing unit) comes into existence — from an
+ * organic signup's auto-created team or an explicit "create team" action. The
+ * team starts with no subscription, so `plan_name` is null. Also seeds the
+ * group's shape (name + member/project counts).
+ */
+export async function trackTeamCreated({
+  supabase,
+  team,
+  creationContext,
+  timestamp,
+}: {
+  supabase: ServiceClient;
+  team: {
+    id: string;
+    name: string | null;
+    created_by: string;
+    created_at?: string | null;
+  };
+  /** How the team was created: `signup` (auto) or `manual` (explicit). */
+  creationContext: "signup" | "manual";
+  timestamp?: Date;
+}): Promise<void> {
+  // Seed the group's real creation date so it can be filtered by when the team
+  // actually existed, not when PostHog first registered the group.
+  await refreshTeamShape(supabase, team.id, {
+    name: team.name,
+    ...(team.created_at ? { created_at: team.created_at } : {}),
+  });
+
+  await captureServerEvent({
+    distinctId: team.created_by,
+    event: "team_created",
+    teamId: team.id,
+    properties: {
+      team_id: team.id,
+      created_by_user_id: team.created_by,
+      creation_context: creationContext,
+      plan_name: null,
+    },
+    dedupeKey: deterministicUuid(`team_created:${team.id}`),
+    timestamp,
+  });
+}
+
+/**
+ * Fire `project_created`. Projects are where events originate, so creation is a
+ * strong activation signal. Attributed to the acting user and rolled up to both
+ * the team and the project groups.
+ */
+export async function trackProjectCreated({
+  supabase,
+  project,
+  actorUserId,
+  timestamp,
+}: {
+  supabase: ServiceClient;
+  project: {
+    id: string;
+    name: string | null;
+    team_id: string;
+    created_at?: string | null;
+  };
+  actorUserId: string;
+  timestamp?: Date;
+}): Promise<void> {
+  await setProjectGroupProperties(project.id, {
+    name: project.name,
+    team_id: project.team_id,
+    ...(project.created_at ? { created_at: project.created_at } : {}),
+  });
+
+  await captureServerEvent({
+    distinctId: actorUserId,
+    event: "project_created",
+    teamId: project.team_id,
+    projectId: project.id,
+    properties: {
+      project_id: project.id,
+      project_name: project.name,
+      team_id: project.team_id,
+    },
+    dedupeKey: deterministicUuid(`project_created:${project.id}`),
+    timestamp,
+  });
+
+  // Project count on the team changed.
+  await refreshTeamShape(supabase, project.team_id);
+}
+
+/**
+ * Fire `project_deleted`. May signal disengagement. Refreshes the team's
+ * `project_count` afterward.
+ */
+export async function trackProjectDeleted({
+  supabase,
+  project,
+  actorUserId,
+  timestamp,
+}: {
+  supabase: ServiceClient;
+  project: { id: string; team_id: string };
+  actorUserId: string;
+  timestamp?: Date;
+}): Promise<void> {
+  await captureServerEvent({
+    distinctId: actorUserId,
+    event: "project_deleted",
+    teamId: project.team_id,
+    projectId: project.id,
+    properties: {
+      project_id: project.id,
+      team_id: project.team_id,
+    },
+    dedupeKey: deterministicUuid(`project_deleted:${project.id}`),
+    timestamp,
+  });
+
+  await refreshTeamShape(supabase, project.team_id);
+}
+
+/**
+ * Fire `team_member_invited` when an invite is sent. Keyed to the invitee so it
+ * pairs with `team_member_joined` for an invite→join funnel. `is_new_user`
+ * distinguishes a brand-new invitee (joins on first auth) from an existing user
+ * (joins immediately — see the members.add action).
+ */
+export async function trackTeamMemberInvited({
+  teamId,
+  inviteeUserId,
+  inviteeEmail,
+  inviterUserId,
+  isNewUser,
+}: {
+  teamId: string;
+  inviteeUserId: string;
+  inviteeEmail: string;
+  inviterUserId: string;
+  isNewUser: boolean;
+}): Promise<void> {
+  await captureServerEvent({
+    distinctId: inviteeUserId,
+    event: "team_member_invited",
+    teamId,
+    properties: {
+      team_id: teamId,
+      role: TEAM_ROLE_MEMBER,
+      inviter_user_id: inviterUserId,
+      invitee_email: inviteeEmail,
+      is_new_user: isNewUser,
+    },
+    dedupeKey: deterministicUuid(`team_member_invited:${teamId}:${inviteeUserId}`),
+  });
+}
+
+/**
+ * Fire `team_member_joined` when a seat becomes active: an already-existing user
+ * is added (immediate) or an invited new user authenticates for the first time.
+ * Refreshes the team's `member_count`.
+ */
+export async function trackTeamMemberJoined({
+  supabase,
+  teamId,
+  userId,
+  role,
+  invitedBy,
+  timestamp,
+}: {
+  supabase: ServiceClient;
+  teamId: string;
+  userId: string;
+  role: TeamRole;
+  invitedBy?: string | null;
+  timestamp?: Date;
+}): Promise<void> {
+  await captureServerEvent({
+    distinctId: userId,
+    event: "team_member_joined",
+    teamId,
+    properties: {
+      team_id: teamId,
+      role,
+      invited_by: invitedBy ?? null,
+    },
+    dedupeKey: deterministicUuid(`team_member_joined:${teamId}:${userId}`),
+    timestamp,
+  });
+
+  await refreshTeamShape(supabase, teamId);
+}
+
+/**
+ * Fire `team_member_removed`. Seat loss often precedes churn. Keyed to the
+ * removed user; refreshes the team's `member_count`.
+ *
+ * NOTE: dedupe is `team:user`, so a remove → re-invite → remove of the same
+ * user collapses to one event. There's no historical record of removals (the
+ * `team_users` row is gone), so this event is live-only — no backfill.
+ */
+export async function trackTeamMemberRemoved({
+  supabase,
+  teamId,
+  removedUserId,
+  removedByUserId,
+  role,
+  isSelfRemoval,
+}: {
+  supabase: ServiceClient;
+  teamId: string;
+  removedUserId: string;
+  removedByUserId: string;
+  role: TeamRole;
+  isSelfRemoval: boolean;
+}): Promise<void> {
+  await captureServerEvent({
+    distinctId: removedUserId,
+    event: "team_member_removed",
+    teamId,
+    properties: {
+      team_id: teamId,
+      role,
+      removed_by_user_id: removedByUserId,
+      is_self_removal: isSelfRemoval,
+    },
+    dedupeKey: deterministicUuid(`team_member_removed:${teamId}:${removedUserId}`),
+  });
+
+  await refreshTeamShape(supabase, teamId);
+}

--- a/dashboard/app/tracking/.server/posthog.ts
+++ b/dashboard/app/tracking/.server/posthog.ts
@@ -48,15 +48,21 @@ export function deterministicUuid(key: string): string {
 }
 
 /**
- * Capture a server-side event. `teamId`, when provided, attaches the PostHog
- * `team` group so the event rolls up to the billing entity. Best-effort: any
- * failure is logged, never thrown, so analytics can't break a webhook.
+ * Capture a server-side event. `teamId` / `projectId`, when provided, attach the
+ * PostHog `team` / `project` groups so the event rolls up to the billing entity
+ * and (for project-scoped actions) the project the user was acting on. Best-effort:
+ * any failure is logged, never thrown, so analytics can't break a webhook.
  */
 export async function captureServerEvent(params: {
   distinctId: string;
   event: string;
   properties?: Record<string, unknown>;
   teamId?: string;
+  /**
+   * Attaches the PostHog `project` group. Set on project-scoped events so they
+   * roll up to the project a user is acting on behalf of (one project at a time).
+   */
+  projectId?: string;
   dedupeKey?: string;
   /**
    * When the event actually occurred. Pass the source system's timestamp (e.g.
@@ -70,12 +76,16 @@ export async function captureServerEvent(params: {
     return;
   }
 
+  const groups: Record<string, string> = {};
+  if (params.teamId) groups.team = params.teamId;
+  if (params.projectId) groups.project = params.projectId;
+
   try {
     posthog.capture({
       distinctId: params.distinctId,
       event: params.event,
       properties: params.properties,
-      groups: params.teamId ? { team: params.teamId } : undefined,
+      groups: Object.keys(groups).length > 0 ? groups : undefined,
       uuid: params.dedupeKey,
       timestamp: params.timestamp,
     });
@@ -108,5 +118,30 @@ export async function setTeamGroupProperties(
     await posthog.flush();
   } catch (error) {
     console.error("Failed to set PostHog team group properties:", error);
+  }
+}
+
+/**
+ * Set/refresh properties on a `project` group. `groupIdentify` merges (rather
+ * than replaces) properties, so partial updates are safe. Best-effort.
+ */
+export async function setProjectGroupProperties(
+  projectId: string,
+  properties: Record<string, unknown>,
+): Promise<void> {
+  const posthog = getClient();
+  if (!posthog) {
+    return;
+  }
+
+  try {
+    posthog.groupIdentify({
+      groupType: "project",
+      groupKey: projectId,
+      properties,
+    });
+    await posthog.flush();
+  } catch (error) {
+    console.error("Failed to set PostHog project group properties:", error);
   }
 }

--- a/dashboard/app/tracking/README.md
+++ b/dashboard/app/tracking/README.md
@@ -9,7 +9,7 @@ PostHog / Meta / Google, this is where to look.
 | File | Responsibility |
 |---|---|
 | `posthog-provider.tsx` | Initializes the `posthog-js` client with cross-subdomain cookie config. Mounted in `app/root.tsx`. |
-| `posthog-identifier.tsx` | Calls `identify()` + `group("team", …)` once per authenticated session. Sets person properties the PostHog → Meta/Google destinations need (`email`, `first/last_name`, `gclid`, `fbclid`, `fbc`, `fbp`, `utm_*`). Mounted in `app/routes/_protected.$teamId/route.component.tsx`. |
+| `posthog-identifier.tsx` | Calls `identify()` + `group("team", …)` + `group("project", …)` (the latter only on project-scoped routes) once per authenticated session. Sets person properties the PostHog → Meta/Google destinations need (`email`, `first/last_name`, `gclid`, `fbclid`, `fbc`, `fbp`, `utm_*`). Mounted in `app/routes/_protected.$teamId/route.component.tsx`. |
 | `pixels.tsx` | One-line wrapper that mounts both ad pixels. Mounted in `app/root.tsx`'s `<head>`. |
 | `google-ads-tag.tsx` | `gtag.js` loader. Env: `GOOGLE_ADS_TAG_ID`. |
 | `meta-pixel.tsx` | Meta Pixel `fbq` loader + `PageView` + `<noscript>` fallback. Env: `META_PIXEL_ID`. |
@@ -19,7 +19,8 @@ PostHog / Meta / Google, this is where to look.
 
 | File | Responsibility |
 |---|---|
-| `posthog.ts` | `posthog-node` wrapper: `captureServerEvent`, `setTeamGroupProperties`, `deterministicUuid`. No-op when env unset; `await flush()` for serverless. |
+| `posthog.ts` | `posthog-node` wrapper: `captureServerEvent` (accepts `teamId` + `projectId`), `setTeamGroupProperties`, `setProjectGroupProperties`, `deterministicUuid`. No-op when env unset; `await flush()` for serverless. |
+| `lifecycle-tracking.ts` | User-lifecycle (non-billing) event helpers: `trackTeamCreated`, `trackProjectCreated`/`trackProjectDeleted`, `trackTeamMemberInvited`/`_Joined`/`_Removed`, `refreshTeamShape` (member/project counts), `roleForTeam` (derived owner/member). The user-lifecycle analog of the webhook's `subscription-lifecycle-tracking.ts`. |
 | `attribution.ts` | Reads the same cookies from a server-side `Request`. |
 
 ## Where the wiring happens (outside this folder)
@@ -31,7 +32,16 @@ These route files import from `~/tracking/.server/…` to do the work:
   `subscription_upgraded`/`_downgraded`, `subscription_cancel_scheduled`,
   `subscription_canceled`) and refreshes the `team` group state on each event.
 - **OTP verify** — `app/routes/_auth.sign-in.otp.verify._index/route.action.ts`
-  emits `user_signed_up` for first-time signups.
+  emits `user_signed_up` (with `team_id`/`role`/`invited_by`); for organic signups also
+  `team_created` + `project_created` (the auto-created team + default project); for invited
+  users `team_member_joined`.
+- **Team create** — `app/routes/api.teams.new/route.action.ts` emits `team_created` +
+  `project_created` for the trigger-created default project.
+- **Project create / delete** — `app/routes/_protected.$teamId.new._index/route.action.ts`
+  and `…$projectId.delete._index/route.action.ts` emit `project_created` / `project_deleted`.
+- **Member invite / remove** — `app/routes/_protected.$teamId.members.add._index/route.action.ts`
+  emits `team_member_invited` (+ immediate `team_member_joined` for existing users);
+  `…members.remove._index/route.action.ts` emits `team_member_removed`.
 - **Checkout** — `app/routes/_protected.$teamId.billing._index/route.loader.ts`
   stamps ad attribution + `_fbc`/`_fbp` + URL + UA into `subscription_data.metadata`
   so the webhook can attribute the conversion server-side and enrich it with

--- a/dashboard/app/tracking/posthog-identifier.tsx
+++ b/dashboard/app/tracking/posthog-identifier.tsx
@@ -8,6 +8,7 @@ import {
 } from "./attribution";
 
 import type { loader } from "~/routes/_protected.$teamId/route";
+import type { loader as projectLoader } from "~/routes/_protected.$teamId.$projectId/route.loader";
 
 /**
  * Identifies the authenticated user and registers the current `team` group with
@@ -20,9 +21,15 @@ import type { loader } from "~/routes/_protected.$teamId/route";
  */
 export function PostHogIdentifier() {
   const data = useRouteLoaderData<typeof loader>("routes/_protected.$teamId");
+  // Present only when the user is on a project-scoped route. Lets us register the
+  // `project` group so pageviews roll up to the project they're acting on.
+  const projectData = useRouteLoaderData<typeof projectLoader>(
+    "routes/_protected.$teamId.$projectId",
+  );
 
   const user = data?.user;
   const team = data?.team;
+  const project = projectData?.project;
 
   useEffect(() => {
     if (!user?.id) {
@@ -68,6 +75,17 @@ export function PostHogIdentifier() {
       billing_email: team.billing_email,
     });
   }, [team?.id, team?.name, team?.stripe_customer_id, team?.billing_email]);
+
+  useEffect(() => {
+    if (!project?.id) {
+      return;
+    }
+
+    posthog.group("project", project.id, {
+      name: project.name,
+      team_id: project.team_id,
+    });
+  }, [project?.id, project?.name, project?.team_id]);
 
   return null;
 }

--- a/trigger/posthog.ts
+++ b/trigger/posthog.ts
@@ -49,14 +49,17 @@ export function deterministicUuid(key: string): string {
 }
 
 /**
- * Capture a server-side event attributed to a `team` group. Best-effort: any
- * failure is logged, never thrown, so analytics can't break the cron.
+ * Capture a server-side event attributed to a `team` group (and optionally a
+ * `project` group). Best-effort: any failure is logged, never thrown, so
+ * analytics can't break the cron.
  */
 export async function captureServerEvent(params: {
   distinctId: string;
   event: string;
   properties?: Record<string, unknown>;
   teamId?: string;
+  /** Attaches the PostHog `project` group for project-scoped events. */
+  projectId?: string;
   dedupeKey?: string;
   /** When the event occurred; defaults to now. */
   timestamp?: Date;
@@ -66,12 +69,16 @@ export async function captureServerEvent(params: {
     return;
   }
 
+  const groups: Record<string, string> = {};
+  if (params.teamId) groups.team = params.teamId;
+  if (params.projectId) groups.project = params.projectId;
+
   try {
     posthog.capture({
       distinctId: params.distinctId,
       event: params.event,
       properties: params.properties,
-      groups: params.teamId ? { team: params.teamId } : undefined,
+      groups: Object.keys(groups).length > 0 ? groups : undefined,
       uuid: params.dedupeKey,
       timestamp: params.timestamp,
     });


### PR DESCRIPTION
## Summary
Extends our PostHog conversion tracking beyond Stripe-sourced billing events to cover the **user-activation funnel** — signup, team/project creation, and team membership changes — so we can measure activation and segment teams by size/engagement, not just revenue. Adds a `project` group dimension so events and pageviews roll up to the project a user is acting on.

## Changes
- **New tracking module** `dashboard/app/tracking/.server/lifecycle-tracking.ts` — the user-lifecycle analog of the webhook's `subscription-lifecycle-tracking.ts`. Centralizes `trackTeamCreated`, `trackProjectCreated`/`trackProjectDeleted`, `trackTeamMemberInvited`/`_Joined`/`_Removed`, `refreshTeamShape` (keeps `member_count`/`project_count` on the team group fresh), and `roleForTeam` (derives `owner`/`member` from `teams.created_by` — no schema added).
- **New `project` PostHog group** (2nd group type): `captureServerEvent` in `dashboard/app/tracking/.server/posthog.ts` and the vendored `trigger/posthog.ts` now accept `projectId` and attach a `project` group; new `setProjectGroupProperties` helper (dashboard); browser `posthog-identifier.tsx` registers the group on project-scoped routes.
- **Route wiring** — fire-and-forget events from the actions that perform the mutation: OTP verify (organic vs invited signup split), `api.teams.new`, project new/delete, member add/remove. A failed team-add now skips silently rather than throwing; minor typing tightening in `members.add`.
- **Docs** — conversion-tracking SKILL.md, event-catalog.md, destination-mappings.md, and tracking README updated.

Reviewer notes: all event emission is **best-effort fire-and-forget** (wrapped so a tracking failure can't break the surrounding action) — these are additive, background, non-functional changes. No DB migrations, no new env vars, no new dependencies.

## Testing
- `dashboard`: `bun run typecheck` ✅, `bun run lint` ✅
- `trigger`: `bun run typecheck` ✅; `eslint posthog.ts` ✅ (the only changed file — repo-wide trigger lint noise is pre-existing, all in `.claude_skip/`)
- Verified the `project` group the browser identifier consumes matches the `_protected.$teamId.$projectId` loader's returned fields (`id`, `name`, `team_id`), and that the referenced backfill harness + `subscription-lifecycle-tracking.ts` exist.

## Notes
- `setProjectGroupProperties` was added to dashboard only; the vendored `trigger/posthog.ts` got the `projectId` group support but not the setter, since trigger fires no project-group properties today. Flagging the intentional divergence per the vendored-copy sync rule.
- Backfill replay tasks live in the gitignored `backfill/` harness (local-only ops); not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)