### PR TITLE
fix(tiktok): associate feed posts with public IDs

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -35,6 +35,7 @@ Follow the repo's commit conventions (conventional-commit style, `type(scope): s
 ## 3. Identify the Linear issue
 
 Find the issue this PR resolves. Look, in order:
+
 1. The branch name (`caleb/pfm-576-...` → `PFM-576`).
 2. What the user told you in conversation.
 3. If neither, ask the user for the issue ID before opening the PR — the link/tag steps depend on it.
@@ -47,28 +48,33 @@ Use this body template. Every section earns its place — a reviewer should gras
 
 ```markdown
 ## Summary
+
 1–3 sentences: what this PR does and why it's needed. Lead with the user/business
 reason, not the implementation.
 
 ## Changes
+
 - The notable changes, as bullets. Group by area if the PR is large.
 - Call out anything a reviewer should pay special attention to.
 - Note new dependencies, env vars, or migrations explicitly.
 
 ## Testing
+
 How you verified this works — commands run, manual steps, what you observed.
 If something is untested or deferred, say so plainly.
 
 ## Notes
+
 (Optional) Known limitations, follow-ups, or decisions worth flagging.
 Screenshots/recordings go here for any UI change.
 
 Closes PFM-XXX
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+🤖 Generated with AI
 ```
 
 Guidance on the sections:
+
 - **Summary** — the "why" matters more than the "what". A reviewer skims this first.
 - **Changes** — bullets, not prose. Surface migrations / new env vars / new deps because they have deploy implications and are easy to miss in a diff.
 - **Testing** — be honest. "Typecheck + lint pass; drove the real Stripe checkout flow against a local team and confirmed `customer_converted` in PostHog" is far more useful than "tested locally". If tests failed or a step was skipped, report it.

--- a/api/src/social-account-feeds/social-account-feeds.service.ts
+++ b/api/src/social-account-feeds/social-account-feeds.service.ts
@@ -25,6 +25,23 @@ import { BlueskyService } from '../bluesky/bluesky.service';
 import { differenceInDays } from 'date-fns';
 import { PlatformPostDto } from './dto/platform-post.dto';
 
+type TikTokPostResultCandidateSocialPost = {
+  external_id: string | null;
+  caption: string | null;
+};
+
+type TikTokPostResultCandidate = {
+  id: string;
+  post_id: string;
+  provider_post_id: string | null;
+  provider_post_url: string | null;
+  created_at: string;
+  social_posts:
+    | TikTokPostResultCandidateSocialPost
+    | TikTokPostResultCandidateSocialPost[]
+    | null;
+};
+
 @Injectable()
 export class SocialAccountFeedsService {
   platformsToAlwaysRefresh = ['youtube', 'bluesky'];
@@ -380,10 +397,11 @@ export class SocialAccountFeedsService {
     const minCreatedAt = new Date(Math.min(...postTimes) - bufferMs);
     const maxCreatedAt = new Date(Math.max(...postTimes) + bufferMs);
 
-    const { data: candidates, error } = await this.supabaseService.supabaseClient
-      .from('social_post_results')
-      .select(
-        `
+    const { data: candidateRows, error } =
+      await this.supabaseService.supabaseClient
+        .from('social_post_results')
+        .select(
+          `
           id,
           post_id,
           provider_post_id,
@@ -391,11 +409,11 @@ export class SocialAccountFeedsService {
           created_at,
           social_posts!inner(external_id, caption)
         `,
-      )
-      .eq('provider_connection_id', accountId)
-      .eq('success', true)
-      .gte('created_at', minCreatedAt.toISOString())
-      .lte('created_at', maxCreatedAt.toISOString());
+        )
+        .eq('provider_connection_id', accountId)
+        .eq('success', true)
+        .gte('created_at', minCreatedAt.toISOString())
+        .lte('created_at', maxCreatedAt.toISOString());
 
     if (error) {
       console.error('Unable to fetch TikTok post result candidates', error);
@@ -403,6 +421,8 @@ export class SocialAccountFeedsService {
     }
 
     const matchedResultIds = new Set<string>();
+    const candidates = (candidateRows ??
+      []) as unknown as TikTokPostResultCandidate[];
 
     for (const post of unmatchedPosts) {
       if (!post.posted_at) continue;
@@ -410,7 +430,7 @@ export class SocialAccountFeedsService {
       const postTime = new Date(post.posted_at).getTime();
       const normalizedCaption = this.normalizeCaption(post.caption);
 
-      const candidate = candidates?.find((result) => {
+      const candidate = candidates.find((result) => {
         if (matchedResultIds.has(result.id)) return false;
         if (result.provider_post_id === post.id) return false;
 

--- a/api/src/social-account-feeds/social-account-feeds.service.ts
+++ b/api/src/social-account-feeds/social-account-feeds.service.ts
@@ -6,7 +6,11 @@ import { PaginatedPlatformPostResponse } from './dto/pagination-platform-post-re
 import { REQUEST } from '@nestjs/core';
 import { Request } from 'express';
 import { ConfigService } from '@nestjs/config';
-import { SocialAccount, PlatformPostMetadata } from '../lib/dto/global.dto';
+import {
+  SocialAccount,
+  PlatformPost,
+  PlatformPostMetadata,
+} from '../lib/dto/global.dto';
 import { SocialPlatformService } from '../lib/social-provider-service';
 import { TikTokBusinessService } from '../tiktok-business/tiktok-business.service';
 import { YouTubeService } from '../youtube/youtube.service';
@@ -280,16 +284,33 @@ export class SocialAccountFeedsService {
     const { data: socialPostResults } = socialPostResultsResponse;
 
     // Create a map of provider_post_id to social post result with post data
-    const postResultMap = new Map(
-      socialPostResults?.map((result) => [
-        result.provider_post_id,
-        {
-          social_post_result_id: result.id,
-          social_post_id: result.post_id,
-          external_post_id: result.social_posts?.external_id,
-        },
-      ]) || [],
+    const postResultMap = new Map<
+      string,
+      {
+        social_post_result_id: string;
+        social_post_id: string;
+        external_post_id: string | null | undefined;
+      }
+    >(
+      socialPostResults
+        ?.filter((result) => result.provider_post_id)
+        .map((result) => [
+          result.provider_post_id!,
+          {
+            social_post_result_id: result.id,
+            social_post_id: result.post_id,
+            external_post_id: result.social_posts?.external_id,
+          },
+        ]) || [],
     );
+
+    if (account.provider === 'tiktok') {
+      await this.reconcileTikTokProviderPostIds({
+        accountId,
+        posts: accountPostsResult.posts,
+        postResultMap,
+      });
+    }
 
     const result: PaginatedPlatformPostResponse = {
       data: accountPostsResult.posts.map((p): PlatformPostDto => {
@@ -325,6 +346,116 @@ export class SocialAccountFeedsService {
     };
 
     return result;
+  }
+
+  private async reconcileTikTokProviderPostIds({
+    accountId,
+    posts,
+    postResultMap,
+  }: {
+    accountId: string;
+    posts: PlatformPost[];
+    postResultMap: Map<
+      string,
+      {
+        social_post_result_id: string;
+        social_post_id: string;
+        external_post_id: string | null | undefined;
+      }
+    >;
+  }) {
+    const unmatchedPosts = posts.filter(
+      (post) => !postResultMap.has(post.id) && post.posted_at,
+    );
+
+    if (unmatchedPosts.length === 0) return;
+
+    const postTimes = unmatchedPosts
+      .map((post) => new Date(post.posted_at!).getTime())
+      .filter((time) => Number.isFinite(time));
+
+    if (postTimes.length === 0) return;
+
+    const bufferMs = 60 * 60 * 1000;
+    const minCreatedAt = new Date(Math.min(...postTimes) - bufferMs);
+    const maxCreatedAt = new Date(Math.max(...postTimes) + bufferMs);
+
+    const { data: candidates, error } = await this.supabaseService.supabaseClient
+      .from('social_post_results')
+      .select(
+        `
+          id,
+          post_id,
+          provider_post_id,
+          provider_post_url,
+          created_at,
+          social_posts!inner(external_id, caption)
+        `,
+      )
+      .eq('provider_connection_id', accountId)
+      .eq('success', true)
+      .gte('created_at', minCreatedAt.toISOString())
+      .lte('created_at', maxCreatedAt.toISOString());
+
+    if (error) {
+      console.error('Unable to fetch TikTok post result candidates', error);
+      return;
+    }
+
+    const matchedResultIds = new Set<string>();
+
+    for (const post of unmatchedPosts) {
+      if (!post.posted_at) continue;
+
+      const postTime = new Date(post.posted_at).getTime();
+      const normalizedCaption = this.normalizeCaption(post.caption);
+
+      const candidate = candidates?.find((result) => {
+        if (matchedResultIds.has(result.id)) return false;
+        if (result.provider_post_id === post.id) return false;
+
+        const createdAt = new Date(result.created_at).getTime();
+        if (Math.abs(createdAt - postTime) > bufferMs) return false;
+
+        const socialPost = Array.isArray(result.social_posts)
+          ? result.social_posts[0]
+          : result.social_posts;
+
+        return (
+          socialPost?.caption &&
+          this.normalizeCaption(socialPost.caption) === normalizedCaption
+        );
+      });
+
+      if (!candidate) continue;
+
+      const socialPost = Array.isArray(candidate.social_posts)
+        ? candidate.social_posts[0]
+        : candidate.social_posts;
+
+      matchedResultIds.add(candidate.id);
+      postResultMap.set(post.id, {
+        social_post_result_id: candidate.id,
+        social_post_id: candidate.post_id,
+        external_post_id: socialPost?.external_id,
+      });
+
+      const { error: updateError } = await this.supabaseService.supabaseClient
+        .from('social_post_results')
+        .update({
+          provider_post_id: post.id,
+          provider_post_url: post.url || candidate.provider_post_url,
+        })
+        .eq('id', candidate.id);
+
+      if (updateError) {
+        console.error('Unable to update TikTok provider post id', updateError);
+      }
+    }
+  }
+
+  private normalizeCaption(caption: string): string {
+    return caption.trim().toLowerCase();
   }
 
   async getPlatformService({

--- a/trigger/posting/platforms/tiktok-post-client.ts
+++ b/trigger/posting/platforms/tiktok-post-client.ts
@@ -14,7 +14,11 @@ import {
 
 export class TikTokPostClient extends PostClient {
   #tokenUrl = "https://open.tiktokapis.com/v2/oauth/token/";
-  #processingStatuses = ["PROCESSING", "PROCESSING_DOWNLOAD"];
+  #processingStatuses = [
+    "PROCESSING",
+    "PROCESSING_DOWNLOAD",
+    "PROCESSING_UPLOAD",
+  ];
   #processedStatuses = [
     "PUBLISH_COMPLETE",
     "PUBLISH_SUCCESS",
@@ -156,13 +160,18 @@ export class TikTokPostClient extends PostClient {
             requests: this.#requests,
             responses: this.#responses,
             username: creatorInfoResponse.data.data.creator_username,
+            publish_id: publishId,
           },
           provider_post_url: `https://www.tiktok.com/@${creatorInfoResponse.data.data.creator_username}`,
           provider_post_id: publishId,
         };
       }
 
-      const { status } = await this.#getPublishStatus({ publishId, account });
+      const { status, publicPostId } = await this.#getPublishStatus({
+        publishId,
+        account,
+        waitForPublicPostId: true,
+      });
 
       if (this.#processingStatuses.includes(status)) {
         return {
@@ -177,9 +186,10 @@ export class TikTokPostClient extends PostClient {
             requests: this.#requests,
             responses: this.#responses,
             username: creatorInfoResponse.data.data.creator_username,
+            publish_id: publishId,
           },
           provider_post_url: `https://www.tiktok.com/@${creatorInfoResponse.data.data.creator_username}`,
-          provider_post_id: publishId,
+          provider_post_id: publicPostId ?? publishId,
         };
       }
 
@@ -187,13 +197,14 @@ export class TikTokPostClient extends PostClient {
         success: true,
         post_id: postId,
         provider_connection_id: account.id,
-        provider_post_id: publishId,
+        provider_post_id: publicPostId ?? publishId,
         details: {
           status: "Published successfully",
           addedMedia: this.#addedMedia,
           requests: this.#requests,
           responses: this.#responses,
           username: creatorInfoResponse.data.data.creator_username,
+          publish_id: publishId,
         },
         provider_post_url: `https://www.tiktok.com/@${creatorInfoResponse.data.data.creator_username}`,
       };
@@ -240,19 +251,27 @@ export class TikTokPostClient extends PostClient {
   async #getPublishStatus({
     publishId,
     account,
+    waitForPublicPostId = false,
   }: {
     publishId: string;
     account: SocialAccount;
+    waitForPublicPostId?: boolean;
   }) {
     let status = "PROCESSING";
     let failReason;
-    let statusResponse;
+    let publicPostId: string | undefined;
     let attempts = 0;
+    let publicPostIdAttempts = 0;
     const initialDelayMs = 5000;
     const maxAttempts = 15;
+    const maxPublicPostIdAttempts = 3;
 
     while (
-      this.#processingStatuses.includes(status) &&
+      (this.#processingStatuses.includes(status) ||
+        (waitForPublicPostId &&
+          this.#processedStatuses.includes(status) &&
+          !publicPostId &&
+          publicPostIdAttempts < maxPublicPostIdAttempts)) &&
       attempts < maxAttempts
     ) {
       this.#requests.push({
@@ -263,7 +282,7 @@ export class TikTokPostClient extends PostClient {
           },
         },
       });
-      statusResponse = await axios.post(
+      const statusResponse = await axios.post<string>(
         "https://open.tiktokapis.com/v2/post/publish/status/fetch/",
         {
           publish_id: publishId,
@@ -273,17 +292,39 @@ export class TikTokPostClient extends PostClient {
             Authorization: `Bearer ${account.access_token}`,
             "Content-Type": "application/json; charset=UTF-8",
           },
+          transformResponse: [(data) => data],
         },
       );
 
-      this.#responses.push({ statusResponse: statusResponse.data });
+      const parsedStatusResponse = this.#parsePublishStatusResponse(
+        statusResponse.data,
+      );
 
-      status = statusResponse.data.data.status;
-      failReason = statusResponse.data.data.fail_reason;
+      this.#responses.push({ statusResponse: parsedStatusResponse.data });
+
+      status = parsedStatusResponse.data.data.status;
+      failReason = parsedStatusResponse.data.data.fail_reason;
+      publicPostId = parsedStatusResponse.publicPostId || publicPostId;
       attempts++;
 
-      if (this.#processingStatuses.includes(status) && attempts < maxAttempts) {
-        const delay = initialDelayMs * Math.pow(1.5, attempts - 1);
+      const waitingForPublicPostId =
+        waitForPublicPostId &&
+        this.#processedStatuses.includes(status) &&
+        !publicPostId;
+
+      if (waitingForPublicPostId) {
+        publicPostIdAttempts++;
+      }
+
+      if (
+        (this.#processingStatuses.includes(status) ||
+          (waitingForPublicPostId &&
+            publicPostIdAttempts < maxPublicPostIdAttempts)) &&
+        attempts < maxAttempts
+      ) {
+        const delay = waitingForPublicPostId
+          ? initialDelayMs
+          : initialDelayMs * Math.pow(1.5, attempts - 1);
         await wait.for({ seconds: delay / 1000 });
       }
     }
@@ -306,7 +347,35 @@ export class TikTokPostClient extends PostClient {
       );
     }
 
-    return { status, failReason };
+    return { status, failReason, publicPostId };
+  }
+
+  #parsePublishStatusResponse(responseText: string) {
+    const publicPostIds = this.#extractPublicPostIds(responseText);
+    const data = JSON.parse(responseText);
+
+    return {
+      data,
+      publicPostId: publicPostIds[0],
+    };
+  }
+
+  #extractPublicPostIds(responseText: string): string[] {
+    const idsArrayMatch = responseText.match(
+      /"publicaly_available_post_id"\s*:\s*\[([^\]]*)\]/,
+    );
+
+    if (!idsArrayMatch) return [];
+
+    const ids: string[] = [];
+    const itemPattern = /"([^"\\]*(?:\\.[^"\\]*)*)"|(-?\d+)/g;
+    let itemMatch: RegExpExecArray | null;
+
+    while ((itemMatch = itemPattern.exec(idsArrayMatch[1])) !== null) {
+      ids.push(itemMatch[1] ?? itemMatch[2]);
+    }
+
+    return ids;
   }
 
   async #getPublishId({


### PR DESCRIPTION
## Summary
Fixes TikTok account feed association so fetched posts can resolve their Post for Me social post and result IDs. TikTok publish IDs are still retained as fallbacks, but public TikTok post IDs are captured and used when available.

## Changes
- Capture TikTok `publicaly_available_post_id` from publish status responses and prefer it for `provider_post_id`.
- Preserve TikTok `publish_id` in result details and fall back to it when no public post ID is available.
- Reconcile legacy TikTok result rows during feed fetches by matching caption and timestamp, then update `provider_post_id` to the public TikTok post ID.
- Added bigint-safe extraction for public TikTok post IDs from raw status response text.
- No migrations, new environment variables, or dependency changes.

## Testing
- `cd trigger && bun run typecheck`
- `cd api && bun run typecheck`
- `cd api && bun run lint`
- `cd trigger && bun run lint`

## Notes
The branch name does not include a Linear issue ID, so no Linear close tag was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)