### PR TITLE
fix(trigger): handle platform upload edge cases

### DIFF
--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -228,24 +228,20 @@ export class InstagramPostClient extends PostClient {
             throw error;
           }
 
-          if (error.response?.status === 400) {
-            console.log(
-              `Bad Request With Error: ${error.response?.data?.error?.message}`,
-            );
-            console.log("Waiting 5 secs");
-            const waited = await this.#waitWithTaskBudget({
-              delayMs: 5000,
-              operation: "retrying Instagram media publish",
-            });
+          console.log(
+            `Status: ${error.response?.status} Error: ${error.response?.data?.error?.message}`,
+          );
+          console.log("Waiting 5 secs");
+          const waited = await this.#waitWithTaskBudget({
+            delayMs: 5000,
+            operation: "retrying Instagram media publish",
+          });
 
-            if (!waited) {
-              break;
-            }
-
-            continue;
+          if (!waited) {
+            break;
           }
 
-          throw error;
+          continue;
         } finally {
           publishAttempts++;
         }

--- a/trigger/posting/platforms/youtube-post-client.ts
+++ b/trigger/posting/platforms/youtube-post-client.ts
@@ -429,25 +429,12 @@ export class YouTubePostClient extends PostClient {
 
           const chunkBuf = Buffer.from(await fileRes.arrayBuffer());
           const actualChunkLen = chunkBuf.length;
-          const isFinalChunk = endExclusive === fileSize;
 
-          // Guard: intermediate chunks must be exactly the declared size.
-          // A short read here means the storage layer closed the connection early;
-          // throw so the outer retry loop can re-fetch from the correct offset.
-          if (!isFinalChunk && actualChunkLen !== chunkLen) {
+          // Every ranged read must match the declared range. A short read would
+          // make YouTube treat the request as a non-final undersized chunk.
+          if (actualChunkLen !== chunkLen) {
             throw new Error(
-              `Storage returned ${actualChunkLen} bytes but expected ${chunkLen} bytes for range ${range} (non-final chunk); video would be truncated`,
-            );
-          }
-
-          // For the final chunk the actual length may legitimately be <= chunkLen,
-          // but it must still be positive and must not exceed the declared size.
-          if (
-            isFinalChunk &&
-            (actualChunkLen <= 0 || actualChunkLen > chunkLen)
-          ) {
-            throw new Error(
-              `Storage returned unexpected ${actualChunkLen} bytes for final chunk (expected 1–${chunkLen} bytes)`,
+              `Storage returned ${actualChunkLen} bytes but expected ${chunkLen} bytes for range ${range}; video would be truncated`,
             );
           }
 


### PR DESCRIPTION
## Summary

Fix platform posting edge cases that can cause premature failures or truncated uploads in background jobs.

## Changes

- Retry Instagram media publish failures beyond only HTTP 400 responses while still respecting the task time budget.
- Require every YouTube ranged storage read to match the declared range size so undersized chunks fail before upload.
- No new dependencies, env vars, or migrations.

## Testing

- `cd trigger && bun run typecheck`
- `cd trigger && bun run lint`

## Notes

No Linear issue was provided, so this draft PR does not include a `Closes PFM-XXX` tag.

🤖 Generated with AI
