### PR TITLE
feat(dashboard): allow account email updates

### DIFF
--- a/dashboard/app/components/account-form.tsx
+++ b/dashboard/app/components/account-form.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useForm } from "react-hook-form";
 
@@ -6,20 +7,22 @@ import { useForm as useFormFetcher } from "~/hooks/use-form";
 import { Button } from "~/ui/button";
 import { Input } from "~/ui/input";
 import { Form, FormControl, FormField, FormItem, FormLabel } from "~/ui/form";
-import { useEffect } from "react";
 
 interface AccountFormData {
   firstName: string;
   lastName: string;
+  newEmail: string;
 }
 
 export function AccountForm() {
   const { fetcher, isSubmitting, data } = useFormFetcher({ withToast: true });
+  const [isChangingEmail, setIsChangingEmail] = useState(false);
 
   const form = useForm<AccountFormData>({
     defaultValues: {
       firstName: "",
       lastName: "",
+      newEmail: "",
     },
   });
 
@@ -31,10 +34,20 @@ export function AccountForm() {
       return;
     }
 
+    const newEmail = formData.newEmail.trim();
+
+    if (isChangingEmail && !newEmail) {
+      toast.error("Missing Information", {
+        description: "Please enter a new email address.",
+      });
+      return;
+    }
+
     fetcher.submit(
       {
         firstName: formData.firstName.trim(),
         lastName: formData.lastName.trim(),
+        ...(isChangingEmail ? { newEmail } : {}),
       },
       {
         method: "POST",
@@ -52,7 +65,10 @@ export function AccountForm() {
       form.reset({
         firstName: data.user.firstName || "",
         lastName: data.user.lastName || "",
+        newEmail: "",
       });
+
+      setIsChangingEmail(false);
     }
   }, [data]);
 
@@ -64,14 +80,47 @@ export function AccountForm() {
       >
         <FormItem>
           <FormLabel htmlFor="email">Email</FormLabel>
-          <Input
-            id="email"
-            type="email"
-            value={`${data?.user?.email}`}
-            readOnly
-            className="bg-muted"
-          />
+          <div className="flex gap-2">
+            <Input
+              id="email"
+              type="email"
+              value={data?.user?.email || ""}
+              readOnly
+              className="bg-muted"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isSubmitting}
+              onClick={() => {
+                setIsChangingEmail((value) => !value);
+                form.setValue("newEmail", "");
+              }}
+            >
+              {isChangingEmail ? "Cancel" : "Change"}
+            </Button>
+          </div>
         </FormItem>
+
+        {isChangingEmail ? (
+          <FormField
+            control={form.control}
+            name="newEmail"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="Enter your new email"
+                    disabled={isSubmitting}
+                    {...field}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        ) : null}
 
         <FormField
           control={form.control}

--- a/dashboard/app/routes/_protected.account._index/route.action.ts
+++ b/dashboard/app/routes/_protected.account._index/route.action.ts
@@ -2,42 +2,87 @@ import { data } from "react-router";
 
 import { withSupabase } from "~/lib/.server/supabase";
 
-export const action = withSupabase(async ({ supabase, request }) => {
-  const currentUser = await supabase.auth.getUser();
-  if (!currentUser.data?.user) {
-    throw new Error("User not found");
-  }
+export const action = withSupabase(
+  async ({ supabase, supabaseServiceRole: supabaseAdmin, request }) => {
+    const currentUser = await supabase.auth.getUser();
+    if (!currentUser.data?.user) {
+      throw new Error("User not found");
+    }
 
-  const formData = await request.formData();
+    const { user } = currentUser.data;
 
-  const firstName = formData.get("firstName") as string;
-  const lastName = formData.get("lastName") as string;
+    const formData = await request.formData();
 
-  if (!firstName || !lastName) {
-    return data(
-      { success: false, error: "First name and last name are required" },
-      { status: 400 }
-    );
-  }
+    const firstName = (formData.get("firstName") as string | null)?.trim();
+    const lastName = (formData.get("lastName") as string | null)?.trim();
+    const newEmail = (formData.get("newEmail") as string | null)?.trim();
 
-  const { error } = await supabase.auth.updateUser({
-    data: {
-      first_name: firstName,
-      last_name: lastName,
-    },
-  });
+    if (!firstName || !lastName) {
+      return data(
+        {
+          success: false,
+          error: "First name and last name are required",
+          toast_msg: "First name and last name are required",
+        },
+        { status: 400 },
+      );
+    }
 
-  if (error) {
-    return data({ error: error.message }, { status: 400 });
-  }
+    const shouldUpdateEmail = Boolean(newEmail && newEmail !== user.email);
 
-  return data({
-    success: true,
-    toast_msg: "Profile updated successfully",
-    user: {
-      email: currentUser.data.user.email,
-      firstName,
-      lastName,
-    },
-  });
-});
+    if (shouldUpdateEmail && newEmail) {
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(newEmail)) {
+        return data(
+          {
+            success: false,
+            error: "Please enter a valid email address",
+            toast_msg: "Please enter a valid email address",
+          },
+          { status: 400 },
+        );
+      }
+
+      const { error: emailError } =
+        await supabaseAdmin.auth.admin.updateUserById(user.id, {
+          email: newEmail,
+        });
+
+      if (emailError) {
+        return data(
+          {
+            success: false,
+            error: emailError.message,
+            toast_msg: emailError.message,
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    const { error } = await supabase.auth.updateUser({
+      data: {
+        first_name: firstName,
+        last_name: lastName,
+      },
+    });
+
+    if (error) {
+      return data(
+        { success: false, error: error.message, toast_msg: error.message },
+        { status: 400 },
+      );
+    }
+
+    return data({
+      success: true,
+      toast_msg: shouldUpdateEmail
+        ? "Profile and email updated successfully"
+        : "Profile updated successfully",
+      user: {
+        email: shouldUpdateEmail ? newEmail : user.email,
+        firstName,
+        lastName,
+      },
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Adds an account modal option for users to change their account email while preserving the existing profile name update flow.

## Changes

- Adds a Change toggle next to the current email in the account form.
- Submits a new email only when the user opts into changing it.
- Updates the account action to validate the new email and call Supabase admin auth for the current user.
- No new dependencies, env vars, or migrations.

## Testing

- `bun run typecheck` in `dashboard/`
- `bun run lint` in `dashboard/`

## Notes

No Linear issue ID was provided, so this draft PR does not include an auto-closing Linear tag.

Generated with AI