### PR TITLE
fix(tracking): enable anonymous person profiles for ad attribution

### DIFF
--- a/dashboard/app/tracking/posthog-provider.tsx
+++ b/dashboard/app/tracking/posthog-provider.tsx
@@ -18,7 +18,13 @@ export function PostHogProvider({
       posthog.init(apiKey, {
         api_host: apiHost,
         defaults: "2025-05-24",
-        person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well
+        // 'always' so anonymous visitors get a person profile and PostHog latches
+        // first-touch attribution ($initial_gclid/$initial_utm_*/$gclid etc.) at
+        // landing. Combined with cross_subdomain_cookie below, that attribution
+        // merges onto the user at identify() — which is what the Google/Meta Ads
+        // destinations read. 'identified_only' skips person props on anonymous
+        // events, so the click ID never latches and conversions go unattributed.
+        person_profiles: "always",
         // Share the anonymous distinct_id across *.postforme.dev so a visitor's
         // marketing-site activity stitches to their dashboard user on identify().
         cross_subdomain_cookie: true,

--- a/marketing/app/tracking/posthog-provider.tsx
+++ b/marketing/app/tracking/posthog-provider.tsx
@@ -18,7 +18,13 @@ export function PostHogProvider({
       posthog.init(apiKey, {
         api_host: apiHost,
         defaults: "2025-05-24",
-        person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well
+        // 'always' so anonymous visitors get a person profile and PostHog latches
+        // first-touch attribution ($initial_gclid/$initial_utm_*/$gclid etc.) at
+        // landing. Combined with cross_subdomain_cookie below, that attribution
+        // merges onto the user at identify() — which is what the Google/Meta Ads
+        // destinations read. 'identified_only' skips person props on anonymous
+        // events, so the click ID never latches and conversions go unattributed.
+        person_profiles: "always",
         // Share the anonymous distinct_id across *.postforme.dev so a visitor's
         // marketing-site activity stitches to their dashboard user on identify().
         cross_subdomain_cookie: true,


### PR DESCRIPTION
## Summary
Our PostHog → Google Ads destination has been firing on every conversion but uploading **0** of them (logs are 100% `Empty gclid. Skipping...`), so no paid conversion is attributable to its originating ad click. Root cause is a one-line config: both apps run posthog-js with `person_profiles: "identified_only"`, which skips person-property processing for anonymous events — so the `$initial_gclid` the destination reads is never captured at the anonymous marketing landing. This flips both to `"always"`.

## Changes
- `marketing/app/tracking/posthog-provider.tsx` — `person_profiles: "identified_only"` → `"always"`
- `dashboard/app/tracking/posthog-provider.tsx` — same
- Comment added explaining *why* (so it isn't flipped back).

Why both siblings: the carry only works if the anonymous identity is shared across `www.` and `app.` (via the existing `cross_subdomain_cookie: true` on the shared `postforme.dev` domain), so both apps must agree — they deploy together.

No new deps, env vars, or migrations. No change needed to the Google Ads destination — its existing `{person.properties.gclid ?? person.properties.$initial_gclid}` mapping starts resolving once `$initial_gclid` is populated.

## Testing
- `bun run typecheck` + `bun run lint` pass in both `marketing/` and `dashboard/`.
- **Not yet verified live** (config takes effect only after deploy). End-to-end check planned: in a clean incognito window, visit `www.postforme.dev/?gclid=PFM_TEST_xxxx`, browse, sign up on `app.`, then confirm the identified person has `properties.$initial_gclid = PFM_TEST_xxxx` and the destination stops skipping.

## Notes
- **Forward-only** — does not backfill the existing 1,614 naked conversions.
- **Trade-off:** anonymous visitors now create person profiles (higher person volume / some added cost). Accepted; it also unlocks pre-signup funnel visibility.
- **Bonus:** PostHog now natively captures `gbraid`/`wbraid`/`fbclid` too (iOS + Meta).
- **Caveat:** Safari ITP caps the script-set cookie at ~7 days, so the click→signup window isn't truly 90 days on Safari.

Closes PFM-608

🤖 Generated with [Claude Code](https://claude.com/claude-code)