### PR TITLE
chore(ci): pin Unkey CLI to v2.0.147 in deploy jobs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Install Unkey CLI
         run: |
-          curl -sL https://github.com/unkeyed/unkey/releases/latest/download/unkey_Linux_x86_64.tar.gz | tar xz
+          curl -sL https://github.com/unkeyed/unkey/releases/download/cli%2Fv2.0.147/unkey_Linux_x86_64.tar.gz | tar xz
           ./unkey --version
 
       - name: Deploy API to Unkey
@@ -260,7 +260,7 @@ jobs:
 
       - name: Install Unkey CLI
         run: |
-          curl -sL https://github.com/unkeyed/unkey/releases/latest/download/unkey_Linux_x86_64.tar.gz | tar xz
+          curl -sL https://github.com/unkeyed/unkey/releases/download/cli%2Fv2.0.147/unkey_Linux_x86_64.tar.gz | tar xz
           ./unkey --version
 
       - name: Deploy Dashboard to Unkey
@@ -318,7 +318,7 @@ jobs:
 
       - name: Install Unkey CLI
         run: |
-          curl -sL https://github.com/unkeyed/unkey/releases/latest/download/unkey_Linux_x86_64.tar.gz | tar xz
+          curl -sL https://github.com/unkeyed/unkey/releases/download/cli%2Fv2.0.147/unkey_Linux_x86_64.tar.gz | tar xz
           ./unkey --version
 
       - name: Deploy Marketing to Unkey
@@ -337,7 +337,17 @@ jobs:
 
   notify-final:
     name: Notify Slack — Final
-    needs: [notify-start, precheck, migrate, deploy-api, deploy-api-railway-backup, deploy-trigger, deploy-dashboard, deploy-marketing]
+    needs:
+      [
+        notify-start,
+        precheck,
+        migrate,
+        deploy-api,
+        deploy-api-railway-backup,
+        deploy-trigger,
+        deploy-dashboard,
+        deploy-marketing,
+      ]
     if: always()
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
The deploy workflow installs the Unkey CLI from `releases/latest`, so an upstream CLI release can change the binary out from under our deploys without warning. This pins it to a known-good version (`cli/v2.0.147`) across all three deploy jobs.

## Changes
- `.github/workflows/cd.yml` — replace `releases/latest/download/...` with `releases/download/cli%2Fv2.0.147/...` in the **deploy-api**, **deploy-dashboard**, and **deploy-marketing** Unkey CLI install steps.
- Cosmetic: reformat the `notify-final` `needs:` array to multiline.

## Testing
- CI-only change; validated by the workflow itself on this PR / next deploy. The pinned URL resolves to the existing `unkey_Linux_x86_64.tar.gz` asset for tag `cli/v2.0.147`.

## Notes
- Bumping the CLI in future is now an explicit one-line version change rather than implicit drift from `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)