### PR TITLE
Fix: API Deply

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Install Unkey CLI
         run: |
-          curl -sL https://github.com/unkeyed/unkey/releases/latest/download/unkey_Linux_x86_64.tar.gz | tar xz
+          curl -sL https://github.com/unkeyed/unkey/releases/download/cli%2Fv2.0.147/unkey_Linux_x86_64.tar.gz | tar xz
           ./unkey --version
 
       - name: Deploy Dashboard to Unkey
@@ -337,7 +337,17 @@ jobs:
 
   notify-final:
     name: Notify Slack — Final
-    needs: [notify-start, precheck, migrate, deploy-api, deploy-api-railway-backup, deploy-trigger, deploy-dashboard, deploy-marketing]
+    needs:
+      [
+        notify-start,
+        precheck,
+        migrate,
+        deploy-api,
+        deploy-api-railway-backup,
+        deploy-trigger,
+        deploy-dashboard,
+        deploy-marketing,
+      ]
     if: always()
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Pinning Unkey CLI version so deploy doesn't break