### PR TITLE
fix(trigger): avoid overwriting processed video media

### DIFF
--- a/trigger/ffmpeg-process-video.ts
+++ b/trigger/ffmpeg-process-video.ts
@@ -91,6 +91,14 @@ const getFileKeyFromPublicUrl = (
   return match ? match[1] : null;
 };
 
+const getProcessedFileKey = (key: string): string => {
+  const dirname = path.dirname(key);
+  const basename = path.basename(key);
+  const processedBasename = `processed_${Date.now()}_${basename}`;
+
+  return dirname === "." ? processedBasename : `${dirname}/${processedBasename}`;
+};
+
 export const ffmpegProcessVideo = task({
   id: "ffmpeg-process-video",
   maxDuration: 800,
@@ -101,7 +109,16 @@ export const ffmpegProcessVideo = task({
     },
   },
   machine: "medium-2x",
-  run: async ({ medium: { url } }: { medium: { url: string } }) => {
+  run: async ({
+    medium: { id, url },
+  }: {
+    medium: { id: string; url: string };
+  }): Promise<{
+    id: string;
+    url: string;
+    key: string;
+    processed: boolean;
+  }> => {
     logger.info("Starting video processing", { url });
     const tempDir = os.tmpdir();
     const bucket = "post-media";
@@ -255,7 +272,7 @@ export const ffmpegProcessVideo = task({
         hasValidAudio
       ) {
         logger.info("video already meets requirements, skipping processing");
-        return;
+        return { id, url, key, processed: false };
       }
 
       if (needsProcessingForBitrate) {
@@ -384,15 +401,26 @@ export const ffmpegProcessVideo = task({
 
       fileProcessed = true;
 
-      logger.info("Uploading processed video to storage");
-      await uploadFile({ bucketName: bucket, key, filePath: outputPath });
+      const processedKey = getProcessedFileKey(key);
+      const processedUrl = url.replace(key, processedKey);
+
+      logger.info("Uploading processed video to storage", {
+        key,
+        processedKey,
+      });
+      await uploadFile({
+        bucketName: bucket,
+        key: processedKey,
+        filePath: outputPath,
+      });
 
       logger.info("Video processing completed successfully", {
-        key: key,
+        key: processedKey,
+        originalKey: key,
         bucket,
         processed: true,
       });
-      return;
+      return { id, url: processedUrl, key: processedKey, processed: true };
     } catch (e) {
       logger.error("Error processing video", { error: e });
       throw e;

--- a/trigger/ffmpeg-process-video.ts
+++ b/trigger/ffmpeg-process-video.ts
@@ -99,6 +99,17 @@ const getProcessedFileKey = (key: string): string => {
   return dirname === "." ? processedBasename : `${dirname}/${processedBasename}`;
 };
 
+type ProcessPostVideoMedium = {
+  id: string;
+  provider?: string | null;
+  provider_connection_id?: string | null;
+  url: string;
+  thumbnail_url: string;
+  thumbnail_timestamp_ms?: number | null;
+  type: string;
+  skip_processing?: boolean | null;
+};
+
 export const ffmpegProcessVideo = task({
   id: "ffmpeg-process-video",
   maxDuration: 800,
@@ -110,15 +121,11 @@ export const ffmpegProcessVideo = task({
   },
   machine: "medium-2x",
   run: async ({
-    medium: { id, url },
+    medium,
   }: {
-    medium: { id: string; url: string };
-  }): Promise<{
-    id: string;
-    url: string;
-    key: string;
-    processed: boolean;
-  }> => {
+    medium: ProcessPostVideoMedium;
+  }): Promise<ProcessPostVideoMedium> => {
+    const { url } = medium;
     logger.info("Starting video processing", { url });
     const tempDir = os.tmpdir();
     const bucket = "post-media";
@@ -272,7 +279,7 @@ export const ffmpegProcessVideo = task({
         hasValidAudio
       ) {
         logger.info("video already meets requirements, skipping processing");
-        return { id, url, key, processed: false };
+        return medium;
       }
 
       if (needsProcessingForBitrate) {
@@ -420,7 +427,7 @@ export const ffmpegProcessVideo = task({
         bucket,
         processed: true,
       });
-      return { id, url: processedUrl, key: processedKey, processed: true };
+      return { ...medium, url: processedUrl };
     } catch (e) {
       logger.error("Error processing video", { error: e });
       throw e;

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -274,15 +274,19 @@ export const processPost = task({
 
         logger.info("Localizing Media Complete", { localizedMedia });
 
-        postMedia.push(
-          ...localizedMedia.runs
-            .filter((run) => run.ok)
-            .map((run) => run.output),
-        );
+        const succesfulMedia = localizedMedia.runs
+          .filter((run) => run.ok)
+          .map((run) => run.output);
 
+        const postImages = succesfulMedia.filter(
+          (medium) => medium.type !== "video",
+        );
         const postVideos = postMedia.filter(
           (medium) => medium.type === "video",
         );
+
+        postMedia.push(...postImages);
+        postMedia.push(...postVideos.filter((m) => m.skip_processing));
 
         const videosToProcess = postVideos.filter((m) => !m.skip_processing);
 
@@ -298,6 +302,16 @@ export const processPost = task({
           );
 
           logger.info("Processing Videos Complete", { processVideosResult });
+
+          postMedia.push(
+            ...processVideosResult.runs
+              .filter((run) => run.ok)
+              .map((run) => run.output),
+          );
+
+          logger.info("Updated post media with processed video URLs", {
+            postMedia,
+          });
         }
 
         if (postMedia.length == 0) {

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -207,8 +207,6 @@ export const processPost = task({
         throw new Error("API Key is invalid");
       }
 
-      const isYouTubeOnly = accounts.every((a) => a.provider == "youtube");
-
       logger.info("Getting Stripe Customer Id");
       const { data: project, error: projectError } = await supabaseClient
         .from("projects")
@@ -281,7 +279,7 @@ export const processPost = task({
         const postImages = succesfulMedia.filter(
           (medium) => medium.type !== "video",
         );
-        const postVideos = postMedia.filter(
+        const postVideos = succesfulMedia.filter(
           (medium) => medium.type === "video",
         );
 
@@ -290,7 +288,7 @@ export const processPost = task({
 
         const videosToProcess = postVideos.filter((m) => !m.skip_processing);
 
-        if (!isYouTubeOnly && videosToProcess.length > 0) {
+        if (videosToProcess.length > 0) {
           logger.info("Processing Videos");
           const processVideosResult = await tasks.batchTriggerAndWait(
             "ffmpeg-process-video",


### PR DESCRIPTION
## Summary

Avoid stale CDN/object-version reads by writing ffmpeg-processed videos to new storage keys instead of overwriting the localized media object. This lets downstream platform posting, including YouTube uploads, use the processed media URL directly.

## Changes

- Upload processed videos to a new `processed_<timestamp>_<original>` key while preserving any existing storage folder path.
- Return the full media object from `ffmpeg-process-video`, updating only `url` when processing creates a new object.
- Update post processing to split localized media into images, skipped videos, and videos requiring ffmpeg processing, then use successful processed media outputs for platform posting.
- Remove the YouTube-only bypass so videos consistently flow through the processing decision before posting.
- No new dependencies, migrations, or environment variables.

## Testing

- `cd trigger && bun run typecheck`
- `cd trigger && bun run lint`

## Notes

No Linear issue provided.

Generated with AI