### PR TITLE
feat(linkedin): support resharing posts

### DIFF
--- a/api/src/social-posts/dto/post-configurations.dto.ts
+++ b/api/src/social-posts/dto/post-configurations.dto.ts
@@ -475,7 +475,15 @@ export class FacebookConfigurationDto extends BaseConfigurationDto {
   set_caption_for_each_image?: boolean;
 }
 
-export class LinkedinConfigurationDto extends BaseConfigurationDto {}
+export class LinkedinConfigurationDto extends BaseConfigurationDto {
+  @ApiProperty({
+    description:
+      'LinkedIn UGC post id to reshare. The caption is used as the reshare commentary.',
+    nullable: true,
+    required: false,
+  })
+  reshare_ugc_post_id?: string;
+}
 
 export class BlueskyConfigurationDto extends BaseConfigurationDto {}
 
@@ -875,6 +883,14 @@ export class AccountConfigurationDetailsDto {
     default: true,
   })
   set_caption_for_each_image?: boolean;
+
+  @ApiProperty({
+    description:
+      'LinkedIn UGC post id to reshare. The caption is used as the reshare commentary.',
+    nullable: true,
+    required: false,
+  })
+  reshare_ugc_post_id?: string;
 }
 
 export class AccountConfigurationDto {

--- a/api/src/social-posts/dto/post-configurations.dto.ts
+++ b/api/src/social-posts/dto/post-configurations.dto.ts
@@ -482,7 +482,7 @@ export class LinkedinConfigurationDto extends BaseConfigurationDto {
     nullable: true,
     required: false,
   })
-  reshare_ugc_post_id?: string;
+  reshare_post_id?: string;
 }
 
 export class BlueskyConfigurationDto extends BaseConfigurationDto {}
@@ -890,7 +890,7 @@ export class AccountConfigurationDetailsDto {
     nullable: true,
     required: false,
   })
-  reshare_ugc_post_id?: string;
+  reshare_post_id?: string;
 }
 
 export class AccountConfigurationDto {

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -844,22 +844,8 @@ export class InstagramPostClient extends PostClient {
         }
 
         const permalink = mediaResponse.data.permalink as string | undefined;
-        const actualMediaType = mediaResponse.data.media_type as
-          | string
-          | undefined;
-
         if (!permalink) {
           throw new Error("Permalink missing from media response");
-        }
-
-        if (actualMediaType === "VIDEO" || actualMediaType === "REELS") {
-          // Extract the shortcode from the permalink
-          const shortcode = permalink.split("/").filter(Boolean).pop();
-          if (!shortcode) {
-            throw new Error("Unable to derive Instagram reel shortcode");
-          }
-
-          return `https://www.instagram.com/reel/${shortcode}/`;
         }
 
         return permalink;

--- a/trigger/posting/platforms/linkedin-post-client.ts
+++ b/trigger/posting/platforms/linkedin-post-client.ts
@@ -6,6 +6,7 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { PostClient } from "../post-client";
 import {
+  LinkedinConfiguration,
   PlatformAppCredentials,
   PostMedia,
   PostResult,
@@ -71,24 +72,19 @@ export class LinkedInPostClient extends PostClient {
     account,
     caption,
     media,
+    platformConfig,
   }: {
     postId: string;
     account: SocialAccount;
     caption: string;
     media: PostMedia[];
+    platformConfig?: LinkedinConfiguration;
   }): Promise<PostResult> {
     try {
       const authorUrn =
         account.social_provider_metadata?.connection_type === "page"
           ? `urn:li:company:${account.social_provider_user_id}`
           : `urn:li:person:${account.social_provider_user_id}`;
-
-      const { uploadedMedia, mediaCategory } = await this.#processMedia({
-        caption,
-        media,
-        authorUrn,
-        account,
-      });
 
       const postBody: Record<string, any> = {
         author: authorUrn,
@@ -98,7 +94,6 @@ export class LinkedInPostClient extends PostClient {
             shareCommentary: {
               text: caption,
             },
-            shareMediaCategory: mediaCategory,
           },
         },
         visibility: {
@@ -106,9 +101,31 @@ export class LinkedInPostClient extends PostClient {
         },
       };
 
-      if (uploadedMedia.length > 0) {
-        postBody.specificContent["com.linkedin.ugc.ShareContent"].media =
-          uploadedMedia;
+      if (platformConfig?.reshare_ugc_post_id) {
+        postBody.responseContext = {
+          parent: this.#toUgcPostUrn(platformConfig.reshare_ugc_post_id),
+        };
+        postBody.specificContent["com.linkedin.ugc.ShareContent"] = {
+          ...postBody.specificContent["com.linkedin.ugc.ShareContent"],
+          shareMediaCategory: "NONE",
+          media: [],
+          shareCategorization: {},
+        };
+      } else {
+        const { uploadedMedia, mediaCategory } = await this.#processMedia({
+          caption,
+          media,
+          authorUrn,
+          account,
+        });
+
+        postBody.specificContent["com.linkedin.ugc.ShareContent"].shareMediaCategory =
+          mediaCategory;
+
+        if (uploadedMedia.length > 0) {
+          postBody.specificContent["com.linkedin.ugc.ShareContent"].media =
+            uploadedMedia;
+        }
       }
 
       this.#requests.push({ postRequest: postBody });
@@ -117,6 +134,7 @@ export class LinkedInPostClient extends PostClient {
         headers: {
           Authorization: `Bearer ${account.access_token}`,
           "Content-Type": "application/json",
+          "X-Restli-Protocol-Version": "2.0.0",
         },
         body: JSON.stringify(postBody),
       });
@@ -127,15 +145,20 @@ export class LinkedInPostClient extends PostClient {
         );
       }
 
-      const result = await response.json();
+      const responseText = await response.text();
+      const result = responseText ? JSON.parse(responseText) : {};
+      const providerPostId =
+        result.id || response.headers.get("x-restli-id") || undefined;
 
       this.#responses.push({ postResponse: result });
       return {
         success: true,
         provider_connection_id: account.id,
         post_id: postId,
-        provider_post_id: result.id,
-        provider_post_url: `https://www.linkedin.com/feed/update/${result.id}`,
+        provider_post_id: providerPostId,
+        provider_post_url: providerPostId
+          ? `https://www.linkedin.com/feed/update/${providerPostId}`
+          : undefined,
         details: {
           requests: this.#requests,
           responses: this.#responses,
@@ -172,6 +195,12 @@ export class LinkedInPostClient extends PostClient {
     }
 
     return url;
+  }
+
+  #toUgcPostUrn(ugcPostId: string) {
+    return ugcPostId.startsWith("urn:")
+      ? ugcPostId
+      : `urn:li:ugcPost:${ugcPostId}`;
   }
 
   async #createMedia({

--- a/trigger/posting/platforms/linkedin-post-client.ts
+++ b/trigger/posting/platforms/linkedin-post-client.ts
@@ -1,8 +1,3 @@
- 
- 
- 
- 
- 
 import { SupabaseClient } from "@supabase/supabase-js";
 import { PostClient } from "../post-client";
 import {
@@ -101,9 +96,9 @@ export class LinkedInPostClient extends PostClient {
         },
       };
 
-      if (platformConfig?.reshare_ugc_post_id) {
+      if (platformConfig?.reshare_post_id) {
         postBody.responseContext = {
-          parent: this.#toUgcPostUrn(platformConfig.reshare_ugc_post_id),
+          parent: this.#toUgcPostUrn(platformConfig.reshare_post_id),
         };
         postBody.specificContent["com.linkedin.ugc.ShareContent"] = {
           ...postBody.specificContent["com.linkedin.ugc.ShareContent"],
@@ -119,8 +114,9 @@ export class LinkedInPostClient extends PostClient {
           account,
         });
 
-        postBody.specificContent["com.linkedin.ugc.ShareContent"].shareMediaCategory =
-          mediaCategory;
+        postBody.specificContent[
+          "com.linkedin.ugc.ShareContent"
+        ].shareMediaCategory = mediaCategory;
 
         if (uploadedMedia.length > 0) {
           postBody.specificContent["com.linkedin.ugc.ShareContent"].media =

--- a/trigger/posting/post.types.ts
+++ b/trigger/posting/post.types.ts
@@ -194,6 +194,7 @@ export interface FacebookConfiguration {
 export interface LinkedinConfiguration {
   caption?: string;
   media?: PostMedia[];
+  reshare_ugc_post_id?: string;
 }
 
 export interface BlueskyConfiguration {

--- a/trigger/posting/post.types.ts
+++ b/trigger/posting/post.types.ts
@@ -194,7 +194,7 @@ export interface FacebookConfiguration {
 export interface LinkedinConfiguration {
   caption?: string;
   media?: PostMedia[];
-  reshare_ugc_post_id?: string;
+  reshare_post_id?: string;
 }
 
 export interface BlueskyConfiguration {


### PR DESCRIPTION
## Summary

Adds LinkedIn UGC reshare support so API consumers can repost an existing LinkedIn post while using the caption as share commentary.

## Changes

- Adds `reshare_post_id` to LinkedIn platform configuration DTOs and trigger types.
- Builds LinkedIn UGC reshare payloads with `responseContext.parent`, `shareMediaCategory: "NONE"`, empty media, and caption commentary.
- Normalizes raw LinkedIn post ids into `urn:li:ugcPost:{id}` while allowing full URNs.
- Adds the Rest.li protocol header and handles LinkedIn create responses that return the new post id in `x-restli-id`.
- Includes the existing branch change that returns Instagram media permalinks directly instead of rewriting reel URLs.

## Testing

- `cd trigger && bun run typecheck`
- `cd trigger && bun run lint`
- `cd api && bun run typecheck`
- `cd api && bun run lint`

## Notes

No Linear issue was provided for this draft PR, so there is no `Closes PFM-XXX` tag.

Generated with AI