### PR TITLE
Add Instagram Reels audio attachment (audio_configuration) and audio search endpoint

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { UnkeyModule } from './unkey/unkey.module';
 import { SocialPostPreviewsModule } from './social-posts-previews/social-posts-previews.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { SocialAccountFeedsModule } from './social-account-feeds/social-account-feeds.module';
+import { InstagramModule } from './instagram/instagram.module';
 import { PrivateModule } from './private/private.module';
 import { HealthcheckModule } from './healthcheck/healthcheck.module';
 
@@ -37,6 +38,7 @@ import { HealthcheckModule } from './healthcheck/healthcheck.module';
     SocialPostPreviewsModule,
     WebhooksModule,
     SocialAccountFeedsModule,
+    InstagramModule,
     PrivateModule,
     HealthcheckModule,
   ],

--- a/api/src/instagram/dto/instagram-audio.dto.ts
+++ b/api/src/instagram/dto/instagram-audio.dto.ts
@@ -1,0 +1,167 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsOptional, IsString } from 'class-validator';
+import type {
+  InstagramAudioAsset,
+  InstagramAudioSearchResponse,
+  Paging,
+  PagingCursors,
+} from '../instagram.types';
+
+export class InstagramAudioQueryDto {
+  @ApiProperty({
+    description: 'The type of audio to search for',
+    enum: ['music', 'original_sound'],
+    required: true,
+  })
+  @IsIn(['music', 'original_sound'])
+  audio_type: 'music' | 'original_sound';
+
+  @ApiProperty({
+    description:
+      'Search string to filter results by keyword. If omitted, trending audio is returned.',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  search_query?: string;
+}
+
+export class InstagramAudioAssetDto implements InstagramAudioAsset {
+  @ApiProperty({
+    description:
+      'Unique identifier of the audio asset. Use as `audio_configuration.audio_id` when creating an Instagram reel post.',
+  })
+  audio_id: string;
+
+  @ApiProperty({
+    description: 'Title of the audio asset',
+    nullable: true,
+    required: false,
+  })
+  title?: string;
+
+  @ApiProperty({
+    description: 'Display name of the artist. Returned for music only.',
+    nullable: true,
+    required: false,
+  })
+  display_artist?: string;
+
+  @ApiProperty({
+    description: 'Duration of the audio asset in milliseconds',
+    nullable: true,
+    required: false,
+  })
+  duration_in_ms?: number;
+
+  @ApiProperty({
+    description: 'Type of the audio asset',
+    enum: ['music', 'original_sound'],
+    nullable: true,
+    required: false,
+  })
+  audio_type?: string;
+
+  @ApiProperty({
+    description:
+      'Temporary URL to preview the audio file. Expires after approximately 1.5 days. May be null.',
+    nullable: true,
+    required: false,
+  })
+  download_url?: string | null;
+
+  @ApiProperty({
+    description:
+      'URL of the cover artwork thumbnail. Returned for music only. May be null.',
+    nullable: true,
+    required: false,
+  })
+  cover_artwork_thumbnail_uri?: string | null;
+
+  @ApiProperty({
+    description:
+      'Instagram username of the creator. Returned for original sounds only.',
+    nullable: true,
+    required: false,
+  })
+  ig_username?: string;
+
+  @ApiProperty({
+    description:
+      "URL of the creator's profile picture. Returned for original sounds only.",
+    nullable: true,
+    required: false,
+  })
+  profile_picture_url?: string;
+
+  @ApiProperty({
+    description: 'Whether the audio asset can be used in ads',
+    nullable: true,
+    required: false,
+  })
+  is_ads_eligible?: boolean | null;
+
+  @ApiProperty({
+    description: 'URL to preview the audio on Instagram. May be null.',
+    nullable: true,
+    required: false,
+  })
+  on_platform_audio_preview_link?: string | null;
+}
+
+export class InstagramAudioPagingCursorsDto implements PagingCursors {
+  @ApiProperty({
+    description: 'Cursor for the previous page of results',
+    nullable: true,
+    required: false,
+  })
+  before?: string;
+
+  @ApiProperty({
+    description: 'Cursor for the next page of results',
+    nullable: true,
+    required: false,
+  })
+  after?: string;
+}
+
+export class InstagramAudioPagingDto implements Paging {
+  @ApiProperty({
+    description: 'Paging cursors',
+    type: InstagramAudioPagingCursorsDto,
+    nullable: true,
+    required: false,
+  })
+  cursors?: InstagramAudioPagingCursorsDto;
+
+  @ApiProperty({
+    description: 'URL of the next page of results',
+    nullable: true,
+    required: false,
+  })
+  next?: string;
+
+  @ApiProperty({
+    description: 'URL of the previous page of results',
+    nullable: true,
+    required: false,
+  })
+  previous?: string;
+}
+
+export class InstagramAudioResponseDto implements InstagramAudioSearchResponse {
+  @ApiProperty({
+    description: 'List of audio assets',
+    type: InstagramAudioAssetDto,
+    isArray: true,
+  })
+  audio: InstagramAudioAssetDto[];
+
+  @ApiProperty({
+    description: 'Paging information for fetching further results',
+    type: InstagramAudioPagingDto,
+    nullable: true,
+    required: false,
+  })
+  paging?: InstagramAudioPagingDto;
+}

--- a/api/src/instagram/instagram.controller.ts
+++ b/api/src/instagram/instagram.controller.ts
@@ -1,0 +1,137 @@
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Param,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AxiosError } from 'axios';
+
+import { User } from '../auth/user.decorator';
+import type { RequestUser } from '../auth/user.interface';
+
+import { Protect } from '../auth/protect.decorator';
+import { SupabaseService } from '../supabase/supabase.service';
+import { InstagramService } from './instagram.service';
+import {
+  InstagramAudioQueryDto,
+  InstagramAudioResponseDto,
+} from './dto/instagram-audio.dto';
+import type { SocialAccount } from '../lib/dto/global.dto';
+
+@Controller('instagram-audio')
+@ApiTags('Instagram Audio')
+@ApiBearerAuth()
+@Protect()
+export class InstagramController {
+  constructor(
+    private readonly supabaseService: SupabaseService,
+    private readonly instagramService: InstagramService,
+  ) {}
+
+  @Get(':social_account_id')
+  @ApiOperation({
+    summary: 'Search Instagram audio',
+    description: `Search Meta's audio catalog for music or original sounds that can be attached to an Instagram Reel via the \`audio_configuration\` platform configuration. Returns trending audio when no search query is provided. Only available for Instagram accounts connected with Facebook Login.`,
+  })
+  @ApiParam({
+    name: 'social_account_id',
+    description: 'The id of the Instagram social account to search with',
+  })
+  @ApiOkResponse({
+    description: 'List of audio assets matching the search',
+    type: InstagramAudioResponseDto,
+  })
+  async searchAudio(
+    @Param('social_account_id') socialAccountId: string,
+    @Query() queryParams: InstagramAudioQueryDto,
+    @User() user: RequestUser,
+  ): Promise<InstagramAudioResponseDto> {
+    const { data: account, error: accountError } =
+      await this.supabaseService.supabaseClient
+        .from('social_provider_connections')
+        .select(
+          'id, provider, access_token, refresh_token, access_token_expires_at, refresh_token_expires_at, social_provider_user_id, social_provider_user_name, social_provider_metadata',
+        )
+        .eq('id', socialAccountId)
+        .eq('project_id', user.projectId)
+        .eq('provider', 'instagram')
+        .single();
+
+    if (accountError || !account) {
+      throw new HttpException('Unable to fetch account', HttpStatus.NOT_FOUND);
+    }
+
+    if (!account.access_token) {
+      throw new HttpException(
+        'Account has no access token, please reconnect the account',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const socialAccount: SocialAccount = {
+      provider: account.provider,
+      id: account.id,
+      social_provider_user_name: account.social_provider_user_name,
+      access_token: account.access_token || '',
+      refresh_token: account.refresh_token,
+      access_token_expires_at: new Date(
+        account.access_token_expires_at || new Date(),
+      ),
+      refresh_token_expires_at: account.refresh_token_expires_at
+        ? new Date(account.refresh_token_expires_at)
+        : null,
+      social_provider_user_id: account.social_provider_user_id,
+      social_provider_metadata: account.social_provider_metadata,
+    };
+
+    // The Audio API is only available on the Instagram API with Facebook
+    // Login; direct Instagram Login connections are not supported by Meta.
+    if (
+      !this.instagramService
+        .getApiBaseUrl(socialAccount)
+        .includes('graph.facebook.com')
+    ) {
+      throw new HttpException(
+        'Audio search is only available for Instagram accounts connected with Facebook Login',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    try {
+      return await this.instagramService.searchAudio({
+        account: socialAccount,
+        audioType: queryParams.audio_type,
+        searchQuery: queryParams.search_query,
+      });
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        const metaError = error.response?.data as
+          | { error?: { message?: string } }
+          | undefined;
+
+        const status = error.response?.status;
+
+        throw new HttpException(
+          metaError?.error?.message || 'Unable to search audio',
+          status && status >= 400 && status < 500
+            ? status
+            : HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+
+      throw new HttpException(
+        'Unable to search audio',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/api/src/instagram/instagram.module.ts
+++ b/api/src/instagram/instagram.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { InstagramController } from './instagram.controller';
 import { InstagramService } from './instagram.service';
 
 @Module({
+  controllers: [InstagramController],
   exports: [InstagramService],
   providers: [InstagramService],
 })

--- a/api/src/instagram/instagram.service.ts
+++ b/api/src/instagram/instagram.service.ts
@@ -16,6 +16,7 @@ import type {
   InstagramAccountMetadata,
   InstagramInsightsResponse,
   InstagramInsight,
+  InstagramAudioSearchResponse,
 } from './instagram.types';
 import { mapWithConcurrency } from '../lib/async.utils';
 
@@ -39,6 +40,30 @@ export class InstagramService implements SocialPlatformService {
       return 'https://graph.instagram.com/v23.0';
     }
     return 'https://graph.facebook.com/v23.0';
+  }
+
+  async searchAudio({
+    account,
+    audioType,
+    searchQuery,
+  }: {
+    account: SocialAccount;
+    audioType: 'music' | 'original_sound';
+    searchQuery?: string;
+  }): Promise<InstagramAudioSearchResponse> {
+    const response = await axios.get<InstagramAudioSearchResponse>(
+      `${this.getApiBaseUrl(account)}/ig_audio`,
+      {
+        params: {
+          audio_type: audioType,
+          user_id: account.social_provider_user_id,
+          ...(searchQuery ? { search_query: searchQuery } : {}),
+          access_token: account.access_token,
+        },
+      },
+    );
+
+    return response.data;
   }
 
   async initService(projectId: string): Promise<void> {

--- a/api/src/instagram/instagram.types.ts
+++ b/api/src/instagram/instagram.types.ts
@@ -116,3 +116,28 @@ export interface FacebookRefreshTokenResponse {
 export interface InstagramAccountMetadata {
   connection_type?: 'instagram' | 'facebook';
 }
+
+/**
+ * Instagram audio asset from the Audio API
+ */
+export interface InstagramAudioAsset {
+  audio_id: string;
+  title?: string;
+  display_artist?: string;
+  duration_in_ms?: number;
+  audio_type?: string;
+  download_url?: string | null;
+  cover_artwork_thumbnail_uri?: string | null;
+  ig_username?: string;
+  profile_picture_url?: string;
+  is_ads_eligible?: boolean | null;
+  on_platform_audio_preview_link?: string | null;
+}
+
+/**
+ * Instagram audio search response
+ */
+export interface InstagramAudioSearchResponse {
+  audio: InstagramAudioAsset[];
+  paging?: Paging;
+}

--- a/api/src/social-posts/dto/post-configurations.dto.ts
+++ b/api/src/social-posts/dto/post-configurations.dto.ts
@@ -77,6 +77,39 @@ export class PinterestConfigurationDto extends BaseConfigurationDto {
   link?: string;
 }
 
+export class InstagramAudioConfigurationDto {
+  @ApiProperty({
+    description:
+      "Id of the audio asset to attach to the reel, obtained from Meta's Instagram Audio API search or metadata endpoints.",
+    required: true,
+  })
+  audio_id: string;
+
+  @ApiProperty({
+    description:
+      'Volume of the attached audio, from 0 (muted) to 100 (full volume). Defaults to 100.',
+    nullable: true,
+    required: false,
+  })
+  audio_volume?: number;
+
+  @ApiProperty({
+    description:
+      "Volume of the video's original audio, from 0 (muted) to 100 (full volume). Defaults to 100.",
+    nullable: true,
+    required: false,
+  })
+  video_volume?: number;
+
+  @ApiProperty({
+    description:
+      'If true, loop the attached audio when it is shorter than the video. Informally documented by Meta and may be ignored.',
+    nullable: true,
+    required: false,
+  })
+  should_loop_audio?: boolean;
+}
+
 export class InstagramConfigurationDto extends BaseConfigurationDto {
   @ApiProperty({
     description: 'Instagram post placement',
@@ -127,6 +160,15 @@ export class InstagramConfigurationDto extends BaseConfigurationDto {
     required: false,
   })
   audio_name?: string;
+
+  @ApiProperty({
+    description:
+      'Attach an existing audio asset (music or original sound) to a Reel by audio id. Only honored on Reels uploads for accounts connected via Facebook Login (not supported on direct Instagram Login connections). Takes precedence over audio_name when both are set.',
+    type: InstagramAudioConfigurationDto,
+    nullable: true,
+    required: false,
+  })
+  audio_configuration?: InstagramAudioConfigurationDto;
 }
 
 export class TiktokConfigurationDto extends BaseConfigurationDto {
@@ -874,6 +916,15 @@ export class AccountConfigurationDetailsDto {
     required: false,
   })
   audio_name?: string;
+
+  @ApiProperty({
+    description:
+      'Attach an existing audio asset (music or original sound) to an Instagram Reel by audio id. Only honored on Reels uploads for accounts connected via Facebook Login (not supported on direct Instagram Login connections). Takes precedence over audio_name when both are set.',
+    type: InstagramAudioConfigurationDto,
+    nullable: true,
+    required: false,
+  })
+  audio_configuration?: InstagramAudioConfigurationDto;
 
   @ApiProperty({
     description:

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -4,6 +4,7 @@ import { PostClient } from "../post-client";
 import axios from "axios";
 import sharp from "sharp";
 import {
+  InstagramAudioConfiguration,
   InstagramConfiguration,
   PlatformAppCredentials,
   PostMedia,
@@ -27,6 +28,7 @@ export class InstagramPostClient extends PostClient {
   #postStartedAtMs: number | null = null;
   #localSupabaseClient;
   #addedMedia: any[] = [];
+  #warnings: string[] = [];
   #requests: any[] = [];
   #responses: any[] = [];
   #bucket: string = "post-media";
@@ -266,9 +268,14 @@ export class InstagramPostClient extends PostClient {
         provider_post_id: platformId,
         details: {
           warning:
-            media.length > this.#maxItems
-              ? `Only first ${this.#maxItems} items were posted`
-              : null,
+            [
+              media.length > this.#maxItems
+                ? `Only first ${this.#maxItems} items were posted`
+                : null,
+              ...this.#warnings,
+            ]
+              .filter(Boolean)
+              .join("; ") || null,
           addedMedia: this.#addedMedia,
           requests: this.#requests,
           responses: this.#responses,
@@ -361,6 +368,7 @@ export class InstagramPostClient extends PostClient {
       location_id?: string;
       user_tags?: any[];
       audio_name?: string;
+      audio_configuration?: InstagramAudioConfiguration;
       trial_params?: {
         graduation_strategy: "MANUAL" | "SS_PERFORMANCE";
       };
@@ -400,7 +408,25 @@ export class InstagramPostClient extends PostClient {
             createMediaParams.share_to_feed = platformConfig?.share_to_feed;
           }
 
-          if (platformConfig?.audio_name) {
+          // audio_configuration attaches a catalog track by audio_id. Only
+          // supported on the Instagram API with Facebook Login; ignored with
+          // a warning for direct Instagram Login accounts. Supersedes
+          // audio_name when attached.
+          if (platformConfig?.audio_configuration?.audio_id) {
+            if (this.getApiBaseUrl(account).includes("graph.facebook.com")) {
+              createMediaParams.audio_configuration =
+                platformConfig.audio_configuration;
+            } else {
+              this.#warnings.push(
+                "audio_configuration was ignored: attaching audio by id requires an Instagram account connected with Facebook Login",
+              );
+            }
+          }
+
+          if (
+            !createMediaParams.audio_configuration &&
+            platformConfig?.audio_name
+          ) {
             createMediaParams.audio_name = platformConfig.audio_name;
           }
         }

--- a/trigger/posting/post.types.ts
+++ b/trigger/posting/post.types.ts
@@ -129,6 +129,14 @@ export interface InstagramConfiguration {
   location?: string;
   trial_reel_type?: string;
   audio_name?: string;
+  audio_configuration?: InstagramAudioConfiguration;
+}
+
+export interface InstagramAudioConfiguration {
+  audio_id: string;
+  audio_volume?: number;
+  video_volume?: number;
+  should_loop_audio?: boolean;
 }
 
 export interface TiktokConfiguration {


### PR DESCRIPTION
Closes #272

Adds support for attaching licensed / trending audio to Instagram Reels using Meta's new [Audio API](https://developers.facebook.com/docs/instagram-platform/content-publishing/audio-api/) (released June 1, 2026), as discussed with Matt on Discord.

## What this adds

**Commit 1: `audio_configuration` pass-through**

- New `audio_configuration` object (`audio_id` required; `audio_volume`, `video_volume`, `should_loop_audio` optional) on `InstagramConfigurationDto` and `AccountConfigurationDetailsDto`, next to the existing `audio_name`.
- Mirrored `InstagramAudioConfiguration` interface in `trigger/posting/post.types.ts` (vendored per the dumb-monorepo rules).
- `InstagramPostClient` attaches `audio_configuration` on REELS containers, only for accounts routed to `graph.facebook.com`. Meta does not support the Audio API on the Instagram API with Instagram Login, so for direct-IG accounts the config is ignored, a warning is surfaced in `PostResult.details.warning`, and `audio_name` still applies as a fallback.
- When `audio_configuration` is attached, `audio_name` is skipped (precedence between the two is undefined by Meta; documented in the DTO descriptions).

**Commit 2: audio search endpoint**

- `GET /instagram-audio/:social_account_id?audio_type=music|original_sound&search_query=...` so users can find `audio_id`s. Omitting `search_query` returns trending audio (Meta's behavior).
- API-key protected via `@Protect()`, account scoped to the caller's project.
- Rejects direct Instagram-Login connections with a clear 400.
- Meta 4xx errors (expired token, missing scope) pass through with Meta's message; response DTO documents `paging` so generated SDK clients can paginate.

## Notes for review

- `audio_configuration` is sent as a nested object in the JSON body, same as the existing `trial_params` / `user_tags`. Meta's doc examples form-encode it as a JSON string; if Graph rejects the object form in practice, the fix is a `JSON.stringify` on that one field.
- `should_loop_audio` appears in Meta's example workflow but not their parameter table; included as optional and documented as informally supported.
- The search endpoint does not do an inline token refresh (the feeds service does). The `refresh-account-tokens` cron refreshes IG tokens expiring within 7 days every 12h, so a stale token should be rare; happy to add inline refresh if you would rather have parity.
- The account fetch mirrors the query in `SocialAccountFeedsService.getPlatformPosts` rather than extracting a shared helper, to keep this PR's footprint out of the feeds service. Happy to extract one as a follow-up.
- No validation decorators on the new config fields, consistent with the rest of `post-configurations.dto.ts` (nested platform configs are not runtime-validated anywhere).

## Testing

- `api`: lint, typecheck, build all pass. `trigger`: lint, typecheck pass.
- Not yet live-tested against Meta's Graph API (needs a Facebook-Login IG account). The new `media_audio_type` field on IG Media (`GET /{ig_media_id}?fields=media_audio_type`, returns `MUSIC` or `ORIGINAL_SOUND`) can be used to verify the attachment end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
