### PR TITLE
fix(dashboard): shrink provider icons in connect modal

### DIFF
--- a/dashboard/app/routes/_protected.$teamId.$projectId.accounts.connect._index/_provider-grid.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.accounts.connect._index/_provider-grid.tsx
@@ -59,12 +59,12 @@ function ProviderCard({
       disabled={!enabled}
       onClick={handleClick}
       className={cn(
-        "relative flex flex-col items-center justify-center p-4 min-w-[100px] min-h-[220px] rounded-lg border-2 border-dashed transition-all duration-200 text-muted-foreground border-muted-foreground-10 [&:not(:disabled)]:hover:border-accent [&:not(:disabled)]:hover:border-solid [&:not(:disabled)]:hover:text-foreground [&:not(:disabled)]:hover:cursor-pointer disabled:bg-muted disabled:border-none disabled:cursor-not-allowed disabled:opacity-50",
+        "relative flex flex-col items-center justify-center p-4 min-h-[120px] rounded-lg border-2 border-dashed transition-all duration-200 text-muted-foreground border-muted-foreground-10 [&:not(:disabled)]:hover:border-accent [&:not(:disabled)]:hover:border-solid [&:not(:disabled)]:hover:text-foreground [&:not(:disabled)]:hover:cursor-pointer disabled:bg-muted disabled:border-none disabled:cursor-not-allowed disabled:opacity-50",
       )}
     >
       <ProviderIcon
         provider={providerId.split("-")[0]}
-        className="h-[100px] w-[100px] mb-3"
+        className="h-10 w-10 mb-2"
       />
       <span className="text-sm font-medium text-center leading-tight">
         {name}


### PR DESCRIPTION
## Summary

Users opening the "Connect Social Account" modal in the dashboard couldn't see all platform options — the provider icons were rendered so large that the cards overflowed the dialog and cut off some providers. This shrinks the icons and cards so every option fits.

## Changes

- `_provider-grid.tsx`: provider icon `100px → 40px` (`h-10 w-10`)
- Card `min-h-[220px] → min-h-[120px]`, and dropped the fixed `min-w-[100px]` so the 2/3-column grid sizes cards naturally
- Hover states and the "Setup Required" badge are unchanged

## Testing

`bun run typecheck` and `bun run lint` pass in `dashboard/`. Verified the modal now fits all provider cards without overflow.

## Notes

Small CSS-only fix; no logic, deps, env, or migration changes.

Closes PFM-837

🤖 Generated with AI