### PR TITLE
feat(api): normalize platform values globally via interceptor

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 
 import { ConfigModule } from '@nestjs/config';
 import { SentryModule, SentryGlobalFilter } from '@sentry/nestjs/setup';
@@ -19,6 +19,7 @@ import { WebhooksModule } from './webhooks/webhooks.module';
 import { SocialAccountFeedsModule } from './social-account-feeds/social-account-feeds.module';
 import { PrivateModule } from './private/private.module';
 import { HealthcheckModule } from './healthcheck/healthcheck.module';
+import { NormalizePlatformInterceptor } from './lib/interceptors/normalize-platform.interceptor';
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { HealthcheckModule } from './healthcheck/healthcheck.module';
   controllers: [],
   providers: [
     { provide: APP_FILTER, useClass: SentryGlobalFilter },
+    { provide: APP_INTERCEPTOR, useClass: NormalizePlatformInterceptor },
     AuthGuard,
     VerifyKeyGuard,
   ],

--- a/api/src/lib/interceptors/normalize-platform.interceptor.ts
+++ b/api/src/lib/interceptors/normalize-platform.interceptor.ts
@@ -1,0 +1,87 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { Observable } from 'rxjs';
+
+const MAX_DEPTH = 6;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date) &&
+    !(value instanceof Buffer)
+  );
+}
+
+function normalizePlatformValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase();
+  }
+
+  if (Array.isArray(value)) {
+    const items = value as unknown[];
+    return items.map((item) =>
+      typeof item === 'string' ? item.trim().toLowerCase() : item,
+    );
+  }
+
+  return value;
+}
+
+export function normalizePlatformFields(value: unknown, depth = 0): unknown {
+  if (depth >= MAX_DEPTH) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const items = value as unknown[];
+    return items.map((item) => normalizePlatformFields(item, depth + 1));
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (key === 'platform') {
+      result[key] = normalizePlatformValue(val);
+    } else {
+      result[key] = normalizePlatformFields(val, depth + 1);
+    }
+  }
+
+  return result;
+}
+
+@Injectable()
+export class NormalizePlatformInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    if (request.body) {
+      request.body = normalizePlatformFields(request.body);
+    }
+
+    if (request.query) {
+      const normalizedQuery = normalizePlatformFields(request.query);
+      // Express 5 exposes `req.query` as a getter that re-parses the URL on
+      // every access, so mutating the returned object silently doesn't
+      // persist. Redefine the property with a plain value instead.
+      Object.defineProperty(request, 'query', {
+        value: normalizedQuery,
+        writable: true,
+        configurable: true,
+        enumerable: true,
+      });
+    }
+
+    return next.handle();
+  }
+}


### PR DESCRIPTION
## Summary

Any `platform` value clients send us (query params or body fields) needs to match the lowercase `provider` value stored in the DB — today nothing trims whitespace or normalizes case, so requests like `platform=" X "` or `"platform": "Instagram"` silently fail to match (empty filter results, or a wrong branch in `switch(platform)` matching).

## Changes

- Added `api/src/lib/interceptors/normalize-platform.interceptor.ts` — a global `NestInterceptor` that recursively walks `request.body` and `request.query`, trimming + lowercasing any value under a `platform` key (handles flat strings, string arrays, and platform fields nested inside arrays of objects, e.g. `preview_social_accounts[].platform`). Object keys (e.g. `platform_configurations`'s fixed `instagram`/`tiktok_business` keys) are left untouched — those are our own schema property names, not client-supplied provider values.
- Registered it globally in `api/src/app.module.ts` via `APP_INTERCEPTOR`, alongside the existing `APP_FILTER` (Sentry) pattern — no per-DTO changes needed, so it covers every current and future endpoint.
- Along the way, fixed two Express-5-specific bugs found during manual verification: `request.query` can't be reassigned (getter-only) and mutating the object it returns doesn't persist (it's a lazy getter that re-parses the URL each access) — now handled via `Object.defineProperty`.

## Testing

- `bun run typecheck` and `bun run lint` pass in `api/`.
- Ran the real API against local Supabase and manually verified via curl:
  - `GET /v1/social-accounts?platform=%20X%20&platform=Instagram` → normalized before hitting the `.in('provider', ...)` query.
  - `POST /v1/social-accounts/auth-url` with `{"platform": " Instagram "}` → correctly hits the `case 'instagram':` branch in the controller's switch statement instead of falling through to `default`.
  - `GET /healthcheck` still returns 200 (regression check after the Express query-getter fix).
  - Unauthenticated `GET /v1/social-accounts?platform=...` still returns 401, not a 500 — confirms guards still run correctly ahead of the interceptor.
- Also spun up an isolated Nest app importing the real interceptor class (no auth/DB dependency) to unit-verify all shapes: query arrays, single query values, flat body strings, and nested arrays of objects — all normalize correctly, and non-`platform` fields (including `platform_configurations` keys) are left untouched.

Closes PFM-686

🤖 Generated with [Claude Code](https://claude.com/claude-code)