### PR TITLE
feat(trigger): serialize youtube posts per account via a trigger queue

### DIFF
--- a/trigger/post-to-platform.ts
+++ b/trigger/post-to-platform.ts
@@ -1,5 +1,12 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
-import { idempotencyKeys, logger, task, tags, tasks } from "@trigger.dev/sdk";
+import {
+  idempotencyKeys,
+  logger,
+  queue,
+  task,
+  tags,
+  tasks,
+} from "@trigger.dev/sdk";
 import { PostClient } from "./posting/post-client";
 import { TwitterPostClient } from "./posting/platforms/twitter-post-client";
 import { InstagramPostClient } from "./posting/platforms/instagram-post-client";
@@ -131,6 +138,11 @@ const handleTokenRefresh = async ({
     success: true,
   };
 };
+
+export const youtubePerAccountQueue = queue({
+  name: "youtube-post-to-platform",
+  concurrencyLimit: 1,
+});
 
 export const postToPlatform = task({
   id: "post-to-platform",

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -11,6 +11,7 @@ import type {
 import { Unkey } from "@unkey/api";
 
 import { Database, Json } from "./supabase.types";
+import { youtubePerAccountQueue } from "./post-to-platform";
 
 const supabaseClient = createClient<Database>(
   process.env.SUPABASE_URL!,
@@ -498,7 +499,17 @@ export const processPost = task({
         logger.info("Posting To Accounts", { bulkPostData });
         const batchPostResult = await tasks.batchTriggerAndWait(
           "post-to-platform",
-          bulkPostData.map((data) => ({ payload: data })),
+          bulkPostData.map((data) => ({
+            payload: data,
+            ...(data.platform === "youtube"
+              ? {
+                  options: {
+                    queue: youtubePerAccountQueue.name,
+                    concurrencyKey: data.account.id,
+                  },
+                }
+              : {}),
+          })),
         );
 
         logger.info("Posting To Accounts Complete", { batchPostResult });
@@ -520,6 +531,12 @@ export const processPost = task({
           const storyPostResult = await tasks.triggerAndWait(
             "post-to-platform",
             storyPostData,
+            storyPostData.platform === "youtube"
+              ? {
+                  queue: youtubePerAccountQueue.name,
+                  concurrencyKey: storyPostData.account.id,
+                }
+              : undefined,
           );
 
           logger.info("Posting Story Media Complete", {


### PR DESCRIPTION
## Summary

Two scheduled posts targeting the same YouTube channel could previously run `post-to-platform` concurrently, racing YouTube's resumable-upload + mandatory-token-refresh flow (shared OAuth token refresh, quota, resumable session state). This routes YouTube posts through a per-account Trigger.dev queue so posts to the same channel are always processed one at a time, while other channels and all other platforms are unaffected.

## Changes

- `trigger/post-to-platform.ts` — declares a new `youtubePerAccountQueue` (`concurrencyLimit: 1`) via `queue()`. Not attached to the shared `post-to-platform` task itself, since that task serves every platform.
- `trigger/process-post.ts` — both trigger call sites (`batchTriggerAndWait` for normal posts, `triggerAndWait` for story-placement posts) now pass `queue: youtubePerAccountQueue.name` + `concurrencyKey: account.id` only when `platform === "youtube"`. Every other platform's trigger call is unchanged.
- No new dependencies, env vars, or migrations.

## Testing

- `cd trigger && bun run typecheck` — passes
- `cd trigger && bun run lint` — passes
- Not yet verified against a live Trigger.dev dev run (would need two scheduled posts against the same YouTube test account, watched in the Trigger.dev dashboard, to confirm the second run queues behind the first while a different account's run proceeds concurrently) — flagging as a manual follow-up before/at deploy.

## Notes

Known tradeoff: `process-post` and `post-to-platform` both have `maxDuration: 3600`, and `process-post` awaits `post-to-platform` via `*AndWait`. If a backlog builds up for one YouTube channel, a later post now waits in the per-account queue before its `post-to-platform` run even starts, and that wait counts against the *waiting* `process-post` run's own timeout. Not addressed in this PR — deferred as a follow-up if it becomes an issue in practice.

Closes PFM-604

🤖 Generated with [Claude Code](https://claude.com/claude-code)