### PR TITLE
feat(dashboard): add configurable grace period before payment-failure access revocation

### DIFF
--- a/api/supabase/migrations/20260713120000_teams_payment_failed_at.sql
+++ b/api/supabase/migrations/20260713120000_teams_payment_failed_at.sql
@@ -1,0 +1,9 @@
+--
+-- Track when a team's Stripe subscription first left a healthy state
+-- (active/trialing) so a configurable grace period can be applied before
+-- API access is revoked. NULL means healthy / no unresolved payment issue.
+ALTER TABLE public.teams
+  ADD COLUMN payment_failed_at timestamp with time zone NULL;
+
+CREATE INDEX idx_teams_payment_failed_at ON public.teams(payment_failed_at)
+  WHERE payment_failed_at IS NOT NULL;

--- a/api/supabase/supabase.types.ts
+++ b/api/supabase/supabase.types.ts
@@ -4,1452 +4,1452 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
   cms: {
     Tables: {
       article_authors: {
         Row: {
-          article_id: string;
-          author_id: string;
-          position: number;
-        };
+          article_id: string
+          author_id: string
+          position: number
+        }
         Insert: {
-          article_id: string;
-          author_id: string;
-          position?: number;
-        };
+          article_id: string
+          author_id: string
+          position?: number
+        }
         Update: {
-          article_id?: string;
-          author_id?: string;
-          position?: number;
-        };
+          article_id?: string
+          author_id?: string
+          position?: number
+        }
         Relationships: [
           {
-            foreignKeyName: 'article_authors_article_id_fkey';
-            columns: ['article_id'];
-            isOneToOne: false;
-            referencedRelation: 'articles';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_authors_article_id_fkey"
+            columns: ["article_id"]
+            isOneToOne: false
+            referencedRelation: "articles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'article_authors_author_id_fkey';
-            columns: ['author_id'];
-            isOneToOne: false;
-            referencedRelation: 'authors';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_authors_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "authors"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       article_tags: {
         Row: {
-          article_id: string;
-          tag_id: string;
-        };
+          article_id: string
+          tag_id: string
+        }
         Insert: {
-          article_id: string;
-          tag_id: string;
-        };
+          article_id: string
+          tag_id: string
+        }
         Update: {
-          article_id?: string;
-          tag_id?: string;
-        };
+          article_id?: string
+          tag_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'article_tags_article_id_fkey';
-            columns: ['article_id'];
-            isOneToOne: false;
-            referencedRelation: 'articles';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_tags_article_id_fkey"
+            columns: ["article_id"]
+            isOneToOne: false
+            referencedRelation: "articles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'article_tags_tag_id_fkey';
-            columns: ['tag_id'];
-            isOneToOne: false;
-            referencedRelation: 'tags';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_tags_tag_id_fkey"
+            columns: ["tag_id"]
+            isOneToOne: false
+            referencedRelation: "tags"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       articles: {
         Row: {
-          attribution: Json | null;
-          category_id: string | null;
-          content: string | null;
-          content_format: string;
-          cover_image_url: string | null;
-          cover_video_url: string | null;
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          featured: boolean;
-          id: string;
-          published_at: string | null;
-          slug: string;
-          status: string;
-          title: string;
-          updated_at: string;
-        };
+          attribution: Json | null
+          category_id: string | null
+          content: string | null
+          content_format: string
+          cover_image_url: string | null
+          cover_video_url: string | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          featured: boolean
+          id: string
+          published_at: string | null
+          slug: string
+          status: string
+          title: string
+          updated_at: string
+        }
         Insert: {
-          attribution?: Json | null;
-          category_id?: string | null;
-          content?: string | null;
-          content_format?: string;
-          cover_image_url?: string | null;
-          cover_video_url?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          featured?: boolean;
-          id?: string;
-          published_at?: string | null;
-          slug: string;
-          status?: string;
-          title: string;
-          updated_at?: string;
-        };
+          attribution?: Json | null
+          category_id?: string | null
+          content?: string | null
+          content_format?: string
+          cover_image_url?: string | null
+          cover_video_url?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          featured?: boolean
+          id?: string
+          published_at?: string | null
+          slug: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
         Update: {
-          attribution?: Json | null;
-          category_id?: string | null;
-          content?: string | null;
-          content_format?: string;
-          cover_image_url?: string | null;
-          cover_video_url?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          featured?: boolean;
-          id?: string;
-          published_at?: string | null;
-          slug?: string;
-          status?: string;
-          title?: string;
-          updated_at?: string;
-        };
+          attribution?: Json | null
+          category_id?: string | null
+          content?: string | null
+          content_format?: string
+          cover_image_url?: string | null
+          cover_video_url?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          featured?: boolean
+          id?: string
+          published_at?: string | null
+          slug?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'articles_category_id_fkey';
-            columns: ['category_id'];
-            isOneToOne: false;
-            referencedRelation: 'categories';
-            referencedColumns: ['id'];
+            foreignKeyName: "articles_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       authors: {
         Row: {
-          bio: string | null;
-          created_at: string;
-          deleted_at: string | null;
-          id: string;
-          image_url: string | null;
-          name: string;
-          role: string | null;
-          slug: string;
-          socials: Json;
-          updated_at: string;
-        };
+          bio: string | null
+          created_at: string
+          deleted_at: string | null
+          id: string
+          image_url: string | null
+          name: string
+          role: string | null
+          slug: string
+          socials: Json
+          updated_at: string
+        }
         Insert: {
-          bio?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          id?: string;
-          image_url?: string | null;
-          name: string;
-          role?: string | null;
-          slug: string;
-          socials?: Json;
-          updated_at?: string;
-        };
+          bio?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          image_url?: string | null
+          name: string
+          role?: string | null
+          slug: string
+          socials?: Json
+          updated_at?: string
+        }
         Update: {
-          bio?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          id?: string;
-          image_url?: string | null;
-          name?: string;
-          role?: string | null;
-          slug?: string;
-          socials?: Json;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          bio?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          image_url?: string | null
+          name?: string
+          role?: string | null
+          slug?: string
+          socials?: Json
+          updated_at?: string
+        }
+        Relationships: []
+      }
       categories: {
         Row: {
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          id: string;
-          name: string;
-          slug: string;
-          updated_at: string;
-        };
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          slug: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name: string;
-          slug: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          slug: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name?: string;
-          slug?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       tags: {
         Row: {
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          id: string;
-          name: string;
-          slug: string;
-          updated_at: string;
-        };
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          slug: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name: string;
-          slug: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          slug: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name?: string;
-          slug?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
-    };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   graphql_public: {
     Tables: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json;
-          operationName?: string;
-          query?: string;
-          variables?: Json;
-        };
-        Returns: Json;
-      };
-    };
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       projects: {
         Row: {
-          auth_callback_url: string | null;
-          created_at: string | null;
-          created_by: string | null;
-          description: string | null;
-          id: string;
-          is_system: boolean;
-          name: string;
-          team_id: string;
-          updated_at: string | null;
-          updated_by: string | null;
-        };
+          auth_callback_url: string | null
+          created_at: string | null
+          created_by: string | null
+          description: string | null
+          id: string
+          is_system: boolean
+          name: string
+          team_id: string
+          updated_at: string | null
+          updated_by: string | null
+        }
         Insert: {
-          auth_callback_url?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          description?: string | null;
-          id?: string;
-          is_system?: boolean;
-          name: string;
-          team_id: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          auth_callback_url?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          is_system?: boolean
+          name: string
+          team_id: string
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Update: {
-          auth_callback_url?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          description?: string | null;
-          id?: string;
-          is_system?: boolean;
-          name?: string;
-          team_id?: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          auth_callback_url?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          is_system?: boolean
+          name?: string
+          team_id?: string
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'projects_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'projects_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'projects_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_configurations: {
         Row: {
-          caption: string | null;
-          id: string;
-          post_id: string;
-          provider: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id: string | null;
-          provider_data: Json | null;
-        };
+          caption: string | null
+          id: string
+          post_id: string
+          provider: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id: string | null
+          provider_data: Json | null
+        }
         Insert: {
-          caption?: string | null;
-          id?: string;
-          post_id: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          provider_data?: Json | null;
-        };
+          caption?: string | null
+          id?: string
+          post_id: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          provider_data?: Json | null
+        }
         Update: {
-          caption?: string | null;
-          id?: string;
-          post_id?: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          provider_data?: Json | null;
-        };
+          caption?: string | null
+          id?: string
+          post_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          provider_data?: Json | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_configurations_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_configurations_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_configurations_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_configurations_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_media: {
         Row: {
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          meta_data: Json | null;
-          post_id: string;
-          provider: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id: string | null;
-          skip_processing: boolean | null;
-          tags: Json | null;
-          thumbnail_timestamp_ms: number | null;
-          thumbnail_url: string | null;
-          updated_at: string;
-          url: string;
-        };
+          created_at: string
+          external_id: string | null
+          id: string
+          meta_data: Json | null
+          post_id: string
+          provider: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id: string | null
+          skip_processing: boolean | null
+          tags: Json | null
+          thumbnail_timestamp_ms: number | null
+          thumbnail_url: string | null
+          updated_at: string
+          url: string
+        }
         Insert: {
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          meta_data?: Json | null;
-          post_id: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          skip_processing?: boolean | null;
-          tags?: Json | null;
-          thumbnail_timestamp_ms?: number | null;
-          thumbnail_url?: string | null;
-          updated_at?: string;
-          url: string;
-        };
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          meta_data?: Json | null
+          post_id: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url: string
+        }
         Update: {
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          meta_data?: Json | null;
-          post_id?: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          skip_processing?: boolean | null;
-          tags?: Json | null;
-          thumbnail_timestamp_ms?: number | null;
-          thumbnail_url?: string | null;
-          updated_at?: string;
-          url?: string;
-        };
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          meta_data?: Json | null
+          post_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_media_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_media_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_media_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_media_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_provider_connections: {
         Row: {
-          created_at: string;
-          id: string;
-          post_id: string;
-          provider_connection_id: string;
-          updated_at: string;
-        };
+          created_at: string
+          id: string
+          post_id: string
+          provider_connection_id: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          post_id: string;
-          provider_connection_id: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          post_id: string
+          provider_connection_id: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          post_id?: string;
-          provider_connection_id?: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          post_id?: string
+          provider_connection_id?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_provider_connections_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_provider_connections_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_provider_connections_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_provider_connections_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_result_post_media: {
         Row: {
-          id: string;
-          social_post_media_id: string;
-          social_post_result_id: string;
-        };
+          id: string
+          social_post_media_id: string
+          social_post_result_id: string
+        }
         Insert: {
-          id?: string;
-          social_post_media_id: string;
-          social_post_result_id: string;
-        };
+          id?: string
+          social_post_media_id: string
+          social_post_result_id: string
+        }
         Update: {
-          id?: string;
-          social_post_media_id?: string;
-          social_post_result_id?: string;
-        };
+          id?: string
+          social_post_media_id?: string
+          social_post_result_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_result_post_media_social_post_media_id_fkey';
-            columns: ['social_post_media_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_post_media';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_result_post_media_social_post_media_id_fkey"
+            columns: ["social_post_media_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_media"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_result_post_media_social_post_result_id_fkey';
-            columns: ['social_post_result_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_post_results';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_result_post_media_social_post_result_id_fkey"
+            columns: ["social_post_result_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_results"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_results: {
         Row: {
-          created_at: string;
-          details: Json | null;
-          error_message: string | null;
-          id: string;
-          post_id: string;
-          provider_connection_id: string;
-          provider_post_id: string | null;
-          provider_post_url: string | null;
-          success: boolean;
-          updated_at: string;
-        };
+          created_at: string
+          details: Json | null
+          error_message: string | null
+          id: string
+          post_id: string
+          provider_connection_id: string
+          provider_post_id: string | null
+          provider_post_url: string | null
+          success: boolean
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          details?: Json | null;
-          error_message?: string | null;
-          id?: string;
-          post_id: string;
-          provider_connection_id: string;
-          provider_post_id?: string | null;
-          provider_post_url?: string | null;
-          success: boolean;
-          updated_at?: string;
-        };
+          created_at?: string
+          details?: Json | null
+          error_message?: string | null
+          id?: string
+          post_id: string
+          provider_connection_id: string
+          provider_post_id?: string | null
+          provider_post_url?: string | null
+          success: boolean
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          details?: Json | null;
-          error_message?: string | null;
-          id?: string;
-          post_id?: string;
-          provider_connection_id?: string;
-          provider_post_id?: string | null;
-          provider_post_url?: string | null;
-          success?: boolean;
-          updated_at?: string;
-        };
+          created_at?: string
+          details?: Json | null
+          error_message?: string | null
+          id?: string
+          post_id?: string
+          provider_connection_id?: string
+          provider_post_id?: string | null
+          provider_post_url?: string | null
+          success?: boolean
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_results_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_results_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_results_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_results_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_team_usage: {
         Row: {
-          count: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          team_id: string;
-        };
+          count: number
+          end_at: string
+          limit: number
+          start_at: string
+          team_id: string
+        }
         Insert: {
-          count?: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          team_id: string;
-        };
+          count?: number
+          end_at: string
+          limit: number
+          start_at: string
+          team_id: string
+        }
         Update: {
-          count?: number;
-          end_at?: string;
-          limit?: number;
-          start_at?: string;
-          team_id?: string;
-        };
+          count?: number
+          end_at?: string
+          limit?: number
+          start_at?: string
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_team_usage_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_team_usage_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_posts: {
         Row: {
-          api_key: string;
-          caption: string;
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          post_at: string;
-          project_id: string;
-          status: Database['public']['Enums']['social_post_status'];
-          updated_at: string;
-        };
+          api_key: string
+          caption: string
+          created_at: string
+          external_id: string | null
+          id: string
+          post_at: string
+          project_id: string
+          status: Database["public"]["Enums"]["social_post_status"]
+          updated_at: string
+        }
         Insert: {
-          api_key: string;
-          caption: string;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          post_at?: string;
-          project_id: string;
-          status?: Database['public']['Enums']['social_post_status'];
-          updated_at?: string;
-        };
+          api_key: string
+          caption: string
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          post_at?: string
+          project_id: string
+          status?: Database["public"]["Enums"]["social_post_status"]
+          updated_at?: string
+        }
         Update: {
-          api_key?: string;
-          caption?: string;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          post_at?: string;
-          project_id?: string;
-          status?: Database['public']['Enums']['social_post_status'];
-          updated_at?: string;
-        };
+          api_key?: string
+          caption?: string
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          post_at?: string
+          project_id?: string
+          status?: Database["public"]["Enums"]["social_post_status"]
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_posts_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_posts_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_app_credentials: {
         Row: {
-          app_id: string | null;
-          app_secret: string | null;
-          created_at: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string;
-        };
+          app_id: string | null
+          app_secret: string | null
+          created_at: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string
+        }
         Insert: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Update: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_app_credentials_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_app_credentials_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connection_oauth_data: {
         Row: {
-          created_at: string | null;
-          id: string;
-          key: string;
-          key_id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string | null;
-          value: string;
-        };
+          created_at: string | null
+          id: string
+          key: string
+          key_id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string | null
+          value: string
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          key: string;
-          key_id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string | null;
-          value: string;
-        };
+          created_at?: string | null
+          id?: string
+          key: string
+          key_id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string | null
+          value: string
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          key?: string;
-          key_id?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string | null;
-          value?: string;
-        };
+          created_at?: string | null
+          id?: string
+          key?: string
+          key_id?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string | null
+          value?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connection_oauth_data_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connection_oauth_data_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connection_pagination_data: {
         Row: {
-          created_at: string | null;
-          id: string;
-          metadata: Json;
-          provider_connection_id: string;
-          updated_at: string | null;
-        };
+          created_at: string | null
+          id: string
+          metadata: Json
+          provider_connection_id: string
+          updated_at: string | null
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          metadata: Json;
-          provider_connection_id: string;
-          updated_at?: string | null;
-        };
+          created_at?: string | null
+          id?: string
+          metadata: Json
+          provider_connection_id: string
+          updated_at?: string | null
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          metadata?: Json;
-          provider_connection_id?: string;
-          updated_at?: string | null;
-        };
+          created_at?: string | null
+          id?: string
+          metadata?: Json
+          provider_connection_id?: string
+          updated_at?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connection_paginati_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connection_paginati_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connections: {
         Row: {
-          access_token: string | null;
-          access_token_expires_at: string | null;
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          refresh_token: string | null;
-          refresh_token_expires_at: string | null;
-          social_provider_metadata: Json | null;
-          social_provider_profile_photo_url: string | null;
-          social_provider_user_id: string;
-          social_provider_user_name: string | null;
-          updated_at: string;
-        };
+          access_token: string | null
+          access_token_expires_at: string | null
+          created_at: string
+          external_id: string | null
+          id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          refresh_token: string | null
+          refresh_token_expires_at: string | null
+          social_provider_metadata: Json | null
+          social_provider_profile_photo_url: string | null
+          social_provider_user_id: string
+          social_provider_user_name: string | null
+          updated_at: string
+        }
         Insert: {
-          access_token?: string | null;
-          access_token_expires_at?: string | null;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          refresh_token?: string | null;
-          refresh_token_expires_at?: string | null;
-          social_provider_metadata?: Json | null;
-          social_provider_profile_photo_url?: string | null;
-          social_provider_user_id: string;
-          social_provider_user_name?: string | null;
-          updated_at?: string;
-        };
+          access_token?: string | null
+          access_token_expires_at?: string | null
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          refresh_token?: string | null
+          refresh_token_expires_at?: string | null
+          social_provider_metadata?: Json | null
+          social_provider_profile_photo_url?: string | null
+          social_provider_user_id: string
+          social_provider_user_name?: string | null
+          updated_at?: string
+        }
         Update: {
-          access_token?: string | null;
-          access_token_expires_at?: string | null;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          refresh_token?: string | null;
-          refresh_token_expires_at?: string | null;
-          social_provider_metadata?: Json | null;
-          social_provider_profile_photo_url?: string | null;
-          social_provider_user_id?: string;
-          social_provider_user_name?: string | null;
-          updated_at?: string;
-        };
+          access_token?: string | null
+          access_token_expires_at?: string | null
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          refresh_token?: string | null
+          refresh_token_expires_at?: string | null
+          social_provider_metadata?: Json | null
+          social_provider_profile_photo_url?: string | null
+          social_provider_user_id?: string
+          social_provider_user_name?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connections_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connections_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       system_social_provider_app_credentials: {
         Row: {
-          app_id: string | null;
-          app_secret: string | null;
-          created_at: string;
-          id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string;
-        };
+          app_id: string | null
+          app_secret: string | null
+          created_at: string
+          id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string
+        }
         Insert: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          id?: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          id?: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Update: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
       team_addons: {
         Row: {
-          addon: Database['public']['Enums']['subscription_addon'];
-          expires_at: string;
-          id: string;
-          team_id: string;
-        };
+          addon: Database["public"]["Enums"]["subscription_addon"]
+          expires_at: string
+          id: string
+          team_id: string
+        }
         Insert: {
-          addon: Database['public']['Enums']['subscription_addon'];
-          expires_at: string;
-          id?: string;
-          team_id: string;
-        };
+          addon: Database["public"]["Enums"]["subscription_addon"]
+          expires_at: string
+          id?: string
+          team_id: string
+        }
         Update: {
-          addon?: Database['public']['Enums']['subscription_addon'];
-          expires_at?: string;
-          id?: string;
-          team_id?: string;
-        };
+          addon?: Database["public"]["Enums"]["subscription_addon"]
+          expires_at?: string
+          id?: string
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_addons_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_addons_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_notifications: {
         Row: {
-          created_at: string;
-          delivery_types: Database['public']['Enums']['delivery_type'][];
-          id: string;
-          message: string;
-          meta_data: Json | null;
-          notification_type: Database['public']['Enums']['notification_type'];
-          project_id: string | null;
-          team_id: string;
-        };
+          created_at: string
+          delivery_types: Database["public"]["Enums"]["delivery_type"][]
+          id: string
+          message: string
+          meta_data: Json | null
+          notification_type: Database["public"]["Enums"]["notification_type"]
+          project_id: string | null
+          team_id: string
+        }
         Insert: {
-          created_at?: string;
-          delivery_types: Database['public']['Enums']['delivery_type'][];
-          id?: string;
-          message: string;
-          meta_data?: Json | null;
-          notification_type: Database['public']['Enums']['notification_type'];
-          project_id?: string | null;
-          team_id: string;
-        };
+          created_at?: string
+          delivery_types: Database["public"]["Enums"]["delivery_type"][]
+          id?: string
+          message: string
+          meta_data?: Json | null
+          notification_type: Database["public"]["Enums"]["notification_type"]
+          project_id?: string | null
+          team_id: string
+        }
         Update: {
-          created_at?: string;
-          delivery_types?: Database['public']['Enums']['delivery_type'][];
-          id?: string;
-          message?: string;
-          meta_data?: Json | null;
-          notification_type?: Database['public']['Enums']['notification_type'];
-          project_id?: string | null;
-          team_id?: string;
-        };
+          created_at?: string
+          delivery_types?: Database["public"]["Enums"]["delivery_type"][]
+          id?: string
+          message?: string
+          meta_data?: Json | null
+          notification_type?: Database["public"]["Enums"]["notification_type"]
+          project_id?: string | null
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_notifications_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_notifications_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_notifications_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_notifications_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_social_post_meters: {
         Row: {
-          count: number;
-          day: number;
-          hour: number;
-          id: string;
-          minute: number;
-          month: number;
-          provider: Database['public']['Enums']['social_provider'];
-          team_id: string;
-          year: number;
-        };
+          count: number
+          day: number
+          hour: number
+          id: string
+          minute: number
+          month: number
+          provider: Database["public"]["Enums"]["social_provider"]
+          team_id: string
+          year: number
+        }
         Insert: {
-          count: number;
-          day: number;
-          hour: number;
-          id?: string;
-          minute: number;
-          month: number;
-          provider: Database['public']['Enums']['social_provider'];
-          team_id: string;
-          year: number;
-        };
+          count: number
+          day: number
+          hour: number
+          id?: string
+          minute: number
+          month: number
+          provider: Database["public"]["Enums"]["social_provider"]
+          team_id: string
+          year: number
+        }
         Update: {
-          count?: number;
-          day?: number;
-          hour?: number;
-          id?: string;
-          minute?: number;
-          month?: number;
-          provider?: Database['public']['Enums']['social_provider'];
-          team_id?: string;
-          year?: number;
-        };
+          count?: number
+          day?: number
+          hour?: number
+          id?: string
+          minute?: number
+          month?: number
+          provider?: Database["public"]["Enums"]["social_provider"]
+          team_id?: string
+          year?: number
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_social_post_meters_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_social_post_meters_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_users: {
         Row: {
-          created_at: string | null;
-          created_by: string | null;
-          team_id: string;
-          updated_at: string | null;
-          updated_by: string | null;
-          user_id: string;
-        };
+          created_at: string | null
+          created_by: string | null
+          team_id: string
+          updated_at: string | null
+          updated_by: string | null
+          user_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          created_by?: string | null;
-          team_id: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-          user_id: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          team_id: string
+          updated_at?: string | null
+          updated_by?: string | null
+          user_id: string
+        }
         Update: {
-          created_at?: string | null;
-          created_by?: string | null;
-          team_id?: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-          user_id?: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          team_id?: string
+          updated_at?: string | null
+          updated_by?: string | null
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_users_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       teams: {
         Row: {
-          billing_email: string | null;
-          created_at: string | null;
-          created_by: string | null;
-          id: string;
-          name: string;
-          stripe_customer_id: string | null;
-          updated_at: string | null;
-          updated_by: string | null;
-        };
+          billing_email: string | null
+          created_at: string | null
+          created_by: string | null
+          id: string
+          name: string
+          payment_failed_at: string | null
+          stripe_customer_id: string | null
+          updated_at: string | null
+          updated_by: string | null
+        }
         Insert: {
-          billing_email?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          id?: string;
-          name: string;
-          stripe_customer_id?: string | null;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          billing_email?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          name: string
+          payment_failed_at?: string | null
+          stripe_customer_id?: string | null
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Update: {
-          billing_email?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          id?: string;
-          name?: string;
-          stripe_customer_id?: string | null;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          billing_email?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          name?: string
+          payment_failed_at?: string | null
+          stripe_customer_id?: string | null
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'teams_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "teams_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'teams_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "teams_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       test_social_provider_connections: {
         Row: {
-          created_at: string | null;
-          created_by: string | null;
-          name: string | null;
-          social_provider_connection_id: string;
-        };
+          created_at: string | null
+          created_by: string | null
+          name: string | null
+          social_provider_connection_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          created_by?: string | null;
-          name?: string | null;
-          social_provider_connection_id: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          name?: string | null
+          social_provider_connection_id: string
+        }
         Update: {
-          created_at?: string | null;
-          created_by?: string | null;
-          name?: string | null;
-          social_provider_connection_id?: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          name?: string | null
+          social_provider_connection_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'test_social_provider_connecti_social_provider_connection_i_fkey';
-            columns: ['social_provider_connection_id'];
-            isOneToOne: true;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "test_social_provider_connecti_social_provider_connection_i_fkey"
+            columns: ["social_provider_connection_id"]
+            isOneToOne: true
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       users: {
         Row: {
-          email: string;
-          first_name: string | null;
-          id: string;
-          last_name: string | null;
-        };
+          email: string
+          first_name: string | null
+          id: string
+          last_name: string | null
+        }
         Insert: {
-          email: string;
-          first_name?: string | null;
-          id: string;
-          last_name?: string | null;
-        };
+          email: string
+          first_name?: string | null
+          id: string
+          last_name?: string | null
+        }
         Update: {
-          email?: string;
-          first_name?: string | null;
-          id?: string;
-          last_name?: string | null;
-        };
-        Relationships: [];
-      };
+          email?: string
+          first_name?: string | null
+          id?: string
+          last_name?: string | null
+        }
+        Relationships: []
+      }
       webhook_events: {
         Row: {
-          created_at: string | null;
-          data: Json;
-          id: string;
-          response: Json | null;
-          status: Database['public']['Enums']['webhook_event_status'];
-          type: Database['public']['Enums']['webhook_event_type'];
-          updated_at: string | null;
-          webhook_id: string;
-        };
+          created_at: string | null
+          data: Json
+          id: string
+          response: Json | null
+          status: Database["public"]["Enums"]["webhook_event_status"]
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at: string | null
+          webhook_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          data: Json;
-          id?: string;
-          response?: Json | null;
-          status: Database['public']['Enums']['webhook_event_status'];
-          type: Database['public']['Enums']['webhook_event_type'];
-          updated_at?: string | null;
-          webhook_id: string;
-        };
+          created_at?: string | null
+          data: Json
+          id?: string
+          response?: Json | null
+          status: Database["public"]["Enums"]["webhook_event_status"]
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at?: string | null
+          webhook_id: string
+        }
         Update: {
-          created_at?: string | null;
-          data?: Json;
-          id?: string;
-          response?: Json | null;
-          status?: Database['public']['Enums']['webhook_event_status'];
-          type?: Database['public']['Enums']['webhook_event_type'];
-          updated_at?: string | null;
-          webhook_id?: string;
-        };
+          created_at?: string | null
+          data?: Json
+          id?: string
+          response?: Json | null
+          status?: Database["public"]["Enums"]["webhook_event_status"]
+          type?: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at?: string | null
+          webhook_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhook_events_webhook_id_fkey';
-            columns: ['webhook_id'];
-            isOneToOne: false;
-            referencedRelation: 'webhooks';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhook_events_webhook_id_fkey"
+            columns: ["webhook_id"]
+            isOneToOne: false
+            referencedRelation: "webhooks"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       webhook_subscribed_event_types: {
         Row: {
-          id: string;
-          type: Database['public']['Enums']['webhook_event_type'];
-          webhook_id: string;
-        };
+          id: string
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id: string
+        }
         Insert: {
-          id?: string;
-          type: Database['public']['Enums']['webhook_event_type'];
-          webhook_id: string;
-        };
+          id?: string
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id: string
+        }
         Update: {
-          id?: string;
-          type?: Database['public']['Enums']['webhook_event_type'];
-          webhook_id?: string;
-        };
+          id?: string
+          type?: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhook_subscribed_event_types_webhook_id_fkey';
-            columns: ['webhook_id'];
-            isOneToOne: false;
-            referencedRelation: 'webhooks';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhook_subscribed_event_types_webhook_id_fkey"
+            columns: ["webhook_id"]
+            isOneToOne: false
+            referencedRelation: "webhooks"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       webhooks: {
         Row: {
-          created_at: string | null;
-          id: string;
-          project_id: string;
-          secret_key: string;
-          updated_at: string | null;
-          url: string;
-        };
+          created_at: string | null
+          id: string
+          project_id: string
+          secret_key: string
+          updated_at: string | null
+          url: string
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          project_id: string;
-          secret_key: string;
-          updated_at?: string | null;
-          url: string;
-        };
+          created_at?: string | null
+          id?: string
+          project_id: string
+          secret_key: string
+          updated_at?: string | null
+          url: string
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          project_id?: string;
-          secret_key?: string;
-          updated_at?: string | null;
-          url?: string;
-        };
+          created_at?: string | null
+          id?: string
+          project_id?: string
+          secret_key?: string
+          updated_at?: string | null
+          url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhooks_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhooks_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Views: {
       v_tiktok_verification_files: {
         Row: {
-          bucket_id: string | null;
-          name: string | null;
-          project_id: string | null;
-        };
+          bucket_id: string | null
+          name: string | null
+          project_id: string | null
+        }
         Insert: {
-          bucket_id?: string | null;
-          name?: string | null;
-          project_id?: never;
-        };
+          bucket_id?: string | null
+          name?: string | null
+          project_id?: never
+        }
         Update: {
-          bucket_id?: string | null;
-          name?: string | null;
-          project_id?: never;
-        };
-        Relationships: [];
-      };
-    };
+          bucket_id?: string | null
+          name?: string | null
+          project_id?: never
+        }
+        Relationships: []
+      }
+    }
     Functions: {
       get_exceeded_team_usage_windows: {
-        Args: never;
+        Args: never
         Returns: {
-          count: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          stripe_customer_id: string;
-          team_id: string;
-          team_name: string;
-        }[];
-      };
+          count: number
+          end_at: string
+          limit: number
+          start_at: string
+          stripe_customer_id: string
+          team_id: string
+          team_name: string
+        }[]
+      }
       increment_team_social_post_meter: {
         Args: {
-          p_day: number;
-          p_hour: number;
-          p_min: number;
-          p_month: number;
-          p_provider: Database['public']['Enums']['social_provider'];
-          p_team_id: string;
-          p_year: number;
-        };
-        Returns: undefined;
-      };
+          p_day: number
+          p_hour: number
+          p_min: number
+          p_month: number
+          p_provider: Database["public"]["Enums"]["social_provider"]
+          p_team_id: string
+          p_year: number
+        }
+        Returns: undefined
+      }
       increment_team_usage: {
         Args: {
-          p_end_at: string;
-          p_limit: number;
-          p_start_at: string;
-          p_team_id: string;
-        };
-        Returns: number;
-      };
+          p_end_at: string
+          p_limit: number
+          p_start_at: string
+          p_team_id: string
+        }
+        Returns: number
+      }
       is_system_project: {
-        Args: { project_id_param: string };
-        Returns: boolean;
-      };
-      is_team_member: { Args: { team_id: string }; Returns: boolean };
+        Args: { project_id_param: string }
+        Returns: boolean
+      }
+      is_team_member: { Args: { team_id: string }; Returns: boolean }
       nanoid: {
-        Args: { alphabet?: string; prefix: string; size?: number };
-        Returns: string;
-      };
-      user_has_post_access: { Args: { post_id: string }; Returns: boolean };
+        Args: { alphabet?: string; prefix: string; size?: number }
+        Returns: string
+      }
+      user_has_post_access: { Args: { post_id: string }; Returns: boolean }
       user_has_post_result_access: {
-        Args: { post_result_id: string };
-        Returns: boolean;
-      };
+        Args: { post_result_id: string }
+        Returns: boolean
+      }
       user_has_project_access: {
-        Args: { project_id: string };
-        Returns: boolean;
-      };
+        Args: { project_id: string }
+        Returns: boolean
+      }
       user_has_webhook_access: {
-        Args: { webhook_id: string };
-        Returns: boolean;
-      };
-    };
+        Args: { webhook_id: string }
+        Returns: boolean
+      }
+    }
     Enums: {
-      delivery_type: 'email';
-      notification_type: 'usage_alert' | 'general';
+      delivery_type: "email"
+      notification_type: "usage_alert" | "general"
       social_post_status:
-        | 'draft'
-        | 'scheduled'
-        | 'processing'
-        | 'posted'
-        | 'processed';
+        | "draft"
+        | "scheduled"
+        | "processing"
+        | "posted"
+        | "processed"
       social_provider:
-        | 'facebook'
-        | 'instagram'
-        | 'x'
-        | 'tiktok'
-        | 'youtube'
-        | 'pinterest'
-        | 'linkedin'
-        | 'bluesky'
-        | 'threads'
-        | 'tiktok_business'
-        | 'instagram_w_facebook';
-      subscription_addon: 'managed_system_credentials';
-      webhook_event_status: 'pending' | 'processing' | 'completed' | 'failed';
+        | "facebook"
+        | "instagram"
+        | "x"
+        | "tiktok"
+        | "youtube"
+        | "pinterest"
+        | "linkedin"
+        | "bluesky"
+        | "threads"
+        | "tiktok_business"
+        | "instagram_w_facebook"
+      subscription_addon: "managed_system_credentials"
+      webhook_event_status: "pending" | "processing" | "completed" | "failed"
       webhook_event_type:
-        | 'social.post.created'
-        | 'social.post.updated'
-        | 'social.post.deleted'
-        | 'social.post.result.created'
-        | 'social.account.created'
-        | 'social.account.updated';
-    };
+        | "social.post.created"
+        | "social.post.updated"
+        | "social.post.deleted"
+        | "social.post.result.created"
+        | "social.account.created"
+        | "social.account.updated"
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<
-  keyof Database,
-  'public'
->];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
-      Row: infer R;
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
-        DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] &
-        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R;
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
       }
       ? R
       : never
-    : never;
+    : never
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Insert: infer I;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
       }
       ? I
       : never
-    : never;
+    : never
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Update: infer U;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
       }
       ? U
       : never
-    : never;
+    : never
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 
 export const Constants = {
   cms: {
@@ -1460,38 +1460,39 @@ export const Constants = {
   },
   public: {
     Enums: {
-      delivery_type: ['email'],
-      notification_type: ['usage_alert', 'general'],
+      delivery_type: ["email"],
+      notification_type: ["usage_alert", "general"],
       social_post_status: [
-        'draft',
-        'scheduled',
-        'processing',
-        'posted',
-        'processed',
+        "draft",
+        "scheduled",
+        "processing",
+        "posted",
+        "processed",
       ],
       social_provider: [
-        'facebook',
-        'instagram',
-        'x',
-        'tiktok',
-        'youtube',
-        'pinterest',
-        'linkedin',
-        'bluesky',
-        'threads',
-        'tiktok_business',
-        'instagram_w_facebook',
+        "facebook",
+        "instagram",
+        "x",
+        "tiktok",
+        "youtube",
+        "pinterest",
+        "linkedin",
+        "bluesky",
+        "threads",
+        "tiktok_business",
+        "instagram_w_facebook",
       ],
-      subscription_addon: ['managed_system_credentials'],
-      webhook_event_status: ['pending', 'processing', 'completed', 'failed'],
+      subscription_addon: ["managed_system_credentials"],
+      webhook_event_status: ["pending", "processing", "completed", "failed"],
       webhook_event_type: [
-        'social.post.created',
-        'social.post.updated',
-        'social.post.deleted',
-        'social.post.result.created',
-        'social.account.created',
-        'social.account.updated',
+        "social.post.created",
+        "social.post.updated",
+        "social.post.deleted",
+        "social.post.result.created",
+        "social.account.created",
+        "social.account.updated",
       ],
     },
   },
-} as const;
+} as const
+

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -14,6 +14,10 @@ STRIPE_API_PRODUCT_ID=
 STRIPE_CREDS_ADDON_PRODUCT_ID=
 STRIPE_METER_EVENT=
 
+# Days a team keeps API access after a payment failure before it's revoked
+# (default 2 if unset). Also read independently by trigger/ — keep in sync.
+PAYMENT_GRACE_PERIOD_DAYS=2
+
 # New Pricing Model Product IDs
 STRIPE_PRICING_TIER_1K_PRODUCT_ID=
 STRIPE_PRICING_TIER_2_5K_PRODUCT_ID=

--- a/dashboard/app/lib/.server/database.types.ts
+++ b/dashboard/app/lib/.server/database.types.ts
@@ -780,6 +780,7 @@ export type Database = {
           created_by: string | null
           id: string
           name: string
+          payment_failed_at: string | null
           stripe_customer_id: string | null
           updated_at: string | null
           updated_by: string | null
@@ -790,6 +791,7 @@ export type Database = {
           created_by?: string | null
           id?: string
           name: string
+          payment_failed_at?: string | null
           stripe_customer_id?: string | null
           updated_at?: string | null
           updated_by?: string | null
@@ -800,6 +802,7 @@ export type Database = {
           created_by?: string | null
           id?: string
           name?: string
+          payment_failed_at?: string | null
           stripe_customer_id?: string | null
           updated_at?: string | null
           updated_by?: string | null

--- a/dashboard/app/lib/.server/handle-subscription-health-change.request.ts
+++ b/dashboard/app/lib/.server/handle-subscription-health-change.request.ts
@@ -1,0 +1,95 @@
+import { updateAPIKeyAccess } from "~/lib/.server/update-api-key-access.request";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type Stripe from "stripe";
+import type { Database } from "~/lib/.server/database.types";
+
+// Statuses where the team fully lost its subscription by choice (or it was
+// never completed) — access is revoked immediately, no grace period. Every
+// other non-active status (past_due, unpaid, incomplete, paused, ...) is
+// treated as a payment-failure-shaped issue and gets the grace period.
+const IMMEDIATE_REVOKE_STATUSES: Array<Stripe.Subscription.Status | null> = [
+  null,
+  "canceled",
+  "incomplete_expired",
+];
+
+/**
+ * Single decision path for both Stripe webhook entry points
+ * (subscription-event.ts and invoice-event.ts) that previously each computed
+ * their own boolean and called updateAPIKeyAccess directly. Centralizing here
+ * lets us apply a configurable grace period to payment failures while still
+ * revoking immediately on explicit cancellation, without the two webhook
+ * paths racing each other or diverging in behavior.
+ */
+export async function handleSubscriptionHealthChange(
+  {
+    stripeCustomerId,
+    latestStatus,
+  }: {
+    stripeCustomerId: string;
+    latestStatus: Stripe.Subscription.Status | null;
+  },
+  supabaseServiceRole: SupabaseClient<Database>,
+) {
+  const isActive = latestStatus === "active" || latestStatus === "trialing";
+  const isImmediateRevoke = IMMEDIATE_REVOKE_STATUSES.includes(latestStatus);
+
+  const team = await supabaseServiceRole
+    .from("teams")
+    .select("id, payment_failed_at")
+    .eq("stripe_customer_id", stripeCustomerId)
+    .maybeSingle();
+
+  if (team.error || !team.data) {
+    console.error(
+      `Failed to find team for customer ${stripeCustomerId}:`,
+      team.error,
+    );
+    return;
+  }
+
+  if (isActive) {
+    if (team.data.payment_failed_at) {
+      await supabaseServiceRole
+        .from("teams")
+        .update({ payment_failed_at: null })
+        .eq("id", team.data.id);
+    }
+
+    await updateAPIKeyAccess(
+      { teamId: team.data.id, enabled: true },
+      supabaseServiceRole,
+    );
+    return;
+  }
+
+  if (isImmediateRevoke) {
+    if (team.data.payment_failed_at) {
+      await supabaseServiceRole
+        .from("teams")
+        .update({ payment_failed_at: null })
+        .eq("id", team.data.id);
+    }
+
+    await updateAPIKeyAccess(
+      { teamId: team.data.id, enabled: false },
+      supabaseServiceRole,
+    );
+    return;
+  }
+
+  // Payment-failure-shaped status (past_due, unpaid, incomplete, paused, ...).
+  // Start the grace period clock only if it isn't already running — the
+  // conditional WHERE keeps this safe against subscription-event.ts and
+  // invoice-event.ts racing each other for the same failure. Access is left
+  // untouched here; only trigger/process-payment-grace-period.ts revokes it,
+  // once the grace period has actually elapsed.
+  if (!team.data.payment_failed_at) {
+    await supabaseServiceRole
+      .from("teams")
+      .update({ payment_failed_at: new Date().toISOString() })
+      .eq("id", team.data.id)
+      .is("payment_failed_at", null);
+  }
+}

--- a/dashboard/app/lib/.server/stripe.constants.ts
+++ b/dashboard/app/lib/.server/stripe.constants.ts
@@ -6,6 +6,16 @@ export const STRIPE_CREDS_ADDON_PRODUCT_ID =
 export const STRIPE_METER_EVENT_ID = process.env?.STRIPE_METER_EVENT_ID || "";
 export const STRIPE_CANCELLED_STATUSES = ["canceled", "unpaid"];
 
+// Days a team keeps API access after its subscription leaves active/trialing
+// (e.g. a failed payment) before access is actually revoked. Explicit
+// cancellation bypasses this and revokes immediately — see
+// handle-subscription-health-change.request.ts. trigger/process-payment-grace-period.ts
+// reads the same env var independently (siblings can't share code in this repo).
+export const PAYMENT_GRACE_PERIOD_DAYS = parseInt(
+  process.env?.PAYMENT_GRACE_PERIOD_DAYS || "2",
+  10,
+);
+
 // New pricing model product IDs
 export const STRIPE_PRICING_TIER_1K_PRODUCT_ID =
   process.env?.STRIPE_PRICING_TIER_1K_PRODUCT_ID || "";

--- a/dashboard/app/routes/api.stripe.webhook/.server/invoice-event.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/invoice-event.ts
@@ -1,8 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Stripe } from "stripe";
 import type { Database } from "~/lib/.server/database.types";
-import { updateAPIKeyAccess } from "~/lib/.server/update-api-key-access.request";
-import { customerHasActiveSubscriptions } from "~/lib/.server/customer-has-active-subscriptions.request";
+import { stripe } from "~/lib/.server/stripe";
+import { handleSubscriptionHealthChange } from "~/lib/.server/handle-subscription-health-change.request";
 
 export async function handleInvoiceEvent(
   invoice: Stripe.Invoice,
@@ -10,12 +10,22 @@ export async function handleInvoiceEvent(
 ) {
   const customerId = invoice.customer as string;
 
-  const isSubscriptionActive = await customerHasActiveSubscriptions(customerId);
+  // Fetch the actual latest subscription status (not just an active/inactive
+  // boolean) so handleSubscriptionHealthChange can tell a payment failure
+  // (grace period) apart from an explicit cancellation (immediate revoke) —
+  // same distinction subscription-event.ts gets for free from its event
+  // payload.
+  const subscriptions = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 1,
+  });
+  const latestStatus = subscriptions.data[0]?.status ?? null;
 
-  await updateAPIKeyAccess(
+  await handleSubscriptionHealthChange(
     {
       stripeCustomerId: customerId,
-      enabled: isSubscriptionActive,
+      latestStatus,
     },
     supabaseServiceRole
   );

--- a/dashboard/app/routes/api.stripe.webhook/.server/subscription-event.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/subscription-event.ts
@@ -1,4 +1,4 @@
-import { updateAPIKeyAccess } from "~/lib/.server/update-api-key-access.request";
+import { handleSubscriptionHealthChange } from "~/lib/.server/handle-subscription-health-change.request";
 
 import { trackSubscriptionLifecycle } from "./subscription-lifecycle-tracking";
 
@@ -15,14 +15,15 @@ export async function handleSubscriptionEvent(
 ) {
   const subscription = event.data.object;
   const customerId = subscription.customer as string;
-  const isSubscriptionActive =
-    subscription.status === "active" || subscription.status === "trialing";
 
-  // Toggle API key access based on subscription status.
-  await updateAPIKeyAccess(
+  // Toggle API key access based on subscription status. Payment-failure-shaped
+  // statuses (past_due, unpaid, ...) get a grace period instead of an
+  // immediate revoke; explicit cancellation (status "canceled" from a
+  // customer.subscription.deleted event) still revokes right away.
+  await handleSubscriptionHealthChange(
     {
       stripeCustomerId: customerId,
-      enabled: isSubscriptionActive,
+      latestStatus: subscription.status,
     },
     supabaseServiceRole,
   );

--- a/trigger/.env.example
+++ b/trigger/.env.example
@@ -3,3 +3,7 @@
 # dashboard/marketing so events attribute to the same teams/people.
 POST_HOG_API_KEY=
 POST_HOG_API_HOST=
+
+# Days a team keeps API access after a payment failure before it's revoked
+# (default 2 if unset). Also read independently by dashboard/ — keep in sync.
+PAYMENT_GRACE_PERIOD_DAYS=2

--- a/trigger/process-payment-grace-period.ts
+++ b/trigger/process-payment-grace-period.ts
@@ -1,0 +1,168 @@
+import { logger, schedules } from "@trigger.dev/sdk";
+import Stripe from "stripe";
+import { createClient } from "@supabase/supabase-js";
+import { Database } from "./supabase.types";
+import { updateApiKeyAccess } from "./update-api-key-access";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+const supabaseClient = createClient<Database>(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+// Kept in sync with dashboard/app/lib/.server/stripe.constants.ts's
+// PAYMENT_GRACE_PERIOD_DAYS — siblings can't share code in this repo, so this
+// value is duplicated. Update both if you change the grace period default.
+const PAYMENT_GRACE_PERIOD_DAYS = parseInt(
+  process.env?.PAYMENT_GRACE_PERIOD_DAYS || "2",
+  10,
+);
+
+type UnhealthyTeam = Pick<
+  Database["public"]["Tables"]["teams"]["Row"],
+  "id" | "stripe_customer_id" | "payment_failed_at"
+>;
+
+const getUnhealthyTeams = async (): Promise<UnhealthyTeam[]> => {
+  const { data, error } = await supabaseClient
+    .from("teams")
+    .select("id, stripe_customer_id, payment_failed_at")
+    .not("payment_failed_at", "is", null);
+
+  if (error) {
+    throw error;
+  }
+
+  return data ?? [];
+};
+
+const getLatestSubscriptionStatus = async (
+  stripeCustomerId: string,
+): Promise<Stripe.Subscription.Status | null> => {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    status: "all",
+    limit: 1,
+  });
+
+  return subscriptions.data[0]?.status ?? null;
+};
+
+const clearGracePeriod = async (teamId: string): Promise<void> => {
+  const { error } = await supabaseClient
+    .from("teams")
+    .update({ payment_failed_at: null })
+    .eq("id", teamId);
+
+  if (error) {
+    logger.error("Failed to clear payment_failed_at", {
+      team_id: teamId,
+      error,
+    });
+  }
+};
+
+/**
+ * Sweeps teams whose subscription left active/trialing (past_due, unpaid,
+ * etc.) and, once PAYMENT_GRACE_PERIOD_DAYS has elapsed since
+ * teams.payment_failed_at, revokes API access. Also self-heals teams whose
+ * subscription actually recovered (or was canceled) but whose webhook never
+ * arrived — see dashboard/app/lib/.server/handle-subscription-health-change.request.ts
+ * for the webhook-side half of this mechanism, which sets/clears
+ * payment_failed_at but never revokes access itself.
+ */
+export const processPaymentGracePeriod = schedules.task({
+  cron: { pattern: "*/30 * * * *", environments: ["PRODUCTION"] },
+  id: "process-payment-grace-period",
+  maxDuration: 3600,
+  retry: { maxAttempts: 1 },
+  run: async () => {
+    const unhealthyTeams = await getUnhealthyTeams();
+
+    if (unhealthyTeams.length === 0) {
+      logger.info("No teams currently in a payment grace period");
+      return;
+    }
+
+    for (const team of unhealthyTeams) {
+      try {
+        if (!team.stripe_customer_id) {
+          logger.error("Unhealthy team missing stripe_customer_id", {
+            team_id: team.id,
+          });
+          continue;
+        }
+
+        if (!team.payment_failed_at) {
+          continue;
+        }
+
+        const latestStatus = await getLatestSubscriptionStatus(
+          team.stripe_customer_id,
+        );
+        const isActive =
+          latestStatus === "active" || latestStatus === "trialing";
+        const isCanceled =
+          latestStatus === null ||
+          latestStatus === "canceled" ||
+          latestStatus === "incomplete_expired";
+
+        if (isActive) {
+          // Webhook was missed or arrived late — self-heal.
+          logger.info(
+            "Team recovered before grace period ended, self-healing",
+            { team_id: team.id },
+          );
+          await clearGracePeriod(team.id);
+          await updateApiKeyAccess(
+            { teamId: team.id, enabled: true },
+            supabaseClient,
+          );
+          continue;
+        }
+
+        if (isCanceled) {
+          logger.info("Team subscription canceled, revoking access", {
+            team_id: team.id,
+          });
+          await clearGracePeriod(team.id);
+          await updateApiKeyAccess(
+            { teamId: team.id, enabled: false },
+            supabaseClient,
+          );
+          continue;
+        }
+
+        const failedAt = new Date(team.payment_failed_at);
+        const deadline = new Date(
+          failedAt.getTime() + PAYMENT_GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000,
+        );
+
+        if (Date.now() < deadline.getTime()) {
+          logger.info("Team still within payment grace period", {
+            team_id: team.id,
+            grace_period_ends_at: deadline.toISOString(),
+          });
+          continue;
+        }
+
+        logger.info("Grace period elapsed, revoking API access", {
+          team_id: team.id,
+          payment_failed_at: team.payment_failed_at,
+        });
+        // payment_failed_at is intentionally left set — it now doubles as an
+        // "already past deadline / already revoked" marker so repeat ticks
+        // are cheap no-ops instead of re-deriving state every 30 minutes.
+        await updateApiKeyAccess(
+          { teamId: team.id, enabled: false },
+          supabaseClient,
+        );
+      } catch (teamError) {
+        logger.error("Error processing team payment grace period", {
+          team_id: team.id,
+          error: teamError,
+        });
+      }
+    }
+  },
+});

--- a/trigger/supabase.types.ts
+++ b/trigger/supabase.types.ts
@@ -780,6 +780,7 @@ export type Database = {
           created_by: string | null
           id: string
           name: string
+          payment_failed_at: string | null
           stripe_customer_id: string | null
           updated_at: string | null
           updated_by: string | null
@@ -790,6 +791,7 @@ export type Database = {
           created_by?: string | null
           id?: string
           name: string
+          payment_failed_at?: string | null
           stripe_customer_id?: string | null
           updated_at?: string | null
           updated_by?: string | null
@@ -800,6 +802,7 @@ export type Database = {
           created_by?: string | null
           id?: string
           name?: string
+          payment_failed_at?: string | null
           stripe_customer_id?: string | null
           updated_at?: string | null
           updated_by?: string | null

--- a/trigger/update-api-key-access.ts
+++ b/trigger/update-api-key-access.ts
@@ -1,0 +1,124 @@
+import { Unkey } from "@unkey/api";
+import Stripe from "stripe";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "./supabase.types";
+
+const unkey = new Unkey({ rootKey: process.env.UNKEY_ROOT_KEY! });
+const UNKEY_API_ID = process.env.UNKEY_API_ID!;
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+// Same "which product IDs include system credentials access" check dashboard's
+// customer-has-subscription-system-creds-addon.request.ts does. Duplicated
+// (not imported) per this repo's dumb-monorepo rule.
+const NEW_PRICING_TIER_PRODUCT_IDS = [
+  process.env?.STRIPE_PRICING_TIER_1K_PRODUCT_ID,
+  process.env?.STRIPE_PRICING_TIER_2_5K_PRODUCT_ID,
+  process.env?.STRIPE_PRICING_TIER_5K_PRODUCT_ID,
+  process.env?.STRIPE_PRICING_TIER_10K_PRODUCT_ID,
+  process.env?.STRIPE_PRICING_TIER_20K_PRODUCT_ID,
+  process.env?.STRIPE_PRICING_TIER_40K_PRODUCT_ID,
+  process.env?.STRIPE_PRICING_TIER_100K_PRODUCT_ID,
+  process.env?.STRIPE_PRICING_TIER_200K_PRODUCT_ID,
+].filter((id): id is string => Boolean(id));
+
+async function customerHasSubscriptionSystemCredsAddon(
+  stripeCustomerId: string | null | undefined,
+): Promise<boolean> {
+  if (!stripeCustomerId) return false;
+
+  const subscriptions = await stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    status: "active",
+  });
+
+  return subscriptions.data.some((sub) => {
+    if (sub.status !== "active") return false;
+
+    return sub.items?.data?.some((item) => {
+      const productId = item.price.product as string;
+
+      if (NEW_PRICING_TIER_PRODUCT_IDS.includes(productId)) return true;
+
+      return (
+        item.price?.metadata?.allows_system_credentials_access === "true"
+      );
+    });
+  });
+}
+
+/**
+ * Trigger-local copy of dashboard/app/lib/.server/update-api-key-access.request.ts's
+ * Unkey key-toggle logic, used by process-payment-grace-period.ts. Vendored
+ * rather than imported per this repo's dumb-monorepo rule (no cross-sibling
+ * imports) — keep both in sync if Unkey enable/disable behavior changes.
+ */
+export async function updateApiKeyAccess(
+  { teamId, enabled }: { teamId: string; enabled: boolean },
+  supabaseClient: SupabaseClient<Database>,
+): Promise<void> {
+  const team = await supabaseClient
+    .from("teams")
+    .select("id, stripe_customer_id")
+    .eq("id", teamId)
+    .maybeSingle();
+
+  if (team.error || !team.data) {
+    console.error(`Failed to find team ${teamId}:`, team.error);
+    return;
+  }
+
+  const hasSystemCredentialsAddon = enabled
+    ? await customerHasSubscriptionSystemCredsAddon(
+        team.data.stripe_customer_id,
+      )
+    : false;
+
+  const projects = await supabaseClient
+    .from("projects")
+    .select("id, is_system")
+    .eq("team_id", teamId);
+
+  if (projects.error) {
+    console.error(`Failed to find projects for team ${teamId}:`, projects.error);
+    return;
+  }
+
+  if (!projects.data || projects.data.length === 0) {
+    return;
+  }
+
+  for (const project of projects.data) {
+    const projectEnabled = project.is_system
+      ? enabled && hasSystemCredentialsAddon
+      : enabled;
+
+    let cursor: string | undefined = undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      const apiKeys = await unkey.apis.listKeys({
+        apiId: UNKEY_API_ID,
+        externalId: project.id,
+        limit: 100,
+        cursor,
+        revalidateKeysCache: true,
+      });
+
+      if (!apiKeys.data || apiKeys.data.length === 0) break;
+
+      const batchSize = 10;
+      for (let i = 0; i < apiKeys.data.length; i += batchSize) {
+        const batch = apiKeys.data.slice(i, i + batchSize);
+        await Promise.all(
+          batch.map((key) =>
+            unkey.keys.updateKey({ keyId: key.keyId, enabled: projectEnabled }),
+          ),
+        );
+      }
+
+      cursor = apiKeys.pagination?.cursor;
+      hasMore = apiKeys.pagination?.hasMore || false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Today, API access is revoked immediately the moment a team's Stripe subscription payment fails, with no buffer for a bounced card to get fixed. This adds a configurable grace period (default 2 days) so teams keep access after a failed payment until the deadline passes, while explicit cancellation still revokes access immediately.

## Changes

- **New migration** (`api/supabase/migrations/20260713120000_teams_payment_failed_at.sql`): adds nullable `teams.payment_failed_at` timestamp + partial index. `NULL` = healthy; set the moment a subscription is first observed leaving active/trialing.
- **New shared decision path** (`dashboard/app/lib/.server/handle-subscription-health-change.request.ts`): replaces the two Stripe webhook handlers' direct `updateAPIKeyAccess` calls. Classifies the latest subscription status into active (clear timestamp, re-enable immediately), canceled/no-subscription (clear timestamp, revoke immediately — no grace period), or payment-failure-shaped (`past_due`/`unpaid`/etc — atomically set the timestamp once, leave access untouched).
  - `subscription-event.ts` and `invoice-event.ts` now call this instead of computing their own active/inactive booleans; `invoice-event.ts` now fetches the real subscription status from Stripe so it can distinguish cancellation from payment failure too.
- **New scheduled sweep** (`trigger/process-payment-grace-period.ts`, 30-min cron, modeled on `process-usage-limits.ts`): re-verifies live Stripe status for every team with `payment_failed_at` set, self-heals teams that actually recovered or canceled but whose webhook was missed, and revokes access once the grace deadline passes.
  - New vendored `trigger/update-api-key-access.ts` — Unkey key-toggle logic duplicated from dashboard per this repo's no-cross-sibling-imports rule.
- **New env var**: `PAYMENT_GRACE_PERIOD_DAYS` (default `2`), added to both `dashboard/.env.example` and `trigger/.env.example` — read independently by each sibling since they can't share code; kept in sync via cross-referencing comments.

## Testing

- `cd api && bun run supabase:reset && bun run supabase:typegen` — migration applies cleanly, types regenerated.
- `cd dashboard && bun run supabase:typegen` and `cd trigger && bun run supabase:typegen` — both siblings picked up `teams.payment_failed_at`.
- `cd dashboard && bun run typecheck && bun run lint` — clean.
- `cd trigger && bun run typecheck && bun run lint` — clean.
- Not yet done: manual Stripe CLI webhook simulation (`past_due` → grace period starts, keys stay enabled; `customer.subscription.deleted` → immediate revoke; local Trigger.dev dev run of the new sweep task against seeded data). Flagging as follow-up verification before merge.

## Notes

- Scope intentionally excludes email notifications and billing UI changes (grace-period deadline is not yet surfaced to users) — confirmed as a fast-follow, not required for the mechanism to work.
- Config is read live: changing `PAYMENT_GRACE_PERIOD_DAYS` reshapes in-flight grace periods immediately (by design).

Closes PFM-613

🤖 Generated with AI