### PR TITLE
fix(trigger): stop post-status loops from retrying terminal auth errors

### DIFF
--- a/trigger/posting/platforms/facebook-post-client.ts
+++ b/trigger/posting/platforms/facebook-post-client.ts
@@ -226,6 +226,21 @@ export class FacebookPostClient extends PostClient {
         "Error posting to Facebook:",
         error.response?.data || error,
       );
+
+      if (error.response?.status === 401 || this.isTerminalAuthError(error)) {
+        return {
+          success: false,
+          post_id: postId,
+          provider_connection_id: account.id,
+          error_message: this.buildAuthErrorMessage(error),
+          details: {
+            error,
+            requests: this.#requests,
+            responses: this.#responses,
+          },
+        };
+      }
+
       return {
         success: false,
         post_id: postId,
@@ -678,6 +693,10 @@ export class FacebookPostClient extends PostClient {
         logger.error("Error getting video status", {
           err,
         });
+
+        if (this.isTerminalAuthError(err)) {
+          throw err;
+        }
       } finally {
         attempts++;
       }
@@ -958,6 +977,10 @@ export class FacebookPostClient extends PostClient {
         logger.error("Error getting video status", {
           err,
         });
+
+        if (this.isTerminalAuthError(err)) {
+          throw err;
+        }
       } finally {
         attempts++;
       }

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -225,7 +225,7 @@ export class InstagramPostClient extends PostClient {
 
           platformId = publishResponse.data.id;
         } catch (error) {
-          if (this.#isNonRetryableError(error)) {
+          if (this.isTerminalAuthError(error)) {
             throw error;
           }
 
@@ -278,13 +278,12 @@ export class InstagramPostClient extends PostClient {
     } catch (error) {
       console.error("Error posting to Instagram:", error);
 
-      if (error.response?.status === 401) {
+      if (error.response?.status === 401 || this.isTerminalAuthError(error)) {
         return {
           success: false,
           post_id: postId,
           provider_connection_id: account.id,
-          error_message:
-            "Account needs to be reconnected, Access token has expired",
+          error_message: this.buildAuthErrorMessage(error),
           details: {
             error,
             requests: this.#requests,
@@ -635,15 +634,16 @@ export class InstagramPostClient extends PostClient {
           });
         }
 
-        const errorMessage = this.#getErrorMessage(error);
+        const errorMessage = this.getErrorMessage(error);
         console.error(
           `Failed to process ${mediaLabel}, attempt ${attempt}/${this.#mediaRetryAttempts}: ${errorMessage}`,
         );
 
-        if (this.#isNonRetryableError(error)) {
-          throw new Error(
-            `Failed to process ${mediaLabel} without retry: ${errorMessage}`,
+        if (this.isTerminalAuthError(error)) {
+          console.error(
+            `Failed to process ${mediaLabel} - terminal auth error, not retrying: ${errorMessage}`,
           );
+          throw error;
         }
 
         if (attempt === this.#mediaRetryAttempts) {
@@ -736,22 +736,6 @@ export class InstagramPostClient extends PostClient {
       `Max attempts reached. Failed to process media. Last status: ${JSON.stringify(
         statusData,
       )}`,
-    );
-  }
-
-  #getErrorMessage(error: any): string {
-    return (
-      error?.response?.data?.error?.message || error?.message || "Unknown error"
-    );
-  }
-
-  #isNonRetryableError(error: any): boolean {
-    const errorMessage = this.#getErrorMessage(error).toLowerCase();
-
-    return (
-      errorMessage.includes(
-        "error validating access token: sessions for the user are not allowed because the user is not a confirmed user",
-      ) || errorMessage.includes("user access is restricted")
     );
   }
 
@@ -853,9 +837,9 @@ export class InstagramPostClient extends PostClient {
 
         return permalink;
       } catch (error) {
-        const errorMessage = this.#getErrorMessage(error);
+        const errorMessage = this.getErrorMessage(error);
 
-        if (this.#isNonRetryableError(error)) {
+        if (this.isTerminalAuthError(error)) {
           throw error;
         }
 

--- a/trigger/posting/platforms/threads-post-client.ts
+++ b/trigger/posting/platforms/threads-post-client.ts
@@ -144,6 +144,10 @@ export class ThreadsPostClient extends PostClient {
           platformId = publishResponse.data.id;
         } catch (error: any) {
           if (error.response?.status === 400) {
+            if (this.isTerminalAuthError(error)) {
+              throw error;
+            }
+
             console.log(
               `Bad Request With Error: ${error.response?.data?.error?.message || "Unknown error"}`,
             );
@@ -180,12 +184,12 @@ export class ThreadsPostClient extends PostClient {
       console.error("Error posting to Threads:", error.response?.data || error);
 
       // Handle specific error cases
-      if (error.response?.status === 401) {
+      if (error.response?.status === 401 || this.isTerminalAuthError(error)) {
         return {
           success: false,
           provider_connection_id: account.id,
           post_id: postId,
-          error_message: "Account needs to be reconnected",
+          error_message: this.buildAuthErrorMessage(error),
           details: {
             error,
             requests: this.#requests,
@@ -350,6 +354,10 @@ export class ThreadsPostClient extends PostClient {
         attempts++;
       } catch (error: any) {
         if (error.response?.status === 400) {
+          if (this.isTerminalAuthError(error)) {
+            throw error;
+          }
+
           // If we get a 400 error, the media might be ready
           break;
         }

--- a/trigger/posting/post-client.ts
+++ b/trigger/posting/post-client.ts
@@ -166,4 +166,48 @@ export class PostClient {
   protected async unlinkQuiet(filePath: string): Promise<void> {
     await fsp.unlink(filePath).catch(() => undefined);
   }
+
+  // Meta Graph API OAuthException (code 190) subcodes that mean the
+  // session/token is permanently dead and will never succeed on retry:
+  // 460 = password changed, 463 = expired, 467 = invalid, 458/490 = deauthorized
+  private static readonly TERMINAL_AUTH_ERROR_SUBCODES = new Set([
+    458, 460, 463, 467, 490,
+  ]);
+
+  private static readonly TERMINAL_AUTH_ERROR_KEYWORDS = [
+    "session has been invalidated",
+    "sessions for the user are not allowed because the user is not a confirmed user",
+    "user access is restricted",
+    "error validating access token",
+  ];
+
+  protected getErrorMessage(error: any): string {
+    return (
+      error?.response?.data?.error?.message ||
+      error?.message ||
+      "Unknown error"
+    );
+  }
+
+  protected isTerminalAuthError(error: any): boolean {
+    const graphError = error?.response?.data?.error;
+    const code = graphError?.code;
+    const subcode = graphError?.error_subcode;
+    const message = this.getErrorMessage(error).toLowerCase();
+
+    const hasTerminalSubcode =
+      code === 190 &&
+      subcode !== undefined &&
+      PostClient.TERMINAL_AUTH_ERROR_SUBCODES.has(subcode);
+
+    const hasTerminalKeyword = PostClient.TERMINAL_AUTH_ERROR_KEYWORDS.some(
+      (kw) => message.includes(kw),
+    );
+
+    return hasTerminalSubcode || hasTerminalKeyword;
+  }
+
+  protected buildAuthErrorMessage(error: any): string {
+    return `Account needs to be reconnected: ${this.getErrorMessage(error)}`;
+  }
 }


### PR DESCRIPTION
## Summary

Instagram's media-processing retry loop was burning all 30 attempts (with exponential backoff, several minutes) retrying Meta Graph API errors that can never succeed — e.g. a session invalidated by a password change. Facebook had an even worse variant where one status loop silently swallowed the error entirely and spun for ~4 minutes. This adds a shared "terminal auth error" classifier and wires it into every Graph-API-based platform's polling/retry loops so these fail fast with an actionable message instead of wasting minutes per post.

## Changes

- `trigger/posting/post-client.ts`: added `isTerminalAuthError`, `getErrorMessage`, `buildAuthErrorMessage` to the shared `PostClient` base class. Classifies Meta `OAuthException` (`code === 190` + terminal `error_subcode`s 458/460/463/467/490) and broadened message keywords, including the exact reported "session has been invalidated..." message.
- `trigger/posting/platforms/instagram-post-client.ts`: replaced the private, too-narrow `#isNonRetryableError` (only matched 2 exact phrases) with the shared classifier across all 3 loop sites (media container retry, publish loop, `#getPostUrl`), and broadened the outer-catch safety net beyond HTTP 401 (Meta often returns 400 for these errors).
- `trigger/posting/platforms/facebook-post-client.ts`: fixed a swallow-and-spin bug where the story-finish and reel status loops caught request errors, logged them, and kept looping for all 48 attempts without ever breaking or rethrowing. Also added a terminal-auth branch to the outer catch (there was none before).
- `trigger/posting/platforms/threads-post-client.ts`: publish loop and container-status loop both blindly retried/treated-as-ok any HTTP 400; now they check for a terminal auth error first and fail fast. Outer catch broadened past 401.

TikTok, TikTok Business, YouTube, Bluesky, Twitter/X, and Pinterest were audited and don't have this bug — their status loops already let request errors propagate immediately. LinkedIn has no polling loop. Left untouched; not in scope.

No new dependencies, env vars, or migrations.

## Testing

- `cd trigger && bun run typecheck` — pass
- `cd trigger && bun run lint` — pass
- Wrote and ran a throwaway script instantiating `PostClient` against the exact reported error shape (`code: 190, error_subcode: 460`, matching message) and confirmed `isTerminalAuthError` returns `true`; confirmed a generic transient error (`code: 1`) returns `false`. Script was deleted after verification, not committed.
- Not run against live Instagram/Facebook/Threads APIs — this is Trigger.dev job code without a local harness for that; verification was via typecheck/lint plus the classifier logic check above.

## Notes
Closes PFM-618

🤖 Generated with AI