### PR TITLE
fix(api): remove system post limit checks during validation

### DIFF
--- a/api/src/social-posts/social-posts.controller.ts
+++ b/api/src/social-posts/social-posts.controller.ts
@@ -140,8 +140,6 @@ export class SocialPostsController {
     const postValidation = await this.postsService.validatePost({
       post: createPostsInput,
       projectId: user.projectId,
-      teamId: user.teamId,
-      isSystem,
     });
 
     if (!postValidation.isValid) {
@@ -236,8 +234,6 @@ export class SocialPostsController {
     const postValidation = await this.postsService.validatePost({
       post: updatePostInput,
       projectId: user.projectId,
-      teamId: user.teamId,
-      isSystem,
     });
 
     if (!postValidation.isValid) {

--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -45,13 +45,9 @@ export class SocialPostsService {
   async validatePost({
     post,
     projectId,
-    teamId,
-    isSystem,
   }: {
     post: CreateSocialPostDto;
     projectId: string;
-    teamId: string;
-    isSystem: boolean;
   }): Promise<PostValidation> {
     if (!post) {
       return {
@@ -156,22 +152,6 @@ export class SocialPostsService {
               );
             }
           }
-        }
-      }
-    }
-
-    if (isSystem && errors.length === 0) {
-      for (const socialAccountProvider of providers) {
-        const hasMetLimit = await this.socialPostMetersService.hasMetLimit({
-          teamId,
-          provider: socialAccountProvider,
-          scheduledDate: post.scheduled_at || new Date(),
-        });
-
-        if (hasMetLimit) {
-          errors.push(
-            `You have reached the post limit for ${socialAccountProvider}, please try again for a different date/time`,
-          );
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR removes provider post-limit enforcement from API post validation so system-created posts are no longer blocked by hourly limit checks.

## Changes

- stop passing `teamId` and `isSystem` from `SocialPostsController` into `validatePost`
- simplify `SocialPostsService.validatePost` signature to only require `post` and `projectId`
- remove the `socialPostMetersService.hasMetLimit` validation block from post validation flow

## Testing

- Not run in this PR flow (code-only change; no additional local verification executed)

## Notes

- No schema changes, migrations, or new environment variables.

🤖 Generated with OpenCode