### PR TITLE
fix(trigger): check Twitter premium status at post time

### DIFF
--- a/trigger/posting/platforms/twitter-post-client.ts
+++ b/trigger/posting/platforms/twitter-post-client.ts
@@ -24,6 +24,7 @@ export class TwitterPostClient extends PostClient {
   #requests: any[] = [];
   #responses: any[] = [];
   #maxFileSize = 5 * 1024 * 1024;
+  #localSupabaseClient;
 
   constructor(
     supabaseClient: SupabaseClient,
@@ -33,6 +34,7 @@ export class TwitterPostClient extends PostClient {
 
     this.#appKey = appCredentials.app_id;
     this.#appSecret = appCredentials.app_secret;
+    this.#localSupabaseClient = supabaseClient;
   }
 
   async refreshAccessToken(
@@ -72,11 +74,11 @@ export class TwitterPostClient extends PostClient {
 
       const mediaIds = await this.#processMedia({ twitterClient, media });
 
+      const isPremium = await this.#getIsPremium({ twitterClient, account });
+
       const allowedCaption = caption.slice(
         0,
-        account.social_provider_metadata?.has_platform_premium
-          ? this.#PREMIUM_CHARACTER_LIMIT
-          : this.#CHARACTER_LIMIT,
+        isPremium ? this.#PREMIUM_CHARACTER_LIMIT : this.#CHARACTER_LIMIT,
       );
 
       const postPayload: SendTweetV2Params = {
@@ -156,6 +158,48 @@ export class TwitterPostClient extends PostClient {
           responses: this.#responses,
         },
       };
+    }
+  }
+
+  async #getIsPremium({
+    twitterClient,
+    account,
+  }: {
+    twitterClient: TwitterApi;
+    account: SocialAccount;
+  }): Promise<boolean> {
+    const storedIsPremium = Boolean(
+      account.social_provider_metadata?.has_platform_premium,
+    );
+
+    try {
+      const { data: user } = await twitterClient.v2.me({
+        "user.fields": "verified_type",
+      });
+
+      const isPremium = user.verified_type
+        ? user.verified_type !== "none"
+        : false;
+
+      if (isPremium !== storedIsPremium) {
+        await this.#localSupabaseClient
+          .from("social_provider_connections")
+          .update({
+            social_provider_metadata: {
+              ...account.social_provider_metadata,
+              has_platform_premium: isPremium,
+            },
+          })
+          .eq("id", account.id);
+      }
+
+      return isPremium;
+    } catch (error) {
+      console.error(
+        `Error checking premium status for Twitter account ${account.id}, falling back to stored value:`,
+        error,
+      );
+      return storedIsPremium;
     }
   }
 


### PR DESCRIPTION
## Summary

Twitter/X premium status was only checked once, at account connect time, and cached in `social_provider_metadata.has_platform_premium`. Users who upgraded to X Premium after connecting their account kept getting captions silently truncated to the 280-char free limit until they disconnected and reconnected. This checks premium status live at post time instead.

## Changes

- `trigger/posting/platforms/twitter-post-client.ts`: added `#getIsPremium()`, which calls `twitterClient.v2.me({ "user.fields": "verified_type" })` at post time to get the account's current premium status, and uses that (instead of the stale stored flag) to pick the 280 vs 2200 char caption limit.
- When the live status differs from the stored `has_platform_premium` value, the connection's `social_provider_metadata` is updated in Supabase so the flag stays in sync going forward.
- If the live check fails (e.g. transient X API error), falls back to the previously stored value rather than failing the post.

## Testing

- `bun run typecheck` — pass
- `bun run lint` — pass
- Not run against a live X account (would need a real premium-eligible connection + trigger.dev job run to fully exercise the API call path).

Closes PFM-575

🤖 Generated with AI