### PR TITLE
feat(tiktok): support follower-only and friends-only post visibility

### DIFF
--- a/api/src/social-posts/dto/post-configurations.dto.ts
+++ b/api/src/social-posts/dto/post-configurations.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
 import { SocialPostMediaDto } from './post-media.dto';
+
+export enum TiktokPrivacyStatus {
+  PUBLIC = 'public',
+  PRIVATE = 'private',
+  FOLLOWERS = 'followers',
+  FRIENDS = 'friends',
+}
 
 export type PlatformConfiguration =
   | PinterestConfigurationDto
@@ -138,11 +146,15 @@ export class TiktokConfigurationDto extends BaseConfigurationDto {
   title?: string;
 
   @ApiProperty({
-    description: 'Sets the privacy status for TikTok (private, public)',
+    description:
+      'Sets the privacy status for TikTok (public, private, followers, friends)',
+    enum: TiktokPrivacyStatus,
     nullable: true,
     required: false,
-    default: 'public',
+    default: TiktokPrivacyStatus.PUBLIC,
   })
+  @IsEnum(TiktokPrivacyStatus)
+  @IsOptional()
   privacy_status?: string;
 
   @ApiProperty({
@@ -220,11 +232,15 @@ export class TiktokBusinessConfigurationDto extends BaseConfigurationDto {
   title?: string;
 
   @ApiProperty({
-    description: 'Sets the privacy status for TikTok (private, public)',
+    description:
+      'Sets the privacy status for TikTok (public, private, followers, friends)',
+    enum: TiktokPrivacyStatus,
     nullable: true,
     required: false,
-    default: 'public',
+    default: TiktokPrivacyStatus.PUBLIC,
   })
+  @IsEnum(TiktokPrivacyStatus)
+  @IsOptional()
   privacy_status?: string;
 
   @ApiProperty({
@@ -632,10 +648,10 @@ export class AccountConfigurationDetailsDto {
 
   @ApiProperty({
     description:
-      'Sets the privacy status for TikTok (private, public), or YouTube (private, public, unlisted)',
+      'Sets the privacy status for TikTok (public, private, followers, friends), or YouTube (private, public, unlisted)',
     nullable: true,
     required: false,
-    enum: ['public', 'private', 'unlisted'],
+    enum: ['public', 'private', 'unlisted', 'followers', 'friends'],
     default: 'public',
   })
   privacy_status?: string;

--- a/dashboard/app/routes/_protected.$teamId.$projectId.composer/_tab-tiktok.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.composer/_tab-tiktok.tsx
@@ -110,7 +110,7 @@ export function TabTikTok() {
                   <CircleInfoIcon className="h-4 w-4" />
                 </TooltipTrigger>
                 <TooltipContent side="top">
-                  Branded content cannot be set to private
+                  Branded content requires this video to be public
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -123,6 +123,20 @@ export function TabTikTok() {
               >
                 <ToggleGroupItem value="public" className="px-3">
                   Public
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="friends"
+                  disabled={discloseBrandedContent}
+                  className="px-3"
+                >
+                  Friends
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="followers"
+                  disabled={discloseBrandedContent}
+                  className="px-3"
+                >
+                  Followers
                 </ToggleGroupItem>
                 <ToggleGroupItem
                   value="private"
@@ -266,7 +280,8 @@ export function TabTikTok() {
                     <div className="flex items-center gap-2">
                       <Switch
                         disabled={
-                          !discloseContent || privacyStatus === "private"
+                          !discloseContent ||
+                          (!!privacyStatus && privacyStatus !== "public")
                         }
                         checked={field.value}
                         onCheckedChange={field.onChange}

--- a/dashboard/app/routes/_protected.$teamId.$projectId.composer/schema.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.composer/schema.ts
@@ -17,7 +17,9 @@ export const formSchema = z
         tiktok: z
           .object({
             title: z.string().optional(),
-            privacy_status: z.enum(["public", "private"]).optional(),
+            privacy_status: z
+              .enum(["public", "private", "followers", "friends"])
+              .optional(),
             disclose_your_brand: z.boolean().optional(),
             disclose_branded_content: z.boolean().optional(),
             allow_comments: z.boolean().optional(),

--- a/marketing/app/lib/.server/data/integrations.tiktok.ts
+++ b/marketing/app/lib/.server/data/integrations.tiktok.ts
@@ -73,7 +73,8 @@ export const tiktok: IntegrationData = {
     {
       name: "Privacy status",
       field: "privacy_status",
-      description: "Set videos to public or private visibility.",
+      description:
+        "Set videos to public, private, followers-only, or friends-only visibility.",
     },
     {
       name: "Comment control",

--- a/trigger/posting/platforms/tiktok-post-client.ts
+++ b/trigger/posting/platforms/tiktok-post-client.ts
@@ -26,6 +26,12 @@ export class TikTokPostClient extends PostClient {
   ];
   #maxItems = 32;
   #titleLength = 85;
+  #privacyLevelMap: Record<string, string> = {
+    public: "PUBLIC_TO_EVERYONE",
+    private: "SELF_ONLY",
+    followers: "FOLLOWER_OF_CREATOR",
+    friends: "MUTUAL_FOLLOW_FRIENDS",
+  };
   #clientKey: string;
   #clientSecret: string;
   #localSupabaseClient;
@@ -131,6 +137,7 @@ export class TikTokPostClient extends PostClient {
           coverTimestamp: medium.thumbnail_timestamp_ms || undefined,
           account,
           platformData: platformConfig,
+          creatorInfoResponse,
         });
       } else {
         publishId = await this.#processImages({
@@ -139,6 +146,7 @@ export class TikTokPostClient extends PostClient {
           title: platformConfig?.title,
           account,
           platformData: platformConfig,
+          creatorInfoResponse,
         });
       }
 
@@ -224,6 +232,32 @@ export class TikTokPostClient extends PostClient {
         },
       };
     }
+  }
+
+  #resolvePrivacyLevel({
+    platformData,
+    creatorInfoResponse,
+  }: {
+    platformData: TiktokConfiguration;
+    creatorInfoResponse: any;
+  }): string {
+    const requestedLevel =
+      this.#privacyLevelMap[platformData.privacy_status ?? "public"] ??
+      "PUBLIC_TO_EVERYONE";
+
+    const allowedLevels: string[] | undefined =
+      creatorInfoResponse?.data?.data?.privacy_level_options;
+
+    if (allowedLevels?.length && !allowedLevels.includes(requestedLevel)) {
+      // The creator's account doesn't support the requested privacy level
+      // (e.g. TikTok hides MUTUAL_FOLLOW_FRIENDS/FOLLOWER_OF_CREATOR for some
+      // accounts) - fall back to the most restrictive option TikTok will allow.
+      return allowedLevels.includes("SELF_ONLY")
+        ? "SELF_ONLY"
+        : allowedLevels[0];
+    }
+
+    return requestedLevel;
   }
 
   async #getCreatorInfo(account: SocialAccount) {
@@ -416,12 +450,14 @@ export class TikTokPostClient extends PostClient {
     coverTimestamp,
     account,
     platformData,
+    creatorInfoResponse,
   }: {
     medium: PostMedia;
     caption: string;
     platformData: TiktokConfiguration;
     coverTimestamp: number | undefined;
     account: SocialAccount;
+    creatorInfoResponse: any;
   }) {
     // Get the signed URL for the file
     const signedUrl = await this.getSignedUrlForFile(medium);
@@ -455,10 +491,10 @@ export class TikTokPostClient extends PostClient {
       payload: {
         post_info: {
           title: caption,
-          privacy_level:
-            platformData.privacy_status == "private"
-              ? "SELF_ONLY"
-              : "PUBLIC_TO_EVERYONE",
+          privacy_level: this.#resolvePrivacyLevel({
+            platformData,
+            creatorInfoResponse,
+          }),
           disable_duet:
             platformData.allow_duet === undefined
               ? false
@@ -500,12 +536,14 @@ export class TikTokPostClient extends PostClient {
     title,
     account,
     platformData,
+    creatorInfoResponse,
   }: {
     media: PostMedia[];
     caption: string;
     title: string | undefined;
     account: SocialAccount;
     platformData: TiktokConfiguration;
+    creatorInfoResponse: any;
   }) {
     const allowedMedia = media.slice(0, this.#maxItems);
 
@@ -524,10 +562,10 @@ export class TikTokPostClient extends PostClient {
         post_info: {
           title: (title ?? "").slice(0, this.#titleLength),
           description: caption,
-          privacy_level:
-            platformData.privacy_status == "private"
-              ? "SELF_ONLY"
-              : "PUBLIC_TO_EVERYONE",
+          privacy_level: this.#resolvePrivacyLevel({
+            platformData,
+            creatorInfoResponse,
+          }),
           disable_comment:
             platformData.allow_comment === undefined
               ? false

--- a/trigger/posting/platforms/tiktok_business-post-client.ts
+++ b/trigger/posting/platforms/tiktok_business-post-client.ts
@@ -27,6 +27,12 @@ export class TikTokBusinessPostClient extends PostClient {
   ];
   #maxItems = 32;
   #titleLength = 85;
+  #privacyLevelMap: Record<string, string> = {
+    public: "PUBLIC_TO_EVERYONE",
+    private: "SELF_ONLY",
+    followers: "FOLLOWER_OF_CREATOR",
+    friends: "MUTUAL_FOLLOW_FRIENDS",
+  };
   #clientKey: string;
   #clientSecret: string;
   #localSupabaseClient;
@@ -473,9 +479,8 @@ export class TikTokBusinessPostClient extends PostClient {
           caption,
           is_draft: platformData?.is_draft ? true : undefined,
           privacy_level:
-            platformData.privacy_status == "private"
-              ? "SELF_ONLY"
-              : "PUBLIC_TO_EVERYONE",
+            this.#privacyLevelMap[platformData.privacy_status ?? "public"] ??
+            "PUBLIC_TO_EVERYONE",
           disable_comment:
             platformData.allow_comment === undefined
               ? false


### PR DESCRIPTION
## Summary

A customer reported that only public/private visibility is supported for TikTok posts, not follower-only or friends-only. TikTok's API actually supports four `privacy_level` values (`PUBLIC_TO_EVERYONE`, `MUTUAL_FOLLOW_FRIENDS`, `FOLLOWER_OF_CREATOR`, `SELF_ONLY`), but this codebase only ever sent the public/private pair. This adds the two missing options end-to-end.

## Changes

- `trigger/posting/platforms/tiktok-post-client.ts`: maps `privacy_status` (`public`/`private`/`followers`/`friends`) to all four TikTok privacy levels for both video and photo publishing. Validates the requested level against the creator's actual `privacy_level_options` (returned by the already-called `creator_info/query` endpoint, previously discarded) and falls back to the most restrictive option the account supports if the requested one isn't available.
- `trigger/posting/platforms/tiktok_business-post-client.ts`: same mapping for the Business API photo-publish path. The Business video-publish endpoint never accepted `privacy_level` at all, so it's left untouched rather than guessing at unconfirmed API behavior.
- `api/src/social-posts/dto/post-configurations.dto.ts`: added a `TiktokPrivacyStatus` enum with `@IsEnum` runtime validation on both the personal and business TikTok configuration DTOs, and widened the shared legacy `AccountConfigurationDetailsDto.privacy_status` enum for Swagger docs.
- `dashboard/.../composer/_tab-tiktok.tsx` + `schema.ts`: added Friends/Followers options to the TikTok privacy toggle group. Also fixed a latent bug where branded-content disclosure was only disabled for `"private"` instead of requiring `"public"` (TikTok's actual rule) — without this fix, branded content could be wrongly enabled alongside the new followers/friends options.
- `marketing/app/lib/.server/data/integrations.tiktok.ts`: updated public-facing feature description copy.

## Testing

- `bun run typecheck` + `bun run lint` — pass on `trigger`, `api`, and `dashboard`.
- `marketing` has no local `node_modules` installed, so its checks weren't run; the change there is a single string literal in an existing data array, low risk.
- Not exercised against a live TikTok account/API — would need a real TikTok Creator/Business connection and a trigger.dev job run to confirm TikTok accepts `FOLLOWER_OF_CREATOR`/`MUTUAL_FOLLOW_FRIENDS` for a given creator and that the `privacy_level_options` fallback behaves as expected.

## Notes

- The TikTok Business video-publish endpoint has no privacy control at all (pre-existing gap, not introduced here) — out of scope for this PR.

Closes PFM-615

🤖 Generated with AI