### PR TITLE
feat(api,trigger): add alt text support for media

### DIFF
--- a/api/src/social-posts/dto/post-media.dto.ts
+++ b/api/src/social-posts/dto/post-media.dto.ts
@@ -58,6 +58,14 @@ export class SocialPostMediaDto {
   thumbnail_timestamp_ms: number | null | undefined;
 
   @ApiProperty({
+    description:
+      'Alt text describing the media, passed to platforms that support it',
+    nullable: true,
+    required: false,
+  })
+  alt_text?: string | null;
+
+  @ApiProperty({
     description: 'List of tags to attach to the media',
     nullable: true,
     required: false,

--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -302,6 +302,7 @@ export class SocialPostsService {
       post_id: string;
       provider_connection_id?: string | undefined;
       provider?: Provider;
+      alt_text?: string | null;
       skip_processing?: boolean | null;
     }[] = [];
 
@@ -321,6 +322,7 @@ export class SocialPostsService {
             thumbnail_url: media.thumbnail_url,
             thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
             post_id: data.id,
+            alt_text: media.alt_text,
             tags: media.tags,
             skip_processing: media.skip_processing,
           };
@@ -337,6 +339,7 @@ export class SocialPostsService {
               url: string;
               thumbnail_url?: string;
               thumbnail_timestamp_ms?: number;
+              alt_text?: string | null;
               tags: any[];
               skip_processing?: boolean | null;
             }[];
@@ -348,6 +351,7 @@ export class SocialPostsService {
                 url: media.url,
                 thumbnail_url: media.thumbnail_url,
                 thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+                alt_text: media.alt_text,
                 tags: media.tags,
                 skip_processing: media.skip_processing,
                 post_id: data.id,
@@ -357,6 +361,7 @@ export class SocialPostsService {
                 thumbnail_url?: string;
                 thumbnail_timestamp_ms?: number;
                 post_id: string;
+                alt_text?: string | null;
                 tags: any[];
                 skip_processing?: boolean | null;
                 provider: Provider;
@@ -390,6 +395,7 @@ export class SocialPostsService {
               thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
               post_id: data.id,
               provider_connection_id: accountConfig.social_account_id,
+              alt_text: media.alt_text,
               tags: media.tags,
               skip_processing: media.skip_processing,
             })),
@@ -507,6 +513,7 @@ export class SocialPostsService {
           thumbnail_timestamp_ms,
           provider,
           provider_connection_id,
+          alt_text,
           tags,
           skip_processing
         ),
@@ -573,6 +580,7 @@ export class SocialPostsService {
           thumbnail_timestamp_ms,
           provider,
           provider_connection_id,
+          alt_text,
           tags,
           skip_processing
         ),
@@ -802,6 +810,7 @@ export class SocialPostsService {
           thumbnail_timestamp_ms,
           provider,
           provider_connection_id,
+          alt_text,
           tags,
           skip_processing
         ),
@@ -859,6 +868,7 @@ export class SocialPostsService {
 
       provider: Provider | null;
       provider_connection_id: string | null;
+      alt_text: string | null;
       tags: Json;
       skip_processing: boolean | null;
     }>;
@@ -876,6 +886,7 @@ export class SocialPostsService {
         url: media.url,
         thumbnail_url: media.thumbnail_url,
         thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+        alt_text: media.alt_text,
         tags: media.tags as any[],
         skip_processing: media.skip_processing,
       }));
@@ -896,6 +907,7 @@ export class SocialPostsService {
                 url: media.url,
                 thumbnail_url: media.thumbnail_url,
                 thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+                alt_text: media.alt_text,
                 tags: media.tags as any[],
                 skip_processing: media.skip_processing,
               })),
@@ -929,6 +941,7 @@ export class SocialPostsService {
               url: media.url,
               thumbnail_url: media.thumbnail_url,
               thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+              alt_text: media.alt_text,
               tags: media.tags as any[],
               skip_processing: media.skip_processing,
             })),

--- a/api/supabase/migrations/20260720120000_add_alt_text_to_media.sql
+++ b/api/supabase/migrations/20260720120000_add_alt_text_to_media.sql
@@ -1,0 +1,2 @@
+ALTER TABLE social_post_media
+    ADD COLUMN alt_text text NULL;

--- a/api/supabase/supabase.types.ts
+++ b/api/supabase/supabase.types.ts
@@ -4,1452 +4,1452 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
   cms: {
     Tables: {
       article_authors: {
         Row: {
-          article_id: string;
-          author_id: string;
-          position: number;
-        };
+          article_id: string
+          author_id: string
+          position: number
+        }
         Insert: {
-          article_id: string;
-          author_id: string;
-          position?: number;
-        };
+          article_id: string
+          author_id: string
+          position?: number
+        }
         Update: {
-          article_id?: string;
-          author_id?: string;
-          position?: number;
-        };
+          article_id?: string
+          author_id?: string
+          position?: number
+        }
         Relationships: [
           {
-            foreignKeyName: 'article_authors_article_id_fkey';
-            columns: ['article_id'];
-            isOneToOne: false;
-            referencedRelation: 'articles';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_authors_article_id_fkey"
+            columns: ["article_id"]
+            isOneToOne: false
+            referencedRelation: "articles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'article_authors_author_id_fkey';
-            columns: ['author_id'];
-            isOneToOne: false;
-            referencedRelation: 'authors';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_authors_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "authors"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       article_tags: {
         Row: {
-          article_id: string;
-          tag_id: string;
-        };
+          article_id: string
+          tag_id: string
+        }
         Insert: {
-          article_id: string;
-          tag_id: string;
-        };
+          article_id: string
+          tag_id: string
+        }
         Update: {
-          article_id?: string;
-          tag_id?: string;
-        };
+          article_id?: string
+          tag_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'article_tags_article_id_fkey';
-            columns: ['article_id'];
-            isOneToOne: false;
-            referencedRelation: 'articles';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_tags_article_id_fkey"
+            columns: ["article_id"]
+            isOneToOne: false
+            referencedRelation: "articles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'article_tags_tag_id_fkey';
-            columns: ['tag_id'];
-            isOneToOne: false;
-            referencedRelation: 'tags';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_tags_tag_id_fkey"
+            columns: ["tag_id"]
+            isOneToOne: false
+            referencedRelation: "tags"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       articles: {
         Row: {
-          attribution: Json | null;
-          category_id: string | null;
-          content: string | null;
-          content_format: string;
-          cover_image_url: string | null;
-          cover_video_url: string | null;
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          featured: boolean;
-          id: string;
-          published_at: string | null;
-          slug: string;
-          status: string;
-          title: string;
-          updated_at: string;
-        };
+          attribution: Json | null
+          category_id: string | null
+          content: string | null
+          content_format: string
+          cover_image_url: string | null
+          cover_video_url: string | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          featured: boolean
+          id: string
+          published_at: string | null
+          slug: string
+          status: string
+          title: string
+          updated_at: string
+        }
         Insert: {
-          attribution?: Json | null;
-          category_id?: string | null;
-          content?: string | null;
-          content_format?: string;
-          cover_image_url?: string | null;
-          cover_video_url?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          featured?: boolean;
-          id?: string;
-          published_at?: string | null;
-          slug: string;
-          status?: string;
-          title: string;
-          updated_at?: string;
-        };
+          attribution?: Json | null
+          category_id?: string | null
+          content?: string | null
+          content_format?: string
+          cover_image_url?: string | null
+          cover_video_url?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          featured?: boolean
+          id?: string
+          published_at?: string | null
+          slug: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
         Update: {
-          attribution?: Json | null;
-          category_id?: string | null;
-          content?: string | null;
-          content_format?: string;
-          cover_image_url?: string | null;
-          cover_video_url?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          featured?: boolean;
-          id?: string;
-          published_at?: string | null;
-          slug?: string;
-          status?: string;
-          title?: string;
-          updated_at?: string;
-        };
+          attribution?: Json | null
+          category_id?: string | null
+          content?: string | null
+          content_format?: string
+          cover_image_url?: string | null
+          cover_video_url?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          featured?: boolean
+          id?: string
+          published_at?: string | null
+          slug?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'articles_category_id_fkey';
-            columns: ['category_id'];
-            isOneToOne: false;
-            referencedRelation: 'categories';
-            referencedColumns: ['id'];
+            foreignKeyName: "articles_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       authors: {
         Row: {
-          bio: string | null;
-          created_at: string;
-          deleted_at: string | null;
-          id: string;
-          image_url: string | null;
-          name: string;
-          role: string | null;
-          slug: string;
-          socials: Json;
-          updated_at: string;
-        };
+          bio: string | null
+          created_at: string
+          deleted_at: string | null
+          id: string
+          image_url: string | null
+          name: string
+          role: string | null
+          slug: string
+          socials: Json
+          updated_at: string
+        }
         Insert: {
-          bio?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          id?: string;
-          image_url?: string | null;
-          name: string;
-          role?: string | null;
-          slug: string;
-          socials?: Json;
-          updated_at?: string;
-        };
+          bio?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          image_url?: string | null
+          name: string
+          role?: string | null
+          slug: string
+          socials?: Json
+          updated_at?: string
+        }
         Update: {
-          bio?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          id?: string;
-          image_url?: string | null;
-          name?: string;
-          role?: string | null;
-          slug?: string;
-          socials?: Json;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          bio?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          image_url?: string | null
+          name?: string
+          role?: string | null
+          slug?: string
+          socials?: Json
+          updated_at?: string
+        }
+        Relationships: []
+      }
       categories: {
         Row: {
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          id: string;
-          name: string;
-          slug: string;
-          updated_at: string;
-        };
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          slug: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name: string;
-          slug: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          slug: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name?: string;
-          slug?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       tags: {
         Row: {
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          id: string;
-          name: string;
-          slug: string;
-          updated_at: string;
-        };
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          slug: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name: string;
-          slug: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          slug: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name?: string;
-          slug?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
-    };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   graphql_public: {
     Tables: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json;
-          operationName?: string;
-          query?: string;
-          variables?: Json;
-        };
-        Returns: Json;
-      };
-    };
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       projects: {
         Row: {
-          auth_callback_url: string | null;
-          created_at: string | null;
-          created_by: string | null;
-          description: string | null;
-          id: string;
-          is_system: boolean;
-          name: string;
-          team_id: string;
-          updated_at: string | null;
-          updated_by: string | null;
-        };
+          auth_callback_url: string | null
+          created_at: string | null
+          created_by: string | null
+          description: string | null
+          id: string
+          is_system: boolean
+          name: string
+          team_id: string
+          updated_at: string | null
+          updated_by: string | null
+        }
         Insert: {
-          auth_callback_url?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          description?: string | null;
-          id?: string;
-          is_system?: boolean;
-          name: string;
-          team_id: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          auth_callback_url?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          is_system?: boolean
+          name: string
+          team_id: string
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Update: {
-          auth_callback_url?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          description?: string | null;
-          id?: string;
-          is_system?: boolean;
-          name?: string;
-          team_id?: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          auth_callback_url?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          is_system?: boolean
+          name?: string
+          team_id?: string
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'projects_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'projects_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'projects_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_configurations: {
         Row: {
-          caption: string | null;
-          id: string;
-          post_id: string;
-          provider: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id: string | null;
-          provider_data: Json | null;
-        };
+          caption: string | null
+          id: string
+          post_id: string
+          provider: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id: string | null
+          provider_data: Json | null
+        }
         Insert: {
-          caption?: string | null;
-          id?: string;
-          post_id: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          provider_data?: Json | null;
-        };
+          caption?: string | null
+          id?: string
+          post_id: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          provider_data?: Json | null
+        }
         Update: {
-          caption?: string | null;
-          id?: string;
-          post_id?: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          provider_data?: Json | null;
-        };
+          caption?: string | null
+          id?: string
+          post_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          provider_data?: Json | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_configurations_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_configurations_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_configurations_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_configurations_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_media: {
         Row: {
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          meta_data: Json | null;
-          post_id: string;
-          provider: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id: string | null;
-          skip_processing: boolean | null;
-          tags: Json | null;
-          thumbnail_timestamp_ms: number | null;
-          thumbnail_url: string | null;
-          updated_at: string;
-          url: string;
-        };
+          alt_text: string | null
+          created_at: string
+          external_id: string | null
+          id: string
+          meta_data: Json | null
+          post_id: string
+          provider: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id: string | null
+          skip_processing: boolean | null
+          tags: Json | null
+          thumbnail_timestamp_ms: number | null
+          thumbnail_url: string | null
+          updated_at: string
+          url: string
+        }
         Insert: {
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          meta_data?: Json | null;
-          post_id: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          skip_processing?: boolean | null;
-          tags?: Json | null;
-          thumbnail_timestamp_ms?: number | null;
-          thumbnail_url?: string | null;
-          updated_at?: string;
-          url: string;
-        };
+          alt_text?: string | null
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          meta_data?: Json | null
+          post_id: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url: string
+        }
         Update: {
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          meta_data?: Json | null;
-          post_id?: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          skip_processing?: boolean | null;
-          tags?: Json | null;
-          thumbnail_timestamp_ms?: number | null;
-          thumbnail_url?: string | null;
-          updated_at?: string;
-          url?: string;
-        };
+          alt_text?: string | null
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          meta_data?: Json | null
+          post_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_media_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_media_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_media_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_media_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_provider_connections: {
         Row: {
-          created_at: string;
-          id: string;
-          post_id: string;
-          provider_connection_id: string;
-          updated_at: string;
-        };
+          created_at: string
+          id: string
+          post_id: string
+          provider_connection_id: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          post_id: string;
-          provider_connection_id: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          post_id: string
+          provider_connection_id: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          post_id?: string;
-          provider_connection_id?: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          post_id?: string
+          provider_connection_id?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_provider_connections_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_provider_connections_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_provider_connections_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_provider_connections_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_result_post_media: {
         Row: {
-          id: string;
-          social_post_media_id: string;
-          social_post_result_id: string;
-        };
+          id: string
+          social_post_media_id: string
+          social_post_result_id: string
+        }
         Insert: {
-          id?: string;
-          social_post_media_id: string;
-          social_post_result_id: string;
-        };
+          id?: string
+          social_post_media_id: string
+          social_post_result_id: string
+        }
         Update: {
-          id?: string;
-          social_post_media_id?: string;
-          social_post_result_id?: string;
-        };
+          id?: string
+          social_post_media_id?: string
+          social_post_result_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_result_post_media_social_post_media_id_fkey';
-            columns: ['social_post_media_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_post_media';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_result_post_media_social_post_media_id_fkey"
+            columns: ["social_post_media_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_media"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_result_post_media_social_post_result_id_fkey';
-            columns: ['social_post_result_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_post_results';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_result_post_media_social_post_result_id_fkey"
+            columns: ["social_post_result_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_results"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_results: {
         Row: {
-          created_at: string;
-          details: Json | null;
-          error_message: string | null;
-          id: string;
-          post_id: string;
-          provider_connection_id: string;
-          provider_post_id: string | null;
-          provider_post_url: string | null;
-          success: boolean;
-          updated_at: string;
-        };
+          created_at: string
+          details: Json | null
+          error_message: string | null
+          id: string
+          post_id: string
+          provider_connection_id: string
+          provider_post_id: string | null
+          provider_post_url: string | null
+          success: boolean
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          details?: Json | null;
-          error_message?: string | null;
-          id?: string;
-          post_id: string;
-          provider_connection_id: string;
-          provider_post_id?: string | null;
-          provider_post_url?: string | null;
-          success: boolean;
-          updated_at?: string;
-        };
+          created_at?: string
+          details?: Json | null
+          error_message?: string | null
+          id?: string
+          post_id: string
+          provider_connection_id: string
+          provider_post_id?: string | null
+          provider_post_url?: string | null
+          success: boolean
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          details?: Json | null;
-          error_message?: string | null;
-          id?: string;
-          post_id?: string;
-          provider_connection_id?: string;
-          provider_post_id?: string | null;
-          provider_post_url?: string | null;
-          success?: boolean;
-          updated_at?: string;
-        };
+          created_at?: string
+          details?: Json | null
+          error_message?: string | null
+          id?: string
+          post_id?: string
+          provider_connection_id?: string
+          provider_post_id?: string | null
+          provider_post_url?: string | null
+          success?: boolean
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_results_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_results_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_results_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_results_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_team_usage: {
         Row: {
-          count: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          team_id: string;
-        };
+          count: number
+          end_at: string
+          limit: number
+          start_at: string
+          team_id: string
+        }
         Insert: {
-          count?: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          team_id: string;
-        };
+          count?: number
+          end_at: string
+          limit: number
+          start_at: string
+          team_id: string
+        }
         Update: {
-          count?: number;
-          end_at?: string;
-          limit?: number;
-          start_at?: string;
-          team_id?: string;
-        };
+          count?: number
+          end_at?: string
+          limit?: number
+          start_at?: string
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_team_usage_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_team_usage_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_posts: {
         Row: {
-          api_key: string;
-          caption: string;
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          post_at: string;
-          project_id: string;
-          status: Database['public']['Enums']['social_post_status'];
-          updated_at: string;
-        };
+          api_key: string
+          caption: string
+          created_at: string
+          external_id: string | null
+          id: string
+          post_at: string
+          project_id: string
+          status: Database["public"]["Enums"]["social_post_status"]
+          updated_at: string
+        }
         Insert: {
-          api_key: string;
-          caption: string;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          post_at?: string;
-          project_id: string;
-          status?: Database['public']['Enums']['social_post_status'];
-          updated_at?: string;
-        };
+          api_key: string
+          caption: string
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          post_at?: string
+          project_id: string
+          status?: Database["public"]["Enums"]["social_post_status"]
+          updated_at?: string
+        }
         Update: {
-          api_key?: string;
-          caption?: string;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          post_at?: string;
-          project_id?: string;
-          status?: Database['public']['Enums']['social_post_status'];
-          updated_at?: string;
-        };
+          api_key?: string
+          caption?: string
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          post_at?: string
+          project_id?: string
+          status?: Database["public"]["Enums"]["social_post_status"]
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_posts_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_posts_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_app_credentials: {
         Row: {
-          app_id: string | null;
-          app_secret: string | null;
-          created_at: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string;
-        };
+          app_id: string | null
+          app_secret: string | null
+          created_at: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string
+        }
         Insert: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Update: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_app_credentials_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_app_credentials_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connection_oauth_data: {
         Row: {
-          created_at: string | null;
-          id: string;
-          key: string;
-          key_id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string | null;
-          value: string;
-        };
+          created_at: string | null
+          id: string
+          key: string
+          key_id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string | null
+          value: string
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          key: string;
-          key_id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string | null;
-          value: string;
-        };
+          created_at?: string | null
+          id?: string
+          key: string
+          key_id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string | null
+          value: string
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          key?: string;
-          key_id?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string | null;
-          value?: string;
-        };
+          created_at?: string | null
+          id?: string
+          key?: string
+          key_id?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string | null
+          value?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connection_oauth_data_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connection_oauth_data_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connection_pagination_data: {
         Row: {
-          created_at: string | null;
-          id: string;
-          metadata: Json;
-          provider_connection_id: string;
-          updated_at: string | null;
-        };
+          created_at: string | null
+          id: string
+          metadata: Json
+          provider_connection_id: string
+          updated_at: string | null
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          metadata: Json;
-          provider_connection_id: string;
-          updated_at?: string | null;
-        };
+          created_at?: string | null
+          id?: string
+          metadata: Json
+          provider_connection_id: string
+          updated_at?: string | null
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          metadata?: Json;
-          provider_connection_id?: string;
-          updated_at?: string | null;
-        };
+          created_at?: string | null
+          id?: string
+          metadata?: Json
+          provider_connection_id?: string
+          updated_at?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connection_paginati_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connection_paginati_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connections: {
         Row: {
-          access_token: string | null;
-          access_token_expires_at: string | null;
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          refresh_token: string | null;
-          refresh_token_expires_at: string | null;
-          social_provider_metadata: Json | null;
-          social_provider_profile_photo_url: string | null;
-          social_provider_user_id: string;
-          social_provider_user_name: string | null;
-          updated_at: string;
-        };
+          access_token: string | null
+          access_token_expires_at: string | null
+          created_at: string
+          external_id: string | null
+          id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          refresh_token: string | null
+          refresh_token_expires_at: string | null
+          social_provider_metadata: Json | null
+          social_provider_profile_photo_url: string | null
+          social_provider_user_id: string
+          social_provider_user_name: string | null
+          updated_at: string
+        }
         Insert: {
-          access_token?: string | null;
-          access_token_expires_at?: string | null;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          refresh_token?: string | null;
-          refresh_token_expires_at?: string | null;
-          social_provider_metadata?: Json | null;
-          social_provider_profile_photo_url?: string | null;
-          social_provider_user_id: string;
-          social_provider_user_name?: string | null;
-          updated_at?: string;
-        };
+          access_token?: string | null
+          access_token_expires_at?: string | null
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          refresh_token?: string | null
+          refresh_token_expires_at?: string | null
+          social_provider_metadata?: Json | null
+          social_provider_profile_photo_url?: string | null
+          social_provider_user_id: string
+          social_provider_user_name?: string | null
+          updated_at?: string
+        }
         Update: {
-          access_token?: string | null;
-          access_token_expires_at?: string | null;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          refresh_token?: string | null;
-          refresh_token_expires_at?: string | null;
-          social_provider_metadata?: Json | null;
-          social_provider_profile_photo_url?: string | null;
-          social_provider_user_id?: string;
-          social_provider_user_name?: string | null;
-          updated_at?: string;
-        };
+          access_token?: string | null
+          access_token_expires_at?: string | null
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          refresh_token?: string | null
+          refresh_token_expires_at?: string | null
+          social_provider_metadata?: Json | null
+          social_provider_profile_photo_url?: string | null
+          social_provider_user_id?: string
+          social_provider_user_name?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connections_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connections_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       system_social_provider_app_credentials: {
         Row: {
-          app_id: string | null;
-          app_secret: string | null;
-          created_at: string;
-          id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string;
-        };
+          app_id: string | null
+          app_secret: string | null
+          created_at: string
+          id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string
+        }
         Insert: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          id?: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          id?: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Update: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
       team_addons: {
         Row: {
-          addon: Database['public']['Enums']['subscription_addon'];
-          expires_at: string;
-          id: string;
-          team_id: string;
-        };
+          addon: Database["public"]["Enums"]["subscription_addon"]
+          expires_at: string
+          id: string
+          team_id: string
+        }
         Insert: {
-          addon: Database['public']['Enums']['subscription_addon'];
-          expires_at: string;
-          id?: string;
-          team_id: string;
-        };
+          addon: Database["public"]["Enums"]["subscription_addon"]
+          expires_at: string
+          id?: string
+          team_id: string
+        }
         Update: {
-          addon?: Database['public']['Enums']['subscription_addon'];
-          expires_at?: string;
-          id?: string;
-          team_id?: string;
-        };
+          addon?: Database["public"]["Enums"]["subscription_addon"]
+          expires_at?: string
+          id?: string
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_addons_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_addons_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_notifications: {
         Row: {
-          created_at: string;
-          delivery_types: Database['public']['Enums']['delivery_type'][];
-          id: string;
-          message: string;
-          meta_data: Json | null;
-          notification_type: Database['public']['Enums']['notification_type'];
-          project_id: string | null;
-          team_id: string;
-        };
+          created_at: string
+          delivery_types: Database["public"]["Enums"]["delivery_type"][]
+          id: string
+          message: string
+          meta_data: Json | null
+          notification_type: Database["public"]["Enums"]["notification_type"]
+          project_id: string | null
+          team_id: string
+        }
         Insert: {
-          created_at?: string;
-          delivery_types: Database['public']['Enums']['delivery_type'][];
-          id?: string;
-          message: string;
-          meta_data?: Json | null;
-          notification_type: Database['public']['Enums']['notification_type'];
-          project_id?: string | null;
-          team_id: string;
-        };
+          created_at?: string
+          delivery_types: Database["public"]["Enums"]["delivery_type"][]
+          id?: string
+          message: string
+          meta_data?: Json | null
+          notification_type: Database["public"]["Enums"]["notification_type"]
+          project_id?: string | null
+          team_id: string
+        }
         Update: {
-          created_at?: string;
-          delivery_types?: Database['public']['Enums']['delivery_type'][];
-          id?: string;
-          message?: string;
-          meta_data?: Json | null;
-          notification_type?: Database['public']['Enums']['notification_type'];
-          project_id?: string | null;
-          team_id?: string;
-        };
+          created_at?: string
+          delivery_types?: Database["public"]["Enums"]["delivery_type"][]
+          id?: string
+          message?: string
+          meta_data?: Json | null
+          notification_type?: Database["public"]["Enums"]["notification_type"]
+          project_id?: string | null
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_notifications_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_notifications_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_notifications_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_notifications_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_social_post_meters: {
         Row: {
-          count: number;
-          day: number;
-          hour: number;
-          id: string;
-          minute: number;
-          month: number;
-          provider: Database['public']['Enums']['social_provider'];
-          team_id: string;
-          year: number;
-        };
+          count: number
+          day: number
+          hour: number
+          id: string
+          minute: number
+          month: number
+          provider: Database["public"]["Enums"]["social_provider"]
+          team_id: string
+          year: number
+        }
         Insert: {
-          count: number;
-          day: number;
-          hour: number;
-          id?: string;
-          minute: number;
-          month: number;
-          provider: Database['public']['Enums']['social_provider'];
-          team_id: string;
-          year: number;
-        };
+          count: number
+          day: number
+          hour: number
+          id?: string
+          minute: number
+          month: number
+          provider: Database["public"]["Enums"]["social_provider"]
+          team_id: string
+          year: number
+        }
         Update: {
-          count?: number;
-          day?: number;
-          hour?: number;
-          id?: string;
-          minute?: number;
-          month?: number;
-          provider?: Database['public']['Enums']['social_provider'];
-          team_id?: string;
-          year?: number;
-        };
+          count?: number
+          day?: number
+          hour?: number
+          id?: string
+          minute?: number
+          month?: number
+          provider?: Database["public"]["Enums"]["social_provider"]
+          team_id?: string
+          year?: number
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_social_post_meters_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_social_post_meters_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_users: {
         Row: {
-          created_at: string | null;
-          created_by: string | null;
-          team_id: string;
-          updated_at: string | null;
-          updated_by: string | null;
-          user_id: string;
-        };
+          created_at: string | null
+          created_by: string | null
+          team_id: string
+          updated_at: string | null
+          updated_by: string | null
+          user_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          created_by?: string | null;
-          team_id: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-          user_id: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          team_id: string
+          updated_at?: string | null
+          updated_by?: string | null
+          user_id: string
+        }
         Update: {
-          created_at?: string | null;
-          created_by?: string | null;
-          team_id?: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-          user_id?: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          team_id?: string
+          updated_at?: string | null
+          updated_by?: string | null
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_users_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       teams: {
         Row: {
-          billing_email: string | null;
-          created_at: string | null;
-          created_by: string | null;
-          id: string;
-          name: string;
-          stripe_customer_id: string | null;
-          updated_at: string | null;
-          updated_by: string | null;
-        };
+          billing_email: string | null
+          created_at: string | null
+          created_by: string | null
+          id: string
+          name: string
+          stripe_customer_id: string | null
+          updated_at: string | null
+          updated_by: string | null
+        }
         Insert: {
-          billing_email?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          id?: string;
-          name: string;
-          stripe_customer_id?: string | null;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          billing_email?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          name: string
+          stripe_customer_id?: string | null
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Update: {
-          billing_email?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          id?: string;
-          name?: string;
-          stripe_customer_id?: string | null;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          billing_email?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          name?: string
+          stripe_customer_id?: string | null
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'teams_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "teams_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'teams_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "teams_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       test_social_provider_connections: {
         Row: {
-          created_at: string | null;
-          created_by: string | null;
-          name: string | null;
-          social_provider_connection_id: string;
-        };
+          created_at: string | null
+          created_by: string | null
+          name: string | null
+          social_provider_connection_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          created_by?: string | null;
-          name?: string | null;
-          social_provider_connection_id: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          name?: string | null
+          social_provider_connection_id: string
+        }
         Update: {
-          created_at?: string | null;
-          created_by?: string | null;
-          name?: string | null;
-          social_provider_connection_id?: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          name?: string | null
+          social_provider_connection_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'test_social_provider_connecti_social_provider_connection_i_fkey';
-            columns: ['social_provider_connection_id'];
-            isOneToOne: true;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "test_social_provider_connecti_social_provider_connection_i_fkey"
+            columns: ["social_provider_connection_id"]
+            isOneToOne: true
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       users: {
         Row: {
-          email: string;
-          first_name: string | null;
-          id: string;
-          last_name: string | null;
-        };
+          email: string
+          first_name: string | null
+          id: string
+          last_name: string | null
+        }
         Insert: {
-          email: string;
-          first_name?: string | null;
-          id: string;
-          last_name?: string | null;
-        };
+          email: string
+          first_name?: string | null
+          id: string
+          last_name?: string | null
+        }
         Update: {
-          email?: string;
-          first_name?: string | null;
-          id?: string;
-          last_name?: string | null;
-        };
-        Relationships: [];
-      };
+          email?: string
+          first_name?: string | null
+          id?: string
+          last_name?: string | null
+        }
+        Relationships: []
+      }
       webhook_events: {
         Row: {
-          created_at: string | null;
-          data: Json;
-          id: string;
-          response: Json | null;
-          status: Database['public']['Enums']['webhook_event_status'];
-          type: Database['public']['Enums']['webhook_event_type'];
-          updated_at: string | null;
-          webhook_id: string;
-        };
+          created_at: string | null
+          data: Json
+          id: string
+          response: Json | null
+          status: Database["public"]["Enums"]["webhook_event_status"]
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at: string | null
+          webhook_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          data: Json;
-          id?: string;
-          response?: Json | null;
-          status: Database['public']['Enums']['webhook_event_status'];
-          type: Database['public']['Enums']['webhook_event_type'];
-          updated_at?: string | null;
-          webhook_id: string;
-        };
+          created_at?: string | null
+          data: Json
+          id?: string
+          response?: Json | null
+          status: Database["public"]["Enums"]["webhook_event_status"]
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at?: string | null
+          webhook_id: string
+        }
         Update: {
-          created_at?: string | null;
-          data?: Json;
-          id?: string;
-          response?: Json | null;
-          status?: Database['public']['Enums']['webhook_event_status'];
-          type?: Database['public']['Enums']['webhook_event_type'];
-          updated_at?: string | null;
-          webhook_id?: string;
-        };
+          created_at?: string | null
+          data?: Json
+          id?: string
+          response?: Json | null
+          status?: Database["public"]["Enums"]["webhook_event_status"]
+          type?: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at?: string | null
+          webhook_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhook_events_webhook_id_fkey';
-            columns: ['webhook_id'];
-            isOneToOne: false;
-            referencedRelation: 'webhooks';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhook_events_webhook_id_fkey"
+            columns: ["webhook_id"]
+            isOneToOne: false
+            referencedRelation: "webhooks"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       webhook_subscribed_event_types: {
         Row: {
-          id: string;
-          type: Database['public']['Enums']['webhook_event_type'];
-          webhook_id: string;
-        };
+          id: string
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id: string
+        }
         Insert: {
-          id?: string;
-          type: Database['public']['Enums']['webhook_event_type'];
-          webhook_id: string;
-        };
+          id?: string
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id: string
+        }
         Update: {
-          id?: string;
-          type?: Database['public']['Enums']['webhook_event_type'];
-          webhook_id?: string;
-        };
+          id?: string
+          type?: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhook_subscribed_event_types_webhook_id_fkey';
-            columns: ['webhook_id'];
-            isOneToOne: false;
-            referencedRelation: 'webhooks';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhook_subscribed_event_types_webhook_id_fkey"
+            columns: ["webhook_id"]
+            isOneToOne: false
+            referencedRelation: "webhooks"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       webhooks: {
         Row: {
-          created_at: string | null;
-          id: string;
-          project_id: string;
-          secret_key: string;
-          updated_at: string | null;
-          url: string;
-        };
+          created_at: string | null
+          id: string
+          project_id: string
+          secret_key: string
+          updated_at: string | null
+          url: string
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          project_id: string;
-          secret_key: string;
-          updated_at?: string | null;
-          url: string;
-        };
+          created_at?: string | null
+          id?: string
+          project_id: string
+          secret_key: string
+          updated_at?: string | null
+          url: string
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          project_id?: string;
-          secret_key?: string;
-          updated_at?: string | null;
-          url?: string;
-        };
+          created_at?: string | null
+          id?: string
+          project_id?: string
+          secret_key?: string
+          updated_at?: string | null
+          url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhooks_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhooks_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Views: {
       v_tiktok_verification_files: {
         Row: {
-          bucket_id: string | null;
-          name: string | null;
-          project_id: string | null;
-        };
+          bucket_id: string | null
+          name: string | null
+          project_id: string | null
+        }
         Insert: {
-          bucket_id?: string | null;
-          name?: string | null;
-          project_id?: never;
-        };
+          bucket_id?: string | null
+          name?: string | null
+          project_id?: never
+        }
         Update: {
-          bucket_id?: string | null;
-          name?: string | null;
-          project_id?: never;
-        };
-        Relationships: [];
-      };
-    };
+          bucket_id?: string | null
+          name?: string | null
+          project_id?: never
+        }
+        Relationships: []
+      }
+    }
     Functions: {
       get_exceeded_team_usage_windows: {
-        Args: never;
+        Args: never
         Returns: {
-          count: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          stripe_customer_id: string;
-          team_id: string;
-          team_name: string;
-        }[];
-      };
+          count: number
+          end_at: string
+          limit: number
+          start_at: string
+          stripe_customer_id: string
+          team_id: string
+          team_name: string
+        }[]
+      }
       increment_team_social_post_meter: {
         Args: {
-          p_day: number;
-          p_hour: number;
-          p_min: number;
-          p_month: number;
-          p_provider: Database['public']['Enums']['social_provider'];
-          p_team_id: string;
-          p_year: number;
-        };
-        Returns: undefined;
-      };
+          p_day: number
+          p_hour: number
+          p_min: number
+          p_month: number
+          p_provider: Database["public"]["Enums"]["social_provider"]
+          p_team_id: string
+          p_year: number
+        }
+        Returns: undefined
+      }
       increment_team_usage: {
         Args: {
-          p_end_at: string;
-          p_limit: number;
-          p_start_at: string;
-          p_team_id: string;
-        };
-        Returns: number;
-      };
+          p_end_at: string
+          p_limit: number
+          p_start_at: string
+          p_team_id: string
+        }
+        Returns: number
+      }
       is_system_project: {
-        Args: { project_id_param: string };
-        Returns: boolean;
-      };
-      is_team_member: { Args: { team_id: string }; Returns: boolean };
+        Args: { project_id_param: string }
+        Returns: boolean
+      }
+      is_team_member: { Args: { team_id: string }; Returns: boolean }
       nanoid: {
-        Args: { alphabet?: string; prefix: string; size?: number };
-        Returns: string;
-      };
-      user_has_post_access: { Args: { post_id: string }; Returns: boolean };
+        Args: { alphabet?: string; prefix: string; size?: number }
+        Returns: string
+      }
+      user_has_post_access: { Args: { post_id: string }; Returns: boolean }
       user_has_post_result_access: {
-        Args: { post_result_id: string };
-        Returns: boolean;
-      };
+        Args: { post_result_id: string }
+        Returns: boolean
+      }
       user_has_project_access: {
-        Args: { project_id: string };
-        Returns: boolean;
-      };
+        Args: { project_id: string }
+        Returns: boolean
+      }
       user_has_webhook_access: {
-        Args: { webhook_id: string };
-        Returns: boolean;
-      };
-    };
+        Args: { webhook_id: string }
+        Returns: boolean
+      }
+    }
     Enums: {
-      delivery_type: 'email';
-      notification_type: 'usage_alert' | 'general';
+      delivery_type: "email"
+      notification_type: "usage_alert" | "general"
       social_post_status:
-        | 'draft'
-        | 'scheduled'
-        | 'processing'
-        | 'posted'
-        | 'processed';
+        | "draft"
+        | "scheduled"
+        | "processing"
+        | "posted"
+        | "processed"
       social_provider:
-        | 'facebook'
-        | 'instagram'
-        | 'x'
-        | 'tiktok'
-        | 'youtube'
-        | 'pinterest'
-        | 'linkedin'
-        | 'bluesky'
-        | 'threads'
-        | 'tiktok_business'
-        | 'instagram_w_facebook';
-      subscription_addon: 'managed_system_credentials';
-      webhook_event_status: 'pending' | 'processing' | 'completed' | 'failed';
+        | "facebook"
+        | "instagram"
+        | "x"
+        | "tiktok"
+        | "youtube"
+        | "pinterest"
+        | "linkedin"
+        | "bluesky"
+        | "threads"
+        | "tiktok_business"
+        | "instagram_w_facebook"
+      subscription_addon: "managed_system_credentials"
+      webhook_event_status: "pending" | "processing" | "completed" | "failed"
       webhook_event_type:
-        | 'social.post.created'
-        | 'social.post.updated'
-        | 'social.post.deleted'
-        | 'social.post.result.created'
-        | 'social.account.created'
-        | 'social.account.updated';
-    };
+        | "social.post.created"
+        | "social.post.updated"
+        | "social.post.deleted"
+        | "social.post.result.created"
+        | "social.account.created"
+        | "social.account.updated"
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<
-  keyof Database,
-  'public'
->];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
-      Row: infer R;
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
-        DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] &
-        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R;
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
       }
       ? R
       : never
-    : never;
+    : never
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Insert: infer I;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
       }
       ? I
       : never
-    : never;
+    : never
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Update: infer U;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
       }
       ? U
       : never
-    : never;
+    : never
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 
 export const Constants = {
   cms: {
@@ -1460,38 +1460,39 @@ export const Constants = {
   },
   public: {
     Enums: {
-      delivery_type: ['email'],
-      notification_type: ['usage_alert', 'general'],
+      delivery_type: ["email"],
+      notification_type: ["usage_alert", "general"],
       social_post_status: [
-        'draft',
-        'scheduled',
-        'processing',
-        'posted',
-        'processed',
+        "draft",
+        "scheduled",
+        "processing",
+        "posted",
+        "processed",
       ],
       social_provider: [
-        'facebook',
-        'instagram',
-        'x',
-        'tiktok',
-        'youtube',
-        'pinterest',
-        'linkedin',
-        'bluesky',
-        'threads',
-        'tiktok_business',
-        'instagram_w_facebook',
+        "facebook",
+        "instagram",
+        "x",
+        "tiktok",
+        "youtube",
+        "pinterest",
+        "linkedin",
+        "bluesky",
+        "threads",
+        "tiktok_business",
+        "instagram_w_facebook",
       ],
-      subscription_addon: ['managed_system_credentials'],
-      webhook_event_status: ['pending', 'processing', 'completed', 'failed'],
+      subscription_addon: ["managed_system_credentials"],
+      webhook_event_status: ["pending", "processing", "completed", "failed"],
       webhook_event_type: [
-        'social.post.created',
-        'social.post.updated',
-        'social.post.deleted',
-        'social.post.result.created',
-        'social.account.created',
-        'social.account.updated',
+        "social.post.created",
+        "social.post.updated",
+        "social.post.deleted",
+        "social.post.result.created",
+        "social.account.created",
+        "social.account.updated",
       ],
     },
   },
-} as const;
+} as const
+

--- a/dashboard/app/lib/.server/database.types.ts
+++ b/dashboard/app/lib/.server/database.types.ts
@@ -139,6 +139,7 @@ export type Database = {
       }
       social_post_media: {
         Row: {
+          alt_text: string | null
           created_at: string
           external_id: string | null
           id: string
@@ -154,6 +155,7 @@ export type Database = {
           url: string
         }
         Insert: {
+          alt_text?: string | null
           created_at?: string
           external_id?: string | null
           id?: string
@@ -169,6 +171,7 @@ export type Database = {
           url: string
         }
         Update: {
+          alt_text?: string | null
           created_at?: string
           external_id?: string | null
           id?: string

--- a/trigger/posting/platforms/bluesky-post-client.ts
+++ b/trigger/posting/platforms/bluesky-post-client.ts
@@ -485,7 +485,7 @@ export class BlueskyPostClient extends PostClient {
       });
 
       images.push({
-        alt: caption || "Image",
+        alt: medium.alt_text || caption || "Image",
         image: uploadResult.data.blob,
         aspectRatio: {
           width,

--- a/trigger/posting/platforms/facebook-post-client.ts
+++ b/trigger/posting/platforms/facebook-post-client.ts
@@ -310,6 +310,7 @@ export class FacebookPostClient extends PostClient {
       access_token: string;
       tags?: any[];
       place?: string;
+      alt_text_custom?: string;
     } = {
       url: fileUrl,
       published: true,
@@ -329,6 +330,10 @@ export class FacebookPostClient extends PostClient {
 
     if (platformConfig?.location) {
       payload.place = platformConfig.location;
+    }
+
+    if (medium.alt_text) {
+      payload.alt_text_custom = medium.alt_text;
     }
 
     this.#requests.push({
@@ -380,6 +385,7 @@ export class FacebookPostClient extends PostClient {
         published: boolean;
         access_token: string;
         tags?: any[];
+        alt_text_custom?: string;
       } = {
         url: fileUrl,
         published: false,
@@ -388,6 +394,10 @@ export class FacebookPostClient extends PostClient {
 
       if (setCaptionForEachImage) {
         payload.message = caption;
+      }
+
+      if (medium.alt_text) {
+        payload.alt_text_custom = medium.alt_text;
       }
 
       if (medium.tags && medium.tags.length > 0) {

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -364,6 +364,7 @@ export class InstagramPostClient extends PostClient {
       location_id?: string;
       user_tags?: any[];
       audio_name?: string;
+      alt_text?: string;
       trial_params?: {
         graduation_strategy: "MANUAL" | "SS_PERFORMANCE";
       };
@@ -372,6 +373,10 @@ export class InstagramPostClient extends PostClient {
       caption: caption,
       access_token: account.access_token,
     };
+
+    if (medium.alt_text) {
+      createMediaParams.alt_text = medium.alt_text;
+    }
 
     switch (platformConfig?.placement) {
       case "stories":
@@ -495,12 +500,17 @@ export class InstagramPostClient extends PostClient {
         product_tags?: any[];
         location_id?: string;
         user_tags?: any[];
+        alt_text?: string;
       } = {
         media_type: isVideo ? "VIDEO" : undefined,
         [isVideo ? "video_url" : "image_url"]: signedUrl,
         is_carousel_item: true,
         access_token: account.access_token,
       };
+
+      if (medium.alt_text) {
+        itemPayload.alt_text = medium.alt_text;
+      }
 
       if (!isVideo && medium.tags && medium.tags.length > 0) {
         itemPayload.user_tags = medium.tags

--- a/trigger/posting/platforms/pinterest-post-client.ts
+++ b/trigger/posting/platforms/pinterest-post-client.ts
@@ -108,13 +108,24 @@ export class PinterestPostClient extends PostClient {
 
       // Create the pin
       const pinTitle = platformConfig?.title?.trim() || caption;
-      const pinData = {
+      const pinData: {
+        board_id: string;
+        title: string;
+        link?: string;
+        description: string;
+        media_source: typeof mediaSource;
+        alt_text?: string;
+      } = {
         board_id: boardId,
         title: pinTitle.slice(0, 100),
         link: platformConfig?.link,
         description: caption.slice(0, 800),
         media_source: mediaSource,
       };
+
+      if (medium.alt_text) {
+        pinData.alt_text = medium.alt_text.slice(0, 500);
+      }
 
       this.#requests.push({ postRequest: pinData });
 

--- a/trigger/posting/platforms/threads-post-client.ts
+++ b/trigger/posting/platforms/threads-post-client.ts
@@ -269,6 +269,7 @@ export class ThreadsPostClient extends PostClient {
                 ? "VIDEO"
                 : "IMAGE",
           [isVideo ? "video_url" : "image_url"]: signedUrl,
+          alt_text: medium.alt_text,
           text: caption,
         },
       },
@@ -285,6 +286,7 @@ export class ThreadsPostClient extends PostClient {
                 ? "VIDEO"
                 : "IMAGE",
           [isVideo ? "video_url" : "image_url"]: signedUrl,
+          alt_text: medium.alt_text,
           text: caption,
         },
         {
@@ -382,6 +384,7 @@ export class ThreadsPostClient extends PostClient {
           params: {
             media_type: isVideo ? "VIDEO" : "IMAGE",
             [isVideo ? "video_url" : "image_url"]: signedUrl,
+            alt_text: medium.alt_text,
             is_carousel_item: true,
           },
         },
@@ -393,6 +396,7 @@ export class ThreadsPostClient extends PostClient {
         {
           media_type: isVideo ? "VIDEO" : "IMAGE",
           [isVideo ? "video_url" : "image_url"]: signedUrl,
+          alt_text: medium.alt_text,
           is_carousel_item: true,
         },
         {

--- a/trigger/posting/platforms/twitter-post-client.ts
+++ b/trigger/posting/platforms/twitter-post-client.ts
@@ -195,6 +195,13 @@ export class TwitterPostClient extends PostClient {
 
       this.#responses.push({ uploadResponse: { mediaId } });
       mediaIds.push(mediaId);
+
+      if (medium.alt_text) {
+        await twitterClient.v1.createMediaMetadata(mediaId, {
+          alt_text: { text: medium.alt_text },
+        });
+      }
+
       // Add a small delay after successful upload
       await wait.for({ seconds: 1 });
     } else {
@@ -213,6 +220,12 @@ export class TwitterPostClient extends PostClient {
 
         this.#responses.push({ uploadResponse: { mediaId } });
         mediaIds.push(mediaId);
+
+        if (medium.alt_text) {
+          await twitterClient.v1.createMediaMetadata(mediaId, {
+            alt_text: { text: medium.alt_text },
+          });
+        }
       }
       // Add a small delay after uploads
       await wait.for({ seconds: 1 });

--- a/trigger/posting/post.types.ts
+++ b/trigger/posting/post.types.ts
@@ -59,6 +59,7 @@ export interface Post {
     thumbnail_timestamp_ms: number | null;
     provider: Provider | null;
     provider_connection_id: string | null;
+    alt_text: string | null;
     tags: UserTag[] | null;
     skip_processing: boolean | null;
   }[];
@@ -99,6 +100,7 @@ export interface PostMedia {
   thumbnail_url?: string | null;
   thumbnail_timestamp_ms?: number | null;
   type: string;
+  alt_text?: string | null;
   tags?: UserTag[] | null;
   skip_processing?: boolean | null;
 }

--- a/trigger/process-post-medium.ts
+++ b/trigger/process-post-medium.ts
@@ -346,6 +346,7 @@ export const processPostMedium = task({
       provider,
       provider_connection_id,
       thumbnail_timestamp_ms,
+      alt_text,
       tags,
       skip_processing,
     },
@@ -357,6 +358,7 @@ export const processPostMedium = task({
       url: string;
       thumbnail_url?: string | null;
       thumbnail_timestamp_ms?: number | null;
+      alt_text?: string | null;
       tags?: UserTag[] | null;
       skip_processing?: boolean | null;
     };
@@ -368,6 +370,7 @@ export const processPostMedium = task({
     thumbnail_url: string;
     thumbnail_timestamp_ms?: number | null;
     type: string;
+    alt_text?: string | null;
     tags?: UserTag[] | null;
     skip_processing?: boolean | null;
   }> => {
@@ -409,6 +412,7 @@ export const processPostMedium = task({
         provider: provider,
         provider_connection_id: provider_connection_id,
         thumbnail_timestamp_ms: thumbnail_timestamp_ms,
+        alt_text,
         tags,
         skip_processing: skip_processing,
       };

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -45,6 +45,7 @@ const transformPostData = (data: {
     thumbnail_timestamp_ms: number | null;
     provider: string | null;
     provider_connection_id: string | null;
+    alt_text?: string | null;
     tags?: Json;
   }[];
   social_post_configurations: {
@@ -60,6 +61,7 @@ const transformPostData = (data: {
       url: media.url,
       thumbnail_url: media.thumbnail_url,
       thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+      alt_text: media.alt_text,
       tags: media.tags as any[],
     }));
 
@@ -79,6 +81,7 @@ const transformPostData = (data: {
               url: media.url,
               thumbnail_url: media.thumbnail_url,
               thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+              alt_text: media.alt_text,
               tags: media.tags as any[],
             })),
           ...configData,
@@ -99,6 +102,7 @@ const transformPostData = (data: {
             url: media.url,
             thumbnail_url: media.thumbnail_url,
             thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+            alt_text: media.alt_text,
             tags: media.tags as any[],
           })),
         ...(config.provider_data as PlatformConfiguration),
@@ -249,6 +253,7 @@ export const processPost = task({
         thumbnail_url: string;
         thumbnail_timestamp_ms?: number | null;
         type: string;
+        alt_text?: string | null;
         tags?: UserTag[] | null;
         skip_processing?: boolean | null;
       }[] = [];
@@ -266,6 +271,7 @@ export const processPost = task({
                 url: medium.url,
                 thumbnail_url: medium.thumbnail_url,
                 thumbnail_timestamp_ms: medium.thumbnail_timestamp_ms,
+                alt_text: medium.alt_text,
                 tags: medium.tags,
                 skip_processing: medium.skip_processing,
               },
@@ -588,6 +594,7 @@ export const processPost = task({
           thumbnail_timestamp_ms,
           provider,
           provider_connection_id,
+          alt_text,
           tags
         ),
         social_post_configurations (

--- a/trigger/process-scheduled-posts.ts
+++ b/trigger/process-scheduled-posts.ts
@@ -40,6 +40,7 @@ export const processScheduledPosts = schedules.task({
               thumbnail_timestamp_ms,
               provider,
               provider_connection_id,
+              alt_text,
               tags,
               skip_processing
             ),

--- a/trigger/process-stuck-processing-posts.ts
+++ b/trigger/process-stuck-processing-posts.ts
@@ -88,6 +88,7 @@ const POST_SELECT = `
     thumbnail_timestamp_ms,
     provider,
     provider_connection_id,
+    alt_text,
     tags,
     skip_processing
   ),

--- a/trigger/supabase.types.ts
+++ b/trigger/supabase.types.ts
@@ -139,6 +139,7 @@ export type Database = {
       }
       social_post_media: {
         Row: {
+          alt_text: string | null
           created_at: string
           external_id: string | null
           id: string
@@ -154,6 +155,7 @@ export type Database = {
           url: string
         }
         Insert: {
+          alt_text?: string | null
           created_at?: string
           external_id?: string | null
           id?: string
@@ -169,6 +171,7 @@ export type Database = {
           url: string
         }
         Update: {
+          alt_text?: string | null
           created_at?: string
           external_id?: string | null
           id?: string


### PR DESCRIPTION
## Summary

Adds alt text support for media attached to posts, so accessibility descriptions can be passed through to platforms that support it. Previously there was no way to set alt text at all — Bluesky was silently reusing the post caption as alt text on every image, which is usually the wrong text.

## Changes

- **Migration**: `social_post_media` gets a new nullable `alt_text` column (`api/supabase/migrations/20260720120000_add_alt_text_to_media.sql`).
- **API**: `SocialPostMediaDto` gains an `alt_text` field; `social-posts.service.ts` threads it through post creation, the post/media select queries, and the response mapper.
- **Trigger**: `PostMedia`/`Post` types and every job that selects or passes media (`process-post`, `process-post-medium`, `process-scheduled-posts`, `process-stuck-processing-posts`) now carry `alt_text` end-to-end.
- **Platform clients** (scoped to platforms with confirmed alt-text support):
  - **Bluesky** — fixes the caption-fallback bug: uses `medium.alt_text`, falling back to caption only when alt text isn't set.
  - **Instagram** — `alt_text` added to media container creation, single and carousel.
  - **Threads** — `alt_text` added to container creation, single and carousel.
  - **Twitter/X** — alt text isn't part of the media upload call, so this adds a follow-up `v1.createMediaMetadata` call after upload when `alt_text` is present.
  - **Facebook** — `alt_text` mapped to `alt_text_custom` on both the published-photo and unpublished-photo (carousel) requests.
  - **Pinterest** — `alt_text` added to pin creation (`pinData.alt_text`), truncated to Pinterest's 500-character limit.
- LinkedIn, TikTok, TikTok Business, and YouTube are intentionally untouched — their APIs either don't support per-media alt text as currently coded, or support is unconfirmed and needs real doc verification (tracked as follow-up, not blocking this PR).
- No dashboard UI changes — `tags` (the closest precedent field) was never surfaced there either, so `alt_text` follows the same pattern. Dashboard's generated `database.types.ts` was refreshed as a byproduct of the migration.

## Testing

- `api`: `bun run lint`, `bun run typecheck`, `bun run typegen` (kanel + supabase) — all pass.
- `trigger`: `bun run typecheck`, `bun run lint` — all pass.
- Verified `twitter-api-v2`'s `v1.createMediaMetadata` signature and `MediaMetadataV1Params` shape directly against the installed package types.
- Local Supabase `db reset` applied the new migration cleanly; types regenerated in `api`, `trigger`, and `dashboard`.
- **Not yet done**: end-to-end verification against live/sandbox accounts on Bluesky, Instagram, Threads, Twitter, Facebook, and Pinterest to confirm the outbound alt-text payloads are accepted. Also worth a quick doc check on Instagram's, Threads', Facebook's (`alt_text_custom`), and Pinterest's `alt_text` param names against current API docs before merging, since they were inferred from existing code patterns rather than confirmed live.

## Notes

Opened as a draft pending the live-platform verification above.

Closes PFM-846

🤖 Generated with AI
