### PR TITLE
feat(dashboard): allow CONTENT_ADMINISTRATOR for LinkedIn

### DIFF
--- a/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
@@ -162,28 +162,47 @@ async function getPageAccounts(
   refreshTokenExpiresAt: Date | undefined
 ): Promise<SocialProviderConnection[]> {
   const accounts: SocialProviderConnection[] = [];
-  const pageResponse = await fetch(
-    "https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED",
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "X-Restli-Protocol-Version": "2.0.0",
-      },
-    }
+  const roles = ["ADMINISTRATOR", "CONTENT_ADMINISTRATOR"];
+
+  const responses = await Promise.all(
+    roles.map(async (role) => {
+      const pageResponse = await fetch(
+        `https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=${role}&state=APPROVED`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "X-Restli-Protocol-Version": "2.0.0",
+          },
+        }
+      );
+
+      if (!pageResponse.ok) {
+        return [];
+      }
+
+      const data = await pageResponse.json();
+
+      return data.elements ?? [];
+    })
   );
 
-  if (!pageResponse.ok) {
-    return accounts;
-  }
+  const elements: { organizationalTarget: string }[] = [
+    ...new Map(
+      responses
+        .flat()
+        .map((element: { organizationalTarget: string }) => [
+          element.organizationalTarget,
+          element,
+        ])
+    ).values(),
+  ];
 
-  const data = await pageResponse.json();
-
-  if (!data.elements) {
+  if (elements.length === 0) {
     return accounts;
   }
 
   await Promise.all(
-    data.elements.map(async (element: { organizationalTarget: string }) => {
+    elements.map(async (element: { organizationalTarget: string }) => {
       try {
         const orgId = element.organizationalTarget.split(":").pop();
 


### PR DESCRIPTION
## Summary

When connecting a LinkedIn account, only pages where the user holds the `ADMINISTRATOR` role were surfaced for connection. Users who are `CONTENT_ADMINISTRATOR` on a page (but not full `ADMINISTRATOR`) had no way to add it, even though that role is sufficient to post on the page's behalf.

## Changes

- `dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts`: `getPageAccounts` now queries LinkedIn's `organizationalEntityAcls` endpoint for both `ADMINISTRATOR` and `CONTENT_ADMINISTRATOR` roles in parallel, merges the results, and dedupes by `organizationalTarget` (in case a user holds both roles on the same org) before the existing per-org enrichment/logo-fetch logic.
- No schema, type, or dependency changes.

## Testing

- `bun run typecheck` — pass
- `bun run lint` — pass
- No existing test suite covers this file (dashboard has no test suite currently), so verification was static (types/lint) only. Recommend manually connecting a LinkedIn account that is a `CONTENT_ADMINISTRATOR`-only on a page to confirm it now appears in the page picker before merging.

Closes PFM-905

🤖 Generated with AI