### PR TITLE
docs: clarify that API dates are UTC (ISO 8601)

### DIFF
--- a/api/src/getting-started.md.ts
+++ b/api/src/getting-started.md.ts
@@ -58,7 +58,9 @@ The below example shows how to create a media post from start to finish.
  \`\`\`js
    // Step 2: Create the post using the social account ids
 
-   // We are scheduling the post one hour from now
+   // We are scheduling the post one hour from now.
+   // All dates are in UTC (ISO 8601) - JSON.stringify() below serializes
+   // this Date to a UTC string automatically.
    const scheduledAt = new Date();
    scheduledAt.setHours(scheduledAt.getHours() + 1);
 

--- a/api/src/social-account-feeds/dto/platform-post.dto.ts
+++ b/api/src/social-account-feeds/dto/platform-post.dto.ts
@@ -23,7 +23,7 @@ export class PlatformPostDto {
   social_post_result_id?: string;
 
   @ApiProperty({
-    description: 'Date the post was published',
+    description: 'Date the post was published, in UTC (ISO 8601)',
     required: false,
     type: Date,
   })

--- a/api/src/social-posts/dto/create-post.dto.ts
+++ b/api/src/social-posts/dto/create-post.dto.ts
@@ -12,7 +12,7 @@ export class CreateSocialPostDto {
 
   @ApiProperty({
     description:
-      'Scheduled date and time for the post, setting to null or undefined will post instantly',
+      'Scheduled date and time for the post in UTC (ISO 8601), setting to null or undefined will post instantly',
     nullable: true,
     required: false,
     type: Date,

--- a/api/src/social-posts/dto/post-configurations.dto.ts
+++ b/api/src/social-posts/dto/post-configurations.dto.ts
@@ -408,7 +408,7 @@ export class YoutubeConfigurationDto extends BaseConfigurationDto {
 
   @ApiProperty({
     description:
-      'ISO 8601 datetime at which the video should be published. Only honoured when privacy_status is "private" (maps to status.publishAt).',
+      'ISO 8601 datetime in UTC at which the video should be published. Only honoured when privacy_status is "private" (maps to status.publishAt).',
     nullable: true,
     required: false,
   })
@@ -433,7 +433,7 @@ export class YoutubeConfigurationDto extends BaseConfigurationDto {
 
   @ApiProperty({
     description:
-      'ISO 8601 date (YYYY-MM-DD) or datetime when the video was recorded (maps to recordingDetails.recordingDate).',
+      'ISO 8601 date (YYYY-MM-DD) or UTC datetime when the video was recorded (maps to recordingDetails.recordingDate).',
     nullable: true,
     required: false,
   })
@@ -723,7 +723,7 @@ export class AccountConfigurationDetailsDto {
 
   @ApiProperty({
     description:
-      'ISO 8601 datetime at which the video should be published. Only honoured when privacy_status is "private" (maps to status.publishAt).',
+      'ISO 8601 datetime in UTC at which the video should be published. Only honoured when privacy_status is "private" (maps to status.publishAt).',
     nullable: true,
     required: false,
   })
@@ -731,7 +731,7 @@ export class AccountConfigurationDetailsDto {
 
   @ApiProperty({
     description:
-      'ISO 8601 date (YYYY-MM-DD) or datetime when the video was recorded (maps to recordingDetails.recordingDate).',
+      'ISO 8601 date (YYYY-MM-DD) or UTC datetime when the video was recorded (maps to recordingDetails.recordingDate).',
     nullable: true,
     required: false,
   })

--- a/api/src/social-posts/dto/post.dto.ts
+++ b/api/src/social-posts/dto/post.dto.ts
@@ -35,7 +35,7 @@ export class SocialPostDto {
   status: PostStatus;
 
   @ApiProperty({
-    description: 'Scheduled date and time for the post',
+    description: 'Scheduled date and time for the post in UTC (ISO 8601)',
     nullable: true,
     type: String,
   })
@@ -71,9 +71,13 @@ export class SocialPostDto {
   })
   social_accounts: SocialAccountDto[];
 
-  @ApiProperty({ description: 'Timestamp when the post was created' })
+  @ApiProperty({
+    description: 'Timestamp when the post was created, in UTC (ISO 8601)',
+  })
   created_at: string;
 
-  @ApiProperty({ description: 'Timestamp when the post was last updated' })
+  @ApiProperty({
+    description: 'Timestamp when the post was last updated, in UTC (ISO 8601)',
+  })
   updated_at: string;
 }

--- a/api/src/social-provider-connections/dto/create-social-account.dto.ts
+++ b/api/src/social-provider-connections/dto/create-social-account.dto.ts
@@ -77,7 +77,8 @@ export class CreateSocialAccountDto {
   refresh_token: string | null | undefined;
 
   @ApiProperty({
-    description: 'The access token expiration date of the social account',
+    description:
+      'The access token expiration date of the social account, in UTC (ISO 8601)',
     type: Date,
     required: true,
   })
@@ -85,7 +86,8 @@ export class CreateSocialAccountDto {
   access_token_expires_at: Date;
 
   @ApiProperty({
-    description: 'The refresh token expiration date of the social account',
+    description:
+      'The refresh token expiration date of the social account, in UTC (ISO 8601)',
     type: Date,
     nullable: true,
     required: false,

--- a/api/src/social-provider-connections/dto/social-accounts.dto.ts
+++ b/api/src/social-provider-connections/dto/social-accounts.dto.ts
@@ -42,13 +42,15 @@ export class SocialAccountDto {
   refresh_token: string | null | undefined;
 
   @ApiProperty({
-    description: 'The access token expiration date of the social account',
+    description:
+      'The access token expiration date of the social account, in UTC (ISO 8601)',
     type: Date,
   })
   access_token_expires_at: string;
 
   @ApiProperty({
-    description: 'The refresh token expiration date of the social account',
+    description:
+      'The refresh token expiration date of the social account, in UTC (ISO 8601)',
     type: Date,
     nullable: true,
   })

--- a/marketing/app/routes/_root.social-media._index/route.component.tsx
+++ b/marketing/app/routes/_root.social-media._index/route.component.tsx
@@ -35,7 +35,7 @@ const platformIcons = [
 
 const postingFeatures = [
   "Publish text, images, and video to any platform in one call",
-  "Schedule posts for future publishing with timezone handling",
+  "Schedule posts for future publishing with UTC (ISO 8601) timestamps",
   "Post to multiple platforms simultaneously",
   "Platform-specific formatting applied automatically",
   "Media transcoding and validation handled for you",
@@ -81,7 +81,7 @@ const faqs = [
   {
     question: "Can I schedule social media posts through the API?",
     answer:
-      'Yes. Set a <code>publish_at</code> timestamp in your API call and Post for Me handles the rest, including timezone handling and platform-specific scheduling rules.',
+      'Yes. Set a <code>scheduled_at</code> timestamp (UTC, ISO 8601) in your API call and Post for Me handles the rest, including platform-specific scheduling rules.',
   },
   {
     question: "Do I need my own platform API credentials to get started?",

--- a/marketing/app/routes/_root.social-media._index/route.meta.ts
+++ b/marketing/app/routes/_root.social-media._index/route.meta.ts
@@ -101,7 +101,7 @@ export const meta: Route.MetaFunction = () => {
             name: "Can I schedule social media posts through the API?",
             acceptedAnswer: {
               "@type": "Answer",
-              text: "Yes. You can schedule posts for future publishing across any supported platform. Set a publish time in your API call and Post for Me handles the rest, including timezone normalization and platform-specific scheduling constraints.",
+              text: "Yes. You can schedule posts for future publishing across any supported platform. Set a scheduled_at timestamp (UTC, ISO 8601) in your API call and Post for Me handles the rest, including platform-specific scheduling constraints.",
             },
           },
           {

--- a/marketing/app/routes/_root.social-media.posting._index/route.component.tsx
+++ b/marketing/app/routes/_root.social-media.posting._index/route.component.tsx
@@ -61,7 +61,7 @@ const postingCapabilities = [
     icon: IconCalendar1,
     title: "Scheduled posting",
     description:
-      "Set a future publish time and Post for Me delivers the post on schedule. Timezone normalization and platform scheduling rules are handled for you.",
+      "Set a future scheduled_at timestamp (UTC, ISO 8601) and Post for Me delivers the post on schedule. Platform scheduling rules are handled for you.",
   },
   {
     icon: IconDraft,
@@ -140,7 +140,7 @@ const faqs = [
   {
     question: "Can I schedule posts for future publishing?",
     answer:
-      'Yes. Include a <code>publish_at</code> timestamp in your API call and Post for Me publishes at the specified time. Timezone normalization and platform-specific scheduling rules are handled for you.',
+      'Yes. Include a <code>scheduled_at</code> timestamp (UTC, ISO 8601) in your API call and Post for Me publishes at the specified time. Platform-specific scheduling rules are handled for you.',
   },
   {
     question: "Can I customize posts per platform?",

--- a/marketing/app/routes/_root.social-media.posting._index/route.meta.ts
+++ b/marketing/app/routes/_root.social-media.posting._index/route.meta.ts
@@ -76,7 +76,7 @@ export const meta: Route.MetaFunction = () => {
         featureList: [
           "Post to 9 platforms through one social media posting API",
           "Captions, images, video, and thumbnails",
-          "Scheduled posting with timezone handling",
+          "Scheduled posting with UTC (ISO 8601) timestamps",
           "Draft mode with TikTok app review",
           "Multi-account posting in a single call",
           "Per-platform customization (YouTube titles, Instagram reels, Pinterest boards, X polls, LinkedIn pages)",
@@ -144,7 +144,7 @@ export const meta: Route.MetaFunction = () => {
             name: "Can I schedule posts for future publishing?",
             acceptedAnswer: {
               "@type": "Answer",
-              text: "Yes. Include a publish_at timestamp in your API call and Post for Me publishes at the specified time, with timezone normalization and platform-specific scheduling rules handled for you.",
+              text: "Yes. Include a scheduled_at timestamp (UTC, ISO 8601) in your API call and Post for Me publishes at the specified time, with platform-specific scheduling rules handled for you.",
             },
           },
           {


### PR DESCRIPTION
## Summary

The API's date/time fields (`scheduled_at`, `created_at`, `updated_at`, `posted_at`, token expiry dates) are already UTC end-to-end at runtime (`timestamptz` columns + `.toISOString()` on write), but neither the Swagger docs nor the marketing copy ever stated this explicitly. This left developers to guess the expected input/output format when integrating.

## Changes

- **`api/src/social-posts/dto/*.dto.ts`, `social-account-feeds/dto/platform-post.dto.ts`, `social-provider-connections/dto/*.dto.ts`**: added "in UTC (ISO 8601)" to `@ApiProperty` descriptions for `scheduled_at`, `created_at`, `updated_at`, `posted_at`, `access_token_expires_at`, `refresh_token_expires_at`, and tightened the YouTube-specific `publish_at`/`recording_date` wording to say UTC explicitly.
- **`api/src/getting-started.md.ts`**: added a comment on the `scheduled_at` example explaining it's UTC and that `JSON.stringify()` serializes the `Date` correctly.
- **`marketing/app/routes/_root.social-media._index/*` and `_root.social-media.posting._index/*`**: replaced vague "timezone handling/normalization" language with concrete "UTC (ISO 8601)" wording in FAQ copy, feature lists, and JSON-LD structured data. Also fixed a factual bug where FAQs told developers to send a `publish_at` timestamp for general scheduling — the real top-level field is `scheduled_at`; `publish_at` only exists nested under YouTube's platform configuration.

No behavior changes — this is documentation/copy only.

## Testing

- `cd api && bun run lint` — pass
- `cd api && bun run build` (nest build / typecheck) — pass
- Marketing changes are plain string-literal edits in FAQ/copy/JSON-LD; `bun run lint`/`typecheck` not run locally (marketing `node_modules` not installed in this environment), but no syntax was touched.

## Notes

Closes PFM-803

🤖 Generated with [Claude Code](https://claude.com/claude-code)