### PR TITLE
fix(dashboard): sync team usage limit on subscription upgrade

### DIFF
--- a/api/supabase/migrations/20260721120000_sync_team_usage_limit.sql
+++ b/api/supabase/migrations/20260721120000_sync_team_usage_limit.sql
@@ -1,0 +1,50 @@
+--
+-- Sync a team's current usage-window limit (e.g. on a Stripe subscription
+-- upgrade/downgrade) without touching count or creating a new window.
+--
+-- increment_team_usage() only sets "limit" when it creates a brand-new
+-- window; if a window is already active it just bumps count and silently
+-- ignores the limit it was passed. That means a mid-cycle plan change
+-- doesn't take effect until the window naturally rolls over. This function
+-- lets a billing event push the new limit into the *current* window
+-- immediately. It intentionally does nothing if there's no active window —
+-- the next real increment_team_usage() call (on the next published post)
+-- will create one with the correct limit anyway.
+CREATE OR REPLACE FUNCTION public.sync_team_usage_limit(
+    p_team_id text,
+    p_limit int
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_now timestamptz := now();
+    v_start_at timestamptz;
+    v_end_at timestamptz;
+BEGIN
+    -- Serialize per team_id so this can't race increment_team_usage's
+    -- read-then-INSERT-or-UPDATE branch for the same team.
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_team_id, 0));
+
+    SELECT tu.start_at, tu.end_at
+    INTO v_start_at, v_end_at
+    FROM public.social_post_team_usage tu
+    WHERE tu.team_id = p_team_id
+    ORDER BY tu.end_at DESC, tu.start_at DESC
+    LIMIT 1
+    FOR UPDATE;
+
+    -- No window yet, or the latest window has already ended: nothing to
+    -- sync. The next increment_team_usage() call creates a fresh window
+    -- with a freshly-computed limit.
+    IF v_start_at IS NULL OR v_end_at <= v_now THEN
+        RETURN;
+    END IF;
+
+    UPDATE public.social_post_team_usage tu
+    SET "limit" = p_limit
+    WHERE tu.team_id = p_team_id
+      AND tu.start_at = v_start_at
+      AND tu.end_at = v_end_at;
+END;
+$$;

--- a/api/supabase/supabase.types.ts
+++ b/api/supabase/supabase.types.ts
@@ -1280,6 +1280,10 @@ export type Database = {
         Args: { alphabet?: string; prefix: string; size?: number };
         Returns: string;
       };
+      sync_team_usage_limit: {
+        Args: { p_limit: number; p_team_id: string };
+        Returns: undefined;
+      };
       user_has_post_access: { Args: { post_id: string }; Returns: boolean };
       user_has_post_result_access: {
         Args: { post_result_id: string };

--- a/dashboard/app/lib/.server/database.types.ts
+++ b/dashboard/app/lib/.server/database.types.ts
@@ -1037,6 +1037,10 @@ export type Database = {
         Args: { alphabet?: string; prefix: string; size?: number }
         Returns: string
       }
+      sync_team_usage_limit: {
+        Args: { p_limit: number; p_team_id: string }
+        Returns: undefined
+      }
       user_has_post_access: { Args: { post_id: string }; Returns: boolean }
       user_has_post_result_access: {
         Args: { post_result_id: string }

--- a/dashboard/app/routes/api.stripe.webhook/.server/subscription-event.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/subscription-event.ts
@@ -1,5 +1,6 @@
 import { updateAPIKeyAccess } from "~/lib/.server/update-api-key-access.request";
 
+import { syncTeamUsageLimit } from "./sync-team-usage-limit";
 import { trackSubscriptionLifecycle } from "./subscription-lifecycle-tracking";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -26,6 +27,13 @@ export async function handleSubscriptionEvent(
     },
     supabaseServiceRole,
   );
+
+  // Sync the team's current usage-window limit so a mid-cycle upgrade/
+  // downgrade takes effect immediately, not on the next window rollover.
+  // Primary side effect: allowed to throw -> 500 -> Stripe retries.
+  if (isSubscriptionActive) {
+    await syncTeamUsageLimit(subscription, supabaseServiceRole);
+  }
 
   // Lifecycle analytics. Best-effort: never let a tracking failure break the
   // Unkey side effect above or the webhook response.

--- a/dashboard/app/routes/api.stripe.webhook/.server/subscription-lifecycle-tracking.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/subscription-lifecycle-tracking.ts
@@ -148,7 +148,7 @@ export async function trackSubscriptionLifecycle(
  * redirect, which would otherwise drop a brand-new customer's conversion).
  * Fall back to the customer-id lookup for existing/older subscriptions.
  */
-async function resolveTeam(
+export async function resolveTeam(
   subscription: Stripe.Subscription,
   supabaseServiceRole: SupabaseClient<Database>,
 ): Promise<TeamRow | null> {

--- a/dashboard/app/routes/api.stripe.webhook/.server/sync-team-usage-limit.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/sync-team-usage-limit.ts
@@ -1,0 +1,30 @@
+import { getSubscriptionPlanInfo } from "~/lib/.server/get-subscription-plan-info";
+import { resolveTeam } from "./subscription-lifecycle-tracking";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Stripe } from "stripe";
+import type { Database } from "~/lib/.server/database.types";
+
+/**
+ * Push a team's current plan's post-limit into the active usage window
+ * immediately, instead of waiting for the window to roll over. No-op if
+ * there's no active window yet, or if the plan doesn't resolve to a known
+ * limit (legacy/unrecognized product — never write null into a NOT NULL column).
+ */
+export async function syncTeamUsageLimit(
+  subscription: Stripe.Subscription,
+  supabaseServiceRole: SupabaseClient<Database>,
+): Promise<void> {
+  const planInfo = getSubscriptionPlanInfo(subscription);
+  if (planInfo.postLimit == null) return;
+
+  const team = await resolveTeam(subscription, supabaseServiceRole);
+  if (!team) return;
+
+  const { error } = await supabaseServiceRole.rpc("sync_team_usage_limit", {
+    p_team_id: team.id,
+    p_limit: planInfo.postLimit,
+  });
+
+  if (error) throw error;
+}

--- a/trigger/supabase.types.ts
+++ b/trigger/supabase.types.ts
@@ -1037,6 +1037,10 @@ export type Database = {
         Args: { alphabet?: string; prefix: string; size?: number }
         Returns: string
       }
+      sync_team_usage_limit: {
+        Args: { p_limit: number; p_team_id: string }
+        Returns: undefined
+      }
       user_has_post_access: { Args: { post_id: string }; Returns: boolean }
       user_has_post_result_access: {
         Args: { post_result_id: string }


### PR DESCRIPTION
## Summary

Upgrading a team's subscription mid-cycle didn't update their post-usage limit — teams stayed capped at their old plan's limit until their billing window naturally rolled over. This fixes it so the limit updates immediately when a subscription is upgraded (or downgraded).

## Changes

- **New migration** `api/supabase/migrations/20260721120000_sync_team_usage_limit.sql`: adds `sync_team_usage_limit(p_team_id, p_limit)`, a sibling RPC to the existing `increment_team_usage`. It patches `"limit"` on the team's current active usage window in place (never touches `count`, never creates a window) — a no-op if no active window exists yet, since the next post-publish will create one with a fresh limit anyway.
- **New** `dashboard/app/routes/api.stripe.webhook/.server/sync-team-usage-limit.ts`: resolves the team and the new plan's post limit (via the existing `getSubscriptionPlanInfo()` → `PRICING_TIERS` computation), then calls the new RPC.
- **`subscription-event.ts`**: calls `syncTeamUsageLimit` as a primary side effect (like the existing `updateAPIKeyAccess` call) whenever an active `customer.subscription.created`/`.updated` event comes in — not wrapped in the existing best-effort analytics `try/catch`, so a failure here causes Stripe to retry.
- **`subscription-lifecycle-tracking.ts`**: exported the existing `resolveTeam` helper for reuse (no behavior change).
- Regenerated Supabase types in `api/`, `dashboard/`, `trigger/` per the repo's cross-sibling typegen convention (reformatted with prettier to keep the diff to just the new RPC entry).

**Known tradeoff (scoped out of this PR):** the new limit is sourced from the dashboard's hardcoded `PRICING_TIERS` table, which is a separate source of truth from the Stripe product-metadata (`social_post_limit`) lookup that `trigger/increment-team-usage.ts` uses when creating a new window. Reconciling the two is out of scope here.

## Testing

- `cd dashboard && bun run typecheck && bun run lint` — pass
- `cd api && bun run lint` / `cd trigger && bun run typecheck && bun run lint` — pass (generated-types-only changes)
- RPC-level verification against local Supabase (`api/supabase:reset` applied, `psql` against `127.0.0.1:54322`):
  - Seeded an active window (`limit=25`) via `increment_team_usage`, called `sync_team_usage_limit(team, 100)`, confirmed `limit` became `100` with `count`/`start_at`/`end_at` unchanged.
  - Called `sync_team_usage_limit` for a team with no usage row at all — confirmed no-op, no row created.
  - Expired the active window (`end_at` in the past), called `sync_team_usage_limit` again — confirmed no-op, limit unchanged.
- Not yet driven through the full Stripe CLI webhook path (`stripe listen` + `stripe trigger customer.subscription.updated`) — the RPC and its callers are covered, but an end-to-end webhook exercise is still worth doing before merge.

## Notes

Follow-up worth considering separately: unify the two post-limit sources of truth (`PRICING_TIERS` vs. Stripe product metadata) so window-creation and upgrade-sync can never disagree.

Closes PFM-789

🤖 Generated with AI