### PR TITLE
fix(dashboard): paginate LinkedIn page account sync

### DIFF
--- a/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
@@ -165,58 +165,62 @@ async function getPageAccounts(
   const aclElements: { organizationalTarget: string }[] = [];
   const pageSize = 100;
   let start = 0;
+  let hasMorePages = true;
 
-  while (true) {
-    const pageUrl = new URL(
-      "https://api.linkedin.com/v2/organizationalEntityAcls"
-    );
-    pageUrl.searchParams.set("q", "roleAssignee");
-    pageUrl.searchParams.set(
-      "role",
-      "List(ADMINISTRATOR,CONTENT_ADMINISTRATOR)"
-    );
-    pageUrl.searchParams.set("state", "APPROVED");
-    pageUrl.searchParams.set("start", String(start));
-    pageUrl.searchParams.set("count", String(pageSize));
+  while (hasMorePages) {
+    try {
+      const pageUrl = new URL(
+        "https://api.linkedin.com/v2/organizationalEntityAcls"
+      );
+      pageUrl.searchParams.set("q", "roleAssignee");
+      pageUrl.searchParams.set(
+        "role",
+        "List(ADMINISTRATOR,CONTENT_ADMINISTRATOR)"
+      );
+      pageUrl.searchParams.set("state", "APPROVED");
+      pageUrl.searchParams.set("start", String(start));
+      pageUrl.searchParams.set("count", String(pageSize));
 
-    const pageResponse = await fetch(pageUrl.toString(), {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "X-Restli-Protocol-Version": "2.0.0",
-      },
-    });
+      const pageResponse = await fetch(pageUrl.toString(), {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "X-Restli-Protocol-Version": "2.0.0",
+        },
+      });
 
-    if (!pageResponse.ok) {
+      if (!pageResponse.ok) {
+        break;
+      }
+
+      const data = (await pageResponse.json()) as {
+        elements?: { organizationalTarget: string }[];
+        paging?: { start?: number; count?: number; total?: number };
+      };
+
+      const currentElements = data.elements ?? [];
+
+      if (currentElements.length === 0) {
+        break;
+      }
+
+      aclElements.push(...currentElements);
+
+      const currentStart = data.paging?.start ?? start;
+      const currentCount = data.paging?.count ?? pageSize;
+      const total = data.paging?.total;
+      const nextStart = currentStart + currentCount;
+      const advanced = nextStart > currentStart;
+
+      start = nextStart;
+      hasMorePages =
+        advanced &&
+        (typeof total === "number"
+          ? start < total
+          : currentCount > 0 && currentElements.length >= currentCount);
+    } catch (error) {
+      console.error("Error fetching LinkedIn organization ACL page:", error);
       break;
     }
-
-    const data = (await pageResponse.json()) as {
-      elements?: { organizationalTarget: string }[];
-      paging?: { start?: number; count?: number; total?: number };
-    };
-
-    const currentElements = data.elements ?? [];
-
-    if (currentElements.length === 0) {
-      break;
-    }
-
-    aclElements.push(...currentElements);
-
-    const currentStart = data.paging?.start ?? start;
-    const currentCount = data.paging?.count ?? pageSize;
-    const total = data.paging?.total;
-    const nextStart = currentStart + currentCount;
-
-    if (typeof total === "number" && nextStart >= total) {
-      break;
-    }
-
-    if (currentElements.length < currentCount) {
-      break;
-    }
-
-    start = nextStart;
   }
 
   if (aclElements.length === 0) {

--- a/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
@@ -162,35 +162,78 @@ async function getPageAccounts(
   refreshTokenExpiresAt: Date | undefined
 ): Promise<SocialProviderConnection[]> {
   const accounts: SocialProviderConnection[] = [];
-  const pageResponse = await fetch(
-    "https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED",
-    {
+  const aclElements: { organizationalTarget: string }[] = [];
+  const pageSize = 100;
+  let start = 0;
+
+  while (true) {
+    const pageUrl = new URL(
+      "https://api.linkedin.com/v2/organizationalEntityAcls"
+    );
+    pageUrl.searchParams.set("q", "roleAssignee");
+    pageUrl.searchParams.set(
+      "role",
+      "List(ADMINISTRATOR,CONTENT_ADMINISTRATOR)"
+    );
+    pageUrl.searchParams.set("state", "APPROVED");
+    pageUrl.searchParams.set("start", String(start));
+    pageUrl.searchParams.set("count", String(pageSize));
+
+    const pageResponse = await fetch(pageUrl.toString(), {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         "X-Restli-Protocol-Version": "2.0.0",
       },
+    });
+
+    if (!pageResponse.ok) {
+      break;
     }
+
+    const data = (await pageResponse.json()) as {
+      elements?: { organizationalTarget: string }[];
+      paging?: { start?: number; count?: number; total?: number };
+    };
+
+    const currentElements = data.elements ?? [];
+
+    if (currentElements.length === 0) {
+      break;
+    }
+
+    aclElements.push(...currentElements);
+
+    const currentStart = data.paging?.start ?? start;
+    const currentCount = data.paging?.count ?? pageSize;
+    const total = data.paging?.total;
+    const nextStart = currentStart + currentCount;
+
+    if (typeof total === "number" && nextStart >= total) {
+      break;
+    }
+
+    if (currentElements.length < currentCount) {
+      break;
+    }
+
+    start = nextStart;
+  }
+
+  if (aclElements.length === 0) {
+    return accounts;
+  }
+
+  const organizationIds = Array.from(
+    new Set(
+      aclElements
+        .map((element) => element.organizationalTarget.split(":").pop())
+        .filter((orgId): orgId is string => Boolean(orgId))
+    )
   );
 
-  if (!pageResponse.ok) {
-    return accounts;
-  }
-
-  const data = await pageResponse.json();
-
-  if (!data.elements) {
-    return accounts;
-  }
-
   await Promise.all(
-    data.elements.map(async (element: { organizationalTarget: string }) => {
+    organizationIds.map(async (orgId) => {
       try {
-        const orgId = element.organizationalTarget.split(":").pop();
-
-        if (!orgId) {
-          return;
-        }
-
         const orgResponse = await fetch(
           `https://api.linkedin.com/v2/organizations/${orgId}`,
           {


### PR DESCRIPTION
## Summary
This updates LinkedIn account discovery so company/page connections are fetched across all ACL pages instead of stopping after the first response.

## Changes
- paginate `organizationalEntityAcls` requests with `start`/`count` until all results are retrieved
- aggregate and de-duplicate organization IDs from paginated ACL responses before fetching org metadata
- include both `ADMINISTRATOR` and `CONTENT_ADMINISTRATOR` roles in the ACL query so content admins are also connected

## Testing
- Not run (code change only)

## Notes
- Existing organization detail/logo fetch behavior is unchanged.

🤖 Generated with AI