### PR TITLE
fix(dashboard): include LinkedIn content admin page ACLs

### DIFF
--- a/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
@@ -162,63 +162,18 @@ async function getPageAccounts(
   refreshTokenExpiresAt: Date | undefined,
 ): Promise<SocialProviderConnection[]> {
   const accounts: SocialProviderConnection[] = [];
-  const aclElements: { organizationalTarget: string }[] = [];
-  const pageSize = 100;
-  let start = 0;
-  let hasMorePages = true;
-
-  while (hasMorePages) {
-    try {
-      const pageUrl = new URL(
-        "https://api.linkedin.com/v2/organizationalEntityAcls",
-      );
-      pageUrl.searchParams.set("q", "roleAssignee");
-      pageUrl.searchParams.set("role", "ADMINISTRATOR");
-      pageUrl.searchParams.set("state", "APPROVED");
-      pageUrl.searchParams.set("start", String(start));
-      pageUrl.searchParams.set("count", String(pageSize));
-
-      const pageResponse = await fetch(pageUrl.toString(), {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "X-Restli-Protocol-Version": "2.0.0",
-        },
-      });
-
-      if (!pageResponse.ok) {
-        break;
-      }
-
-      const data = (await pageResponse.json()) as {
-        elements?: { organizationalTarget: string }[];
-        paging?: { start?: number; count?: number; total?: number };
-      };
-
-      const currentElements = data.elements ?? [];
-
-      if (currentElements.length === 0) {
-        break;
-      }
-
-      aclElements.push(...currentElements);
-
-      const currentStart = data.paging?.start ?? start;
-      const currentCount = data.paging?.count ?? pageSize;
-      const total = data.paging?.total;
-      const nextStart = currentStart + currentCount;
-      const advanced = nextStart > currentStart;
-
-      start = nextStart;
-      hasMorePages =
-        advanced &&
-        (typeof total === "number"
-          ? start < total
-          : currentCount > 0 && currentElements.length >= currentCount);
-    } catch (error) {
-      console.error("Error fetching LinkedIn organization ACL page:", error);
-      break;
-    }
-  }
+  const administratorAclElements = await getAclElementsByRole(
+    accessToken,
+    "ADMINISTRATOR",
+  );
+  const contentAdministratorAclElements = await getAclElementsByRole(
+    accessToken,
+    "CONTENT_ADMINISTRATOR",
+  );
+  const aclElements = [
+    ...administratorAclElements,
+    ...contentAdministratorAclElements,
+  ];
 
   if (aclElements.length === 0) {
     return accounts;
@@ -319,4 +274,69 @@ async function getPageAccounts(
   );
 
   return accounts;
+}
+
+async function getAclElementsByRole(
+  accessToken: string,
+  role: "ADMINISTRATOR" | "CONTENT_ADMINISTRATOR",
+): Promise<{ organizationalTarget: string }[]> {
+  const aclElements: { organizationalTarget: string }[] = [];
+  const pageSize = 100;
+  let start = 0;
+  let hasMorePages = true;
+
+  while (hasMorePages) {
+    try {
+      const pageUrl = new URL(
+        "https://api.linkedin.com/v2/organizationalEntityAcls",
+      );
+      pageUrl.searchParams.set("q", "roleAssignee");
+      pageUrl.searchParams.set("role", role);
+      pageUrl.searchParams.set("state", "APPROVED");
+      pageUrl.searchParams.set("start", String(start));
+      pageUrl.searchParams.set("count", String(pageSize));
+
+      const pageResponse = await fetch(pageUrl.toString(), {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "X-Restli-Protocol-Version": "2.0.0",
+        },
+      });
+
+      if (!pageResponse.ok) {
+        break;
+      }
+
+      const data = (await pageResponse.json()) as {
+        elements?: { organizationalTarget: string }[];
+        paging?: { start?: number; count?: number; total?: number };
+      };
+
+      const currentElements = data.elements ?? [];
+
+      if (currentElements.length === 0) {
+        break;
+      }
+
+      aclElements.push(...currentElements);
+
+      const currentStart = data.paging?.start ?? start;
+      const currentCount = data.paging?.count ?? pageSize;
+      const total = data.paging?.total;
+      const nextStart = currentStart + currentCount;
+      const advanced = nextStart > currentStart;
+
+      start = nextStart;
+      hasMorePages =
+        advanced &&
+        (typeof total === "number"
+          ? start < total
+          : currentCount > 0 && currentElements.length >= currentCount);
+    } catch (error) {
+      console.error("Error fetching LinkedIn organization ACL page:", error);
+      break;
+    }
+  }
+
+  return aclElements;
 }


### PR DESCRIPTION
## Summary
This updates LinkedIn page account discovery to include organizations where the user is a CONTENT_ADMINISTRATOR in addition to ADMINISTRATOR. LinkedIn requires separate ACL requests per role, so both roles are now fetched independently and merged before page hydration.

## Changes
- Extracted LinkedIn ACL pagination into a reusable helper named getAclElementsByRole.
- Added a second paginated ACL fetch for CONTENT_ADMINISTRATOR.
- Merged ADMINISTRATOR and CONTENT_ADMINISTRATOR ACL results before deduping organization IDs.

## Testing
- bun run lint
- bun run typecheck

## Notes
- No schema, dependency, or environment variable changes.

🤖 Generated with AI