### PR TITLE
fix(api,trigger): remove accounts from scheduled posts on delete

### DIFF
--- a/api/src/social-provider-connections/social-provider-connections.controller.ts
+++ b/api/src/social-provider-connections/social-provider-connections.controller.ts
@@ -36,6 +36,7 @@ import { SocialAccountProviderAuthUrlDto } from './dto/provider-auth-url.dto';
 import { SocialProviderAppCredentialsService } from '../social-provider-app-credentials/social-provider-app-credentials.service';
 import { CreateSocialAccountProviderAuthUrlDto } from './dto/create-provider-auth-url.dto';
 import { SocialProviderAppCredentialsDto } from '../social-provider-app-credentials/dto/social-provider-app-credentials.dto';
+import { PostStatus, SocialPostDto } from '../social-posts/dto/post.dto';
 import { createAuthUrlDescription } from './docs/create-auth-url.md';
 import { UpdateSocialAccountDto } from './dto/update-social-account.dto';
 import { CreateSocialAccountDto } from './dto/create-social-account.dto';
@@ -435,7 +436,23 @@ export class SocialAccountsController {
           tasks.trigger(PROCESS_WEBHOOK_TASK, {
             projectId: user.projectId,
             eventType: 'social.post.deleted',
-            eventData: post,
+            // Same shape as the direct post-delete webhook (SocialPostDto).
+            // The post's media/configurations/connections are already gone
+            // by this point (cascaded by delete_social_account), so those
+            // relations come back empty rather than omitted or mismatched.
+            eventData: {
+              id: post.id,
+              external_id: post.external_id,
+              caption: post.caption,
+              status: post.status as unknown as PostStatus,
+              scheduled_at: post.post_at,
+              platform_configurations: null,
+              account_configurations: [],
+              media: [],
+              social_accounts: [],
+              created_at: post.created_at,
+              updated_at: post.updated_at,
+            } satisfies SocialPostDto,
           }),
         ),
       );

--- a/api/src/social-provider-connections/social-provider-connections.controller.ts
+++ b/api/src/social-provider-connections/social-provider-connections.controller.ts
@@ -424,10 +424,23 @@ export class SocialAccountsController {
         );
       }
 
-      return this.socialAccountsService.deleteSocialAccount({
-        id,
-        projectId: user.projectId,
-      });
+      const { deletedPosts, ...deleteResponse } =
+        await this.socialAccountsService.deleteSocialAccount({
+          id,
+          projectId: user.projectId,
+        });
+
+      await Promise.all(
+        deletedPosts.map((post) =>
+          tasks.trigger(PROCESS_WEBHOOK_TASK, {
+            projectId: user.projectId,
+            eventType: 'social.post.deleted',
+            eventData: post,
+          }),
+        ),
+      );
+
+      return deleteResponse;
     } catch (error) {
       console.error(`Error deleting social account ${id}:`, error);
       if (error instanceof HttpException) {

--- a/api/src/social-provider-connections/social-provider-connections.service.ts
+++ b/api/src/social-provider-connections/social-provider-connections.service.ts
@@ -257,24 +257,21 @@ export class SocialAccountsService {
   }: {
     id: string;
     projectId: string;
-  }): Promise<DeleteEntityResponseDto> {
-    const { data, error } = await this.supabaseService.supabaseClient
-      .from('social_provider_connections')
-      .delete()
-      .eq('id', id)
-      .eq('project_id', projectId)
-      .select('id')
-      .maybeSingle();
+  }): Promise<
+    DeleteEntityResponseDto & {
+      deletedPosts: Database['public']['Functions']['delete_social_account']['Returns'];
+    }
+  > {
+    const { data, error } = await this.supabaseService.supabaseServiceRole.rpc(
+      'delete_social_account',
+      { p_id: id, p_project_id: projectId },
+    );
 
     if (error) {
       throw new Error(error.message);
     }
 
-    if (!data) {
-      throw new Error('Social account not found');
-    }
-
-    return { success: true };
+    return { success: true, deletedPosts: data ?? [] };
   }
 
   async createSocialAccount({

--- a/api/supabase/migrations/20260722120000_delete_social_account_fn.sql
+++ b/api/supabase/migrations/20260722120000_delete_social_account_fn.sql
@@ -4,10 +4,13 @@
 -- - Scheduled/draft posts whose ONLY account is this connection are deleted
 --   outright (their child rows cascade via existing FKs), rather than being
 --   left referencing zero accounts.
--- - Media/configuration rows scoped to this connection on posts that still
---   have other accounts are explicitly removed, rather than relying on
---   ON DELETE SET NULL, which would otherwise silently reclassify them as
---   applying to the whole post.
+-- - Media/configuration rows scoped to this connection on *scheduled/draft*
+--   posts that still have other accounts are explicitly removed, rather than
+--   relying on ON DELETE SET NULL, which would otherwise silently reclassify
+--   them as applying to the whole post.
+-- - Media/configuration rows on posts in any other status (e.g. already
+--   published) are left alone so the existing ON DELETE SET NULL FK
+--   preserves them as historical record, instead of deleting the row.
 CREATE OR REPLACE FUNCTION delete_social_account(p_id text, p_project_id text)
     RETURNS TABLE(
         id text,
@@ -62,16 +65,20 @@ deleted_posts AS (
     RETURNING sp.id, sp.external_id, sp.caption, sp.status, sp.post_at, sp.project_id, sp.created_at, sp.updated_at
 ),
 cleared_media AS (
-    DELETE FROM social_post_media spm
-    WHERE spm.provider_connection_id = p_id
+    DELETE FROM social_post_media spm USING social_posts sp
+    WHERE spm.post_id = sp.id
+        AND spm.provider_connection_id = p_id
+        AND sp.status IN ('scheduled', 'draft')
         AND spm.post_id NOT IN (
             SELECT
                 id
             FROM orphaned_posts)
 ),
 cleared_configurations AS (
-    DELETE FROM social_post_configurations spc
-    WHERE spc.provider_connection_id = p_id
+    DELETE FROM social_post_configurations spc USING social_posts sp
+    WHERE spc.post_id = sp.id
+        AND spc.provider_connection_id = p_id
+        AND sp.status IN ('scheduled', 'draft')
         AND spc.post_id NOT IN (
             SELECT
                 id

--- a/api/supabase/migrations/20260722120000_delete_social_account_fn.sql
+++ b/api/supabase/migrations/20260722120000_delete_social_account_fn.sql
@@ -1,0 +1,91 @@
+--
+-- Delete a social account and reconcile scheduled/draft posts that reference it.
+--
+-- - Scheduled/draft posts whose ONLY account is this connection are deleted
+--   outright (their child rows cascade via existing FKs), rather than being
+--   left referencing zero accounts.
+-- - Media/configuration rows scoped to this connection on posts that still
+--   have other accounts are explicitly removed, rather than relying on
+--   ON DELETE SET NULL, which would otherwise silently reclassify them as
+--   applying to the whole post.
+CREATE OR REPLACE FUNCTION delete_social_account(p_id text, p_project_id text)
+    RETURNS TABLE(
+        id text,
+        external_id text,
+        caption text,
+        status social_post_status,
+        post_at timestamptz,
+        project_id text,
+        created_at timestamptz,
+        updated_at timestamptz)
+    AS $$
+#variable_conflict use_column
+BEGIN
+    IF NOT EXISTS (
+        SELECT
+            1
+        FROM
+            social_provider_connections spc
+        WHERE
+            spc.id = p_id
+            AND spc.project_id = p_project_id) THEN
+    RAISE EXCEPTION 'Social account not found';
+END IF;
+
+    RETURN QUERY WITH orphaned_posts AS (
+        SELECT
+            sp.id
+        FROM
+            social_posts sp
+        WHERE
+            sp.project_id = p_project_id
+            AND sp.status IN ('scheduled', 'draft')
+            AND EXISTS (
+                SELECT
+                    1
+                FROM
+                    social_post_provider_connections sppc
+                WHERE
+                    sppc.post_id = sp.id
+                    AND sppc.provider_connection_id = p_id)
+                AND (
+                    SELECT
+                        count(*)
+                    FROM
+                        social_post_provider_connections sppc
+                    WHERE
+                        sppc.post_id = sp.id) = 1
+),
+deleted_posts AS (
+    DELETE FROM social_posts sp USING orphaned_posts op
+    WHERE sp.id = op.id
+    RETURNING sp.id, sp.external_id, sp.caption, sp.status, sp.post_at, sp.project_id, sp.created_at, sp.updated_at
+),
+cleared_media AS (
+    DELETE FROM social_post_media spm
+    WHERE spm.provider_connection_id = p_id
+        AND spm.post_id NOT IN (
+            SELECT
+                id
+            FROM orphaned_posts)
+),
+cleared_configurations AS (
+    DELETE FROM social_post_configurations spc
+    WHERE spc.provider_connection_id = p_id
+        AND spc.post_id NOT IN (
+            SELECT
+                id
+            FROM orphaned_posts)
+),
+deleted_connection AS (
+    DELETE FROM social_provider_connections spc
+    WHERE spc.id = p_id
+        AND spc.project_id = p_project_id
+)
+    SELECT
+        *
+    FROM
+        deleted_posts;
+END;
+$$
+LANGUAGE plpgsql;

--- a/api/supabase/supabase.types.ts
+++ b/api/supabase/supabase.types.ts
@@ -1238,6 +1238,19 @@ export type Database = {
       };
     };
     Functions: {
+      delete_social_account: {
+        Args: { p_id: string; p_project_id: string };
+        Returns: {
+          caption: string;
+          created_at: string;
+          external_id: string;
+          id: string;
+          post_at: string;
+          project_id: string;
+          status: Database['public']['Enums']['social_post_status'];
+          updated_at: string;
+        }[];
+      };
       get_exceeded_team_usage_windows: {
         Args: never;
         Returns: {

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -6,6 +6,7 @@ import type {
   PlatformConfiguration,
   Post,
   PostResult,
+  SocialAccount,
   UserTag,
 } from "./posting/post.types";
 import { Unkey } from "@unkey/api";
@@ -152,16 +153,32 @@ export const processPost = task({
 
     await tags.add([`${post.id}`, `${post.project_id}`]);
 
-    logger.info("Getting post accounts");
-    const accounts = post.social_post_provider_connections?.map(
-      ({ social_provider_connections: connection }) => ({
-        ...connection,
-      }),
-    );
-
     const errorResults: PostResult[] = [];
 
     try {
+      logger.info("Getting post accounts");
+      // Re-fetch live rather than trusting payload.post, which is a snapshot
+      // taken by process-scheduled-posts before this task was queued/run —
+      // an account deleted in that window would otherwise be posted to using
+      // stale, already-deleted connection data.
+      const { data: liveConnections, error: liveConnectionsError } =
+        await supabaseClient
+          .from("social_post_provider_connections")
+          .select("social_provider_connections (*)")
+          .eq("post_id", post.id);
+
+      if (liveConnectionsError) {
+        logger.error("Failed to fetch live post accounts", {
+          error: liveConnectionsError,
+        });
+        throw new Error(liveConnectionsError.message);
+      }
+
+      const accounts = liveConnections?.map(
+        ({ social_provider_connections: connection }) =>
+          ({ ...connection }) as unknown as SocialAccount,
+      );
+
       if (!accounts || accounts.length === 0) {
         logger.error("No accounts found for post", { post });
         return [];

--- a/trigger/supabase.types.ts
+++ b/trigger/supabase.types.ts
@@ -995,6 +995,19 @@ export type Database = {
       }
     }
     Functions: {
+      delete_social_account: {
+        Args: { p_id: string; p_project_id: string }
+        Returns: {
+          caption: string
+          created_at: string
+          external_id: string
+          id: string
+          post_at: string
+          project_id: string
+          status: Database["public"]["Enums"]["social_post_status"]
+          updated_at: string
+        }[]
+      }
       get_exceeded_team_usage_windows: {
         Args: never
         Returns: {


### PR DESCRIPTION
## Summary

Deleting a social account should fully remove it from scheduled posts, not just silently drop a join row. Previously, deleting an account left posts referencing zero accounts silently "processed" with no results, leaked that account's per-account media/caption overrides onto the post's remaining accounts, and left a race where an in-flight post could still try to post using a just-deleted account's stale, cached credentials.

## Changes

- **New migration** `api/supabase/migrations/20260722120000_delete_social_account_fn.sql`: adds an atomic `delete_social_account(p_id, p_project_id)` Postgres function that, in one transaction:
  - Deletes any scheduled/draft post whose *only* account is the one being removed (cascades clean up its child rows).
  - Explicitly removes `social_post_media` / `social_post_configurations` rows scoped to the deleted connection on **scheduled/draft** posts that still have other accounts, instead of relying on `ON DELETE SET NULL` (which silently reclassified per-account overrides as post-wide).
  - Leaves `social_post_media` / `social_post_configurations` alone on posts in any other status (e.g. already published) so the existing `ON DELETE SET NULL` FK preserves them as historical record, instead of deleting the row outright.
  - Deletes the connection itself and returns the list of auto-deleted posts.
- `api/src/social-provider-connections/social-provider-connections.service.ts`: `deleteSocialAccount` now calls the new RPC via the service-role client instead of a plain `.delete()`.
- `api/src/social-provider-connections/social-provider-connections.controller.ts`: fires a `social.post.deleted` webhook for each auto-deleted post, shaped to match the existing `SocialPostDto` payload used by the direct post-delete endpoint (`scheduled_at` instead of raw `post_at`, no stray `project_id`). Since the post's media/configurations/connections are already gone by the time the cascade completes, those relations come back as empty arrays rather than omitted or mismatched.
- `trigger/process-post.ts`: fetches the post's accounts live at run time instead of trusting the `payload.post` snapshot taken by `process-scheduled-posts` — closes the race where an account deleted between scheduling and actual processing would still be posted to.
- Regenerated `api/supabase/supabase.types.ts` and `trigger/supabase.types.ts` for the new RPC.

No new env vars or app-level dependencies. One new DB migration (see above).

## Testing

Verified end-to-end against a local Supabase instance (`supabase db reset` to apply the migration), driving the actual `delete_social_account` RPC and the trigger's live-refetch query with realistic fixtures rather than relying on typecheck/lint alone:

- Scheduled post with only the deleted account → post deleted (returned in `RETURNING`).
- Draft post with only the deleted account → also deleted.
- Scheduled post with two accounts, one with a per-account media override → post survives, the deleted account's media/config removed, the surviving account's own media/config untouched.
- **Published post whose only account is the one being deleted → post and its media/config rows survive**, media's `provider_connection_id` set to `NULL` by the existing FK rather than the row being deleted. (This was a real gap in the original migration — the cleanup CTEs weren't scoped by post status, so they deleted media/config rows on already-published posts too. Fixed and re-verified.)
- Unrelated post referencing a different account → untouched.
- Deleting a nonexistent account id, and deleting an account id that belongs to a different project → both raise a clean "Social account not found", confirming project scoping holds.
- Confirmed `bun run supabase:typegen` output is byte-identical to the checked-in types in both `api/` and `trigger/`.
- Confirmed the `process-post.ts` live-refetch query correctly returns only the surviving account after a mid-flight deletion (the staleness bug the diff targets).
- `bun run build`, `bun run lint`, and `bun run typecheck` all pass in `api/`.

Not driven live: the full HTTP round-trip through the running Nest API and an actual webhook delivery to a receiver — both require real Unkey key verification and Trigger.dev task dispatch against shared cloud credentials, which weren't exercised to avoid side effects on those shared accounts.

## Notes

`process-post.ts`'s existing behavior for a post that genuinely ends up with zero accounts (mark `"processed"`, no results, log an error) is unchanged — no new `social_posts` status was introduced for this, per scope discussion.

Closes PFM-766

🤖 Generated with AI
