### PR TITLE
feat: allow deleting published posts from connected platforms

### DIFF
--- a/api/src/social-post-results/dto/post-results.dto.ts
+++ b/api/src/social-post-results/dto/post-results.dto.ts
@@ -21,6 +21,21 @@ export class SocialPostResultDto {
   details: any;
 
   @ApiProperty({
+    description: 'Status of deleting this result from the platform',
+    enum: ['not_deleted', 'deleting', 'deleted', 'delete_failed'],
+  })
+  delete_status: 'not_deleted' | 'deleting' | 'deleted' | 'delete_failed';
+
+  @ApiProperty({ description: 'Error message if platform deletion failed' })
+  delete_error_message: string | null;
+
+  @ApiProperty({
+    description: 'Timestamp when the post was deleted from the platform',
+    nullable: true,
+  })
+  deleted_at: string | null;
+
+  @ApiProperty({
     description: 'Platform-specific data',
     type: 'object',
     properties: {

--- a/api/src/social-post-results/social-post-results.service.ts
+++ b/api/src/social-post-results/social-post-results.service.ts
@@ -27,6 +27,9 @@ export class PostResultsService {
       post_id: string;
       provider_connection_id: string;
       error_message?: string;
+      delete_status: string;
+      delete_error_message?: string;
+      deleted_at?: string;
       media?: SocialPostResultDto['media'];
     };
   }> {
@@ -34,7 +37,7 @@ export class PostResultsService {
       await this.supabaseService.supabaseClient
         .from('social_post_results')
         .select(
-          'id, success, provider_post_id, provider_post_url, details, post_id, provider_connection_id, error_message, social_provider_connections(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
+          'id, success, provider_post_id, provider_post_url, details, post_id, provider_connection_id, error_message, delete_status, delete_error_message, deleted_at, social_provider_connections(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
         )
         .eq('id', id)
         .eq('social_provider_connections.project_id', projectId)
@@ -54,6 +57,9 @@ export class PostResultsService {
         post_id: postResult?.post_id,
         provider_connection_id: postResult?.provider_connection_id,
         error_message: postResult?.error_message || undefined,
+        delete_status: postResult?.delete_status,
+        delete_error_message: postResult?.delete_error_message || undefined,
+        deleted_at: postResult?.deleted_at || undefined,
         media:
           postResult?.social_post_result_post_media?.map((resultMedia) => ({
             url: resultMedia.social_post_media.url,
@@ -125,7 +131,7 @@ export class PostResultsService {
     const query = this.supabaseService.supabaseClient
       .from('social_post_results')
       .select(
-        'id, provider_connection_id, post_id, success, error_message, details, provider_post_id, provider_post_url, created_at, social_provider_connections!inner(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
+        'id, provider_connection_id, post_id, success, error_message, details, provider_post_id, provider_post_url, created_at, delete_status, delete_error_message, deleted_at, social_provider_connections!inner(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
       )
       .eq('social_provider_connections.project_id', projectId)
       .in(
@@ -200,6 +206,9 @@ export class PostResultsService {
         error: raw.error_message,
         details: raw.details,
         platform_data,
+        delete_status: raw.delete_status,
+        delete_error_message: raw.delete_error_message,
+        deleted_at: raw.deleted_at,
         media:
           raw.social_post_result_post_media?.map((resultMedia) => ({
             url: resultMedia.social_post_media.url,
@@ -246,6 +255,10 @@ export class PostResultsService {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       details: postResults.data.details,
       platform_data,
+      delete_status: postResults.data
+        .delete_status as SocialPostResultDto['delete_status'],
+      delete_error_message: postResults.data.delete_error_message || null,
+      deleted_at: postResults.data.deleted_at || null,
       media: postResults.data.media || [],
     };
 

--- a/api/src/social-posts/delete-capability.ts
+++ b/api/src/social-posts/delete-capability.ts
@@ -1,0 +1,68 @@
+import { DELETE_SUPPORTED_PROVIDERS } from './social-posts.constants';
+
+/**
+ * Extra OAuth scope a provider requires specifically to delete a published post
+ * (beyond what publishing needs). Providers not listed here need no extra scope.
+ */
+const REQUIRED_DELETE_SCOPE: Record<string, string> = {
+  instagram: 'instagram_manage_contents',
+  threads: 'threads_delete',
+};
+
+export type DeleteSupport =
+  | { supported: true }
+  | { supported: false; reason: string };
+
+/**
+ * Determines whether a published post on a given connection can be deleted from
+ * the platform, and if not, a human-readable reason (used for API errors and the
+ * dashboard reconnect prompt). `grantedScopes` comes from
+ * `social_provider_metadata.granted_scopes`, captured at connect time.
+ */
+export function evaluateDeleteSupport({
+  provider,
+  connectionType,
+  grantedScopes,
+}: {
+  provider: string | null | undefined;
+  connectionType?: string | null;
+  grantedScopes?: string[] | null;
+}): DeleteSupport {
+  if (
+    !provider ||
+    !(DELETE_SUPPORTED_PROVIDERS as string[]).includes(provider)
+  ) {
+    return {
+      supported: false,
+      reason: `${provider ?? 'this platform'} does not support deleting published posts`,
+    };
+  }
+
+  // Instagram deletion is only available for accounts connected with "Login with
+  // Facebook"; the Instagram Login API cannot delete media at all.
+  if (provider === 'instagram' && connectionType === 'instagram') {
+    return {
+      supported: false,
+      reason:
+        'instagram (reconnect with "Login with Facebook" to enable deletion)',
+    };
+  }
+
+  const requiredScope = REQUIRED_DELETE_SCOPE[provider];
+  if (requiredScope && !(grantedScopes ?? []).includes(requiredScope)) {
+    return {
+      supported: false,
+      reason: `${provider} (reconnect the account to grant deletion permission)`,
+    };
+  }
+
+  return { supported: true };
+}
+
+export function connectionSupportsDelete(args: {
+  provider: string | null | undefined;
+  connectionType?: string | null;
+  grantedScopes?: string[] | null;
+}): boolean {
+  return evaluateDeleteSupport(args).supported;
+}

--- a/api/src/social-posts/dto/post.dto.ts
+++ b/api/src/social-posts/dto/post.dto.ts
@@ -11,6 +11,9 @@ export enum PostStatus {
   SCHEDULED = 'scheduled',
   PROCESSING = 'processing',
   PROCESSED = 'processed',
+  DELETING = 'deleting',
+  DELETED = 'deleted',
+  DELETE_FAILED = 'delete_failed',
 }
 
 export class SocialPostDto {

--- a/api/src/social-posts/social-posts.constants.ts
+++ b/api/src/social-posts/social-posts.constants.ts
@@ -1,0 +1,14 @@
+import type { Database } from '../../supabase';
+
+type ProviderTypeEnum = Database['public']['Enums']['social_provider'];
+
+export const DELETE_SUPPORTED_PROVIDERS: ProviderTypeEnum[] = [
+  'x',
+  'instagram',
+  'facebook',
+  'linkedin',
+  'bluesky',
+  'threads',
+  'pinterest',
+  'youtube',
+];

--- a/api/src/social-posts/social-posts.controller.ts
+++ b/api/src/social-posts/social-posts.controller.ts
@@ -316,27 +316,57 @@ export class SocialPostsController {
     }
 
     if (
-      post.status !== PostStatus.SCHEDULED &&
-      post.status !== PostStatus.DRAFT
+      post.status === PostStatus.SCHEDULED ||
+      post.status === PostStatus.DRAFT
     ) {
-      throw new HttpException('Can only delete scheduled or draft posts', 400);
+      try {
+        const deleteResponse = await this.postsService.deletePost({
+          postId: params.id,
+          projectId: user.projectId,
+        });
+
+        await tasks.trigger(PROCESS_WEBHOOK_TASK, {
+          projectId: user.projectId,
+          eventType: 'social.post.deleted',
+          eventData: post,
+        });
+        return deleteResponse;
+      } catch (error) {
+        console.error('[deletePost] Error:', error);
+        throw new HttpException('Internal Server Error', 500);
+      }
     }
 
-    try {
-      const deleteResponse = await this.postsService.deletePost({
-        postId: params.id,
-        projectId: user.projectId,
-      });
+    if (post.status === PostStatus.PROCESSED) {
+      try {
+        const unsupportedProviders =
+          await this.postsService.getUnsupportedDeleteProviders(
+            params.id,
+            user.projectId,
+          );
 
-      await tasks.trigger(PROCESS_WEBHOOK_TASK, {
-        projectId: user.projectId,
-        eventType: 'social.post.deleted',
-        eventData: post,
-      });
-      return deleteResponse;
-    } catch (error) {
-      console.error('[deletePost] Error:', error);
-      throw new HttpException('Internal Server Error', 500);
+        if (unsupportedProviders.length > 0) {
+          throw new HttpException(
+            `Cannot delete post: it was published to platform(s) that do not support deletion (${unsupportedProviders.join(', ')}).`,
+            400,
+          );
+        }
+
+        await this.postsService.triggerDeleteFromPlatforms({
+          postId: params.id,
+          projectId: user.projectId,
+        });
+
+        return { success: true };
+      } catch (error) {
+        if (error instanceof HttpException) {
+          throw error;
+        }
+        console.error('[deletePost] Error:', error);
+        throw new HttpException('Internal Server Error', 500);
+      }
     }
+
+    throw new HttpException('Cannot delete post in its current status', 400);
   }
 }

--- a/api/src/social-posts/social-posts.controller.ts
+++ b/api/src/social-posts/social-posts.controller.ts
@@ -339,15 +339,15 @@ export class SocialPostsController {
 
     if (post.status === PostStatus.PROCESSED) {
       try {
-        const unsupportedProviders =
-          await this.postsService.getUnsupportedDeleteProviders(
+        const undeletableReasons =
+          await this.postsService.getUndeletableReasons(
             params.id,
             user.projectId,
           );
 
-        if (unsupportedProviders.length > 0) {
+        if (undeletableReasons.length > 0) {
           throw new HttpException(
-            `Cannot delete post: it was published to platform(s) that do not support deletion (${unsupportedProviders.join(', ')}).`,
+            `Cannot delete post from one or more platforms: ${undeletableReasons.join('; ')}.`,
             400,
           );
         }

--- a/api/src/social-posts/social-posts.module.ts
+++ b/api/src/social-posts/social-posts.module.ts
@@ -3,9 +3,14 @@ import { SocialPostsController } from './social-posts.controller';
 import { SocialPostsService } from './social-posts.service';
 import { PaginationModule } from '../pagination/pagination.module';
 import { SocialPostMetersModule } from '../social-post-meters/social-post-meters.module';
+import { SocialProviderAppCredentialsModule } from '../social-provider-app-credentials/social-provider-app-credentials.module';
 
 @Module({
-  imports: [PaginationModule, SocialPostMetersModule],
+  imports: [
+    PaginationModule,
+    SocialPostMetersModule,
+    SocialProviderAppCredentialsModule,
+  ],
   controllers: [SocialPostsController],
   providers: [SocialPostsService],
 })

--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -16,6 +16,9 @@ import {
 import { Database, Json } from '../../supabase';
 import { PostValidation } from './dto/post-validation.dto';
 import { SocialPostMetersService } from '../social-post-meters/social-post-meters.service';
+import { SocialProviderAppCredentialsService } from '../social-provider-app-credentials/social-provider-app-credentials.service';
+import { SocialProviderAppCredentialsDto } from '../social-provider-app-credentials/dto/social-provider-app-credentials.dto';
+import { DELETE_SUPPORTED_PROVIDERS } from './social-posts.constants';
 
 type ProviderTypeEnum = Database['public']['Enums']['social_provider'];
 
@@ -26,6 +29,7 @@ export class SocialPostsService {
   constructor(
     private readonly supabaseService: SupabaseService,
     private readonly socialPostMetersService: SocialPostMetersService,
+    private readonly socialProviderAppCredentialsService: SocialProviderAppCredentialsService,
   ) {}
 
   async getPostData(postId: string): Promise<any> {
@@ -777,6 +781,196 @@ export class SocialPostsService {
       console.error(err);
       return { success: false };
     }
+  }
+
+  async getUnsupportedDeleteProviders(
+    postId: string,
+    projectId: string,
+  ): Promise<string[]> {
+    const { data, error } = await this.supabaseService.supabaseClient
+      .from('social_post_results')
+      .select('social_provider_connections!inner(provider, project_id)')
+      .eq('post_id', postId)
+      .eq('social_provider_connections.project_id', projectId)
+      .eq('success', true)
+      .not('provider_post_id', 'is', null);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const providers = new Set(
+      (data || []).map((row) => row.social_provider_connections.provider),
+    );
+
+    return Array.from(providers).filter(
+      (provider) => !DELETE_SUPPORTED_PROVIDERS.includes(provider),
+    );
+  }
+
+  private resolveDeleteAppCredentials({
+    provider,
+    connectionType,
+    credentials,
+  }: {
+    provider: ProviderTypeEnum;
+    connectionType: string | undefined;
+    credentials: SocialProviderAppCredentialsDto[];
+  }): { app_id: string; app_secret: string } | null {
+    if (provider === 'bluesky') {
+      return {
+        app_id: 'blue_sky_app_id',
+        app_secret: 'blue_sky_app_secret',
+      };
+    }
+
+    let match: SocialProviderAppCredentialsDto | undefined;
+
+    if (provider === 'instagram') {
+      switch (connectionType) {
+        case 'instagram':
+          match = credentials.find((c) => c.provider === 'instagram');
+          break;
+        case 'facebook':
+          match = credentials.find(
+            (c) => c.provider === 'instagram_w_facebook',
+          );
+          break;
+        default:
+          match = credentials.find(
+            (c) =>
+              c.provider === provider || c.provider === 'instagram_w_facebook',
+          );
+          break;
+      }
+    } else {
+      match = credentials.find((c) => c.provider === provider);
+    }
+
+    if (!match) {
+      return null;
+    }
+
+    return { app_id: match.appId, app_secret: match.appSecret };
+  }
+
+  async triggerDeleteFromPlatforms({
+    postId,
+    projectId,
+  }: {
+    postId: string;
+    projectId: string;
+  }): Promise<void> {
+    const { data: results, error } = await this.supabaseService.supabaseClient
+      .from('social_post_results')
+      .select(
+        `
+        id,
+        post_id,
+        provider_post_id,
+        social_provider_connections!inner (
+          id,
+          provider,
+          project_id,
+          social_provider_user_name,
+          social_provider_user_id,
+          access_token,
+          refresh_token,
+          access_token_expires_at,
+          refresh_token_expires_at,
+          social_provider_metadata
+        )
+        `,
+      )
+      .eq('post_id', postId)
+      .eq('social_provider_connections.project_id', projectId)
+      .eq('success', true)
+      .not('provider_post_id', 'is', null);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    if (!results || results.length === 0) {
+      return;
+    }
+
+    const providers = Array.from(
+      new Set(results.map((r) => r.social_provider_connections.provider)),
+    );
+
+    const credentials =
+      (await this.socialProviderAppCredentialsService.getManySocialProviderAppCredentials(
+        [...providers, 'instagram_w_facebook'],
+        projectId,
+      )) || [];
+
+    const items = results
+      .map((result) => {
+        const connection = result.social_provider_connections;
+        const appCredentials = this.resolveDeleteAppCredentials({
+          provider: connection.provider,
+          connectionType: (
+            connection.social_provider_metadata as { connection_type?: string }
+          )?.connection_type,
+          credentials,
+        });
+
+        if (!appCredentials) {
+          return null;
+        }
+
+        return {
+          payload: {
+            resultId: result.id,
+            postId: result.post_id,
+            projectId,
+            platform: connection.provider,
+            account: {
+              id: connection.id,
+              provider: connection.provider,
+              social_provider_user_name: connection.social_provider_user_name,
+              social_provider_user_id: connection.social_provider_user_id,
+              access_token: connection.access_token,
+              refresh_token: connection.refresh_token,
+              access_token_expires_at: connection.access_token_expires_at
+                ? new Date(connection.access_token_expires_at)
+                : null,
+              refresh_token_expires_at: connection.refresh_token_expires_at
+                ? new Date(connection.refresh_token_expires_at)
+                : null,
+              social_provider_metadata: connection.social_provider_metadata,
+            },
+            providerPostId: result.provider_post_id,
+            appCredentials,
+          },
+          options: {
+            idempotencyKey: `delete-from-platform:${result.id}`,
+            idempotencyKeyTTL: '1h',
+          },
+        };
+      })
+      .filter((item): item is NonNullable<typeof item> => item !== null);
+
+    if (items.length === 0) {
+      return;
+    }
+
+    await this.supabaseService.supabaseClient
+      .from('social_posts')
+      .update({ status: 'deleting' })
+      .eq('id', postId)
+      .eq('project_id', projectId);
+
+    await this.supabaseService.supabaseClient
+      .from('social_post_results')
+      .update({ delete_status: 'deleting' })
+      .in(
+        'id',
+        items.map((item) => item.payload.resultId),
+      );
+
+    await tasks.batchTrigger('delete-from-platform', items);
   }
 
   private async triggerPost(postId: string): Promise<void> {

--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -956,6 +956,8 @@ export class SocialPostsService {
       return;
     }
 
+    const resultIds = items.map((item) => item.payload.resultId);
+
     await this.supabaseService.supabaseClient
       .from('social_posts')
       .update({ status: 'deleting' })
@@ -965,12 +967,27 @@ export class SocialPostsService {
     await this.supabaseService.supabaseClient
       .from('social_post_results')
       .update({ delete_status: 'deleting' })
-      .in(
-        'id',
-        items.map((item) => item.payload.resultId),
-      );
+      .in('id', resultIds);
 
-    await tasks.batchTrigger('delete-from-platform', items);
+    try {
+      await tasks.batchTrigger('delete-from-platform', items);
+    } catch (error) {
+      // If we can't enqueue the delete tasks, roll the statuses back so the
+      // post isn't stranded in `deleting` with nothing to finalize it.
+      await this.supabaseService.supabaseClient
+        .from('social_posts')
+        .update({ status: 'processed' })
+        .eq('id', postId)
+        .eq('project_id', projectId)
+        .eq('status', 'deleting');
+
+      await this.supabaseService.supabaseClient
+        .from('social_post_results')
+        .update({ delete_status: 'not_deleted' })
+        .in('id', resultIds);
+
+      throw error;
+    }
   }
 
   private async triggerPost(postId: string): Promise<void> {

--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -18,7 +18,10 @@ import { PostValidation } from './dto/post-validation.dto';
 import { SocialPostMetersService } from '../social-post-meters/social-post-meters.service';
 import { SocialProviderAppCredentialsService } from '../social-provider-app-credentials/social-provider-app-credentials.service';
 import { SocialProviderAppCredentialsDto } from '../social-provider-app-credentials/dto/social-provider-app-credentials.dto';
-import { DELETE_SUPPORTED_PROVIDERS } from './social-posts.constants';
+import {
+  connectionSupportsDelete,
+  evaluateDeleteSupport,
+} from './delete-capability';
 
 type ProviderTypeEnum = Database['public']['Enums']['social_provider'];
 
@@ -502,7 +505,8 @@ export class SocialPostsService {
             refresh_token,
             access_token_expires_at,
             refresh_token_expires_at,
-            external_id
+            external_id,
+            social_provider_metadata
           )
         ),
         social_post_media (
@@ -568,7 +572,8 @@ export class SocialPostsService {
             refresh_token,
             access_token_expires_at,
             refresh_token_expires_at,
-            external_id
+            external_id,
+            social_provider_metadata
           )
         ),
         social_post_media (
@@ -783,13 +788,22 @@ export class SocialPostsService {
     }
   }
 
-  async getUnsupportedDeleteProviders(
+  /**
+   * Returns a de-duplicated list of human-readable reasons why a published post
+   * cannot be fully deleted from its platforms — e.g. an unsupported provider, an
+   * Instagram account connected via Instagram Login, or an account that must be
+   * reconnected to grant the deletion permission. Empty when every published
+   * result can be deleted.
+   */
+  async getUndeletableReasons(
     postId: string,
     projectId: string,
   ): Promise<string[]> {
     const { data, error } = await this.supabaseService.supabaseClient
       .from('social_post_results')
-      .select('social_provider_connections!inner(provider, project_id)')
+      .select(
+        'social_provider_connections!inner(provider, project_id, social_provider_metadata)',
+      )
       .eq('post_id', postId)
       .eq('social_provider_connections.project_id', projectId)
       .eq('success', true)
@@ -799,13 +813,27 @@ export class SocialPostsService {
       throw new Error(error.message);
     }
 
-    const providers = new Set(
-      (data || []).map((row) => row.social_provider_connections.provider),
-    );
+    const reasons = new Set<string>();
 
-    return Array.from(providers).filter(
-      (provider) => !DELETE_SUPPORTED_PROVIDERS.includes(provider),
-    );
+    for (const row of data || []) {
+      const connection = row.social_provider_connections;
+      const metadata = connection.social_provider_metadata as {
+        connection_type?: string;
+        granted_scopes?: string[];
+      } | null;
+
+      const support = evaluateDeleteSupport({
+        provider: connection.provider,
+        connectionType: metadata?.connection_type,
+        grantedScopes: metadata?.granted_scopes,
+      });
+
+      if (!support.supported) {
+        reasons.add(support.reason);
+      }
+    }
+
+    return Array.from(reasons);
   }
 
   private resolveDeleteAppCredentials({
@@ -960,7 +988,9 @@ export class SocialPostsService {
 
     await this.supabaseService.supabaseClient
       .from('social_posts')
-      .update({ status: 'deleting' })
+      // Stamp updated_at so the stuck-delete reconciliation cron has a reliable
+      // "deletion started" clock (there is no updated_at trigger on this table).
+      .update({ status: 'deleting', updated_at: new Date().toISOString() })
       .eq('id', postId)
       .eq('project_id', projectId);
 
@@ -1061,6 +1091,7 @@ export class SocialPostsService {
         access_token_expires_at: string | null | undefined;
         refresh_token_expires_at: string | null | undefined;
         external_id: string | null | undefined;
+        social_provider_metadata?: Json;
       };
     }[];
     social_post_media: Array<{
@@ -1148,21 +1179,36 @@ export class SocialPostsService {
       });
 
     const socialAccounts = data.social_post_provider_connections.map(
-      (connection) => ({
-        id: connection.social_provider_connections.id,
-        platform: connection.social_provider_connections.provider!,
-        username:
-          connection.social_provider_connections.social_provider_user_name,
-        user_id: connection.social_provider_connections.social_provider_user_id,
-        access_token: connection.social_provider_connections.access_token || '',
-        refresh_token: connection.social_provider_connections.refresh_token,
-        access_token_expires_at:
-          connection.social_provider_connections.access_token_expires_at ||
-          new Date().toISOString(),
-        refresh_token_expires_at:
-          connection.social_provider_connections.refresh_token_expires_at,
-        external_id: connection.social_provider_connections.external_id,
-      }),
+      (connection) => {
+        const metadata = connection.social_provider_connections
+          .social_provider_metadata as {
+          connection_type?: string;
+          granted_scopes?: string[];
+        } | null;
+
+        return {
+          id: connection.social_provider_connections.id,
+          platform: connection.social_provider_connections.provider!,
+          username:
+            connection.social_provider_connections.social_provider_user_name,
+          user_id:
+            connection.social_provider_connections.social_provider_user_id,
+          access_token:
+            connection.social_provider_connections.access_token || '',
+          refresh_token: connection.social_provider_connections.refresh_token,
+          access_token_expires_at:
+            connection.social_provider_connections.access_token_expires_at ||
+            new Date().toISOString(),
+          refresh_token_expires_at:
+            connection.social_provider_connections.refresh_token_expires_at,
+          external_id: connection.social_provider_connections.external_id,
+          delete_supported: connectionSupportsDelete({
+            provider: connection.social_provider_connections.provider,
+            connectionType: metadata?.connection_type,
+            grantedScopes: metadata?.granted_scopes,
+          }),
+        };
+      },
     );
 
     const postData: SocialPostDto = {

--- a/api/src/social-provider-connections/dto/create-provider-auth-url.dto.ts
+++ b/api/src/social-provider-connections/dto/create-provider-auth-url.dto.ts
@@ -39,7 +39,7 @@ export class InstagramProviderData {
 
   @ApiProperty({
     description:
-      'Override the default permissions/scopes requested during OAuth. Default instagram scopes: instagram_business_basic, instagram_business_content_publish. Default facebook scopes: instagram_basic, instagram_content_publish, pages_show_list, public_profile, business_management',
+      'Override the default permissions/scopes requested during OAuth. Default instagram scopes: instagram_business_basic, instagram_business_content_publish. Default facebook scopes: instagram_basic, instagram_content_publish, instagram_manage_contents, pages_show_list, public_profile, business_management',
     required: false,
     type: [String],
     isArray: true,

--- a/api/src/social-provider-connections/dto/social-accounts.dto.ts
+++ b/api/src/social-provider-connections/dto/social-accounts.dto.ts
@@ -68,6 +68,13 @@ export class SocialAccountDto {
   external_id?: string | null | undefined;
 
   @ApiProperty({
+    description:
+      'Whether a published post on this account can be deleted from the platform. False when the platform does not support deletion, or the account must be reconnected to grant the deletion permission.',
+    type: Boolean,
+  })
+  delete_supported?: boolean;
+
+  @ApiProperty({
     description: 'The metadata of the social account',
     type: SocialAccountMetadata,
     nullable: true,

--- a/api/src/social-provider-connections/helper/auth-url.helper.ts
+++ b/api/src/social-provider-connections/helper/auth-url.helper.ts
@@ -146,6 +146,7 @@ export async function generateAuthUrl({
           ...[
             'instagram_basic',
             'instagram_content_publish',
+            'instagram_manage_contents',
             'pages_show_list',
             'public_profile',
             'business_management',
@@ -469,7 +470,9 @@ export async function generateAuthUrl({
       ) {
         scopes.push(...providerData.threads.permission_overrides);
       } else {
-        scopes.push(...['threads_basic', 'threads_content_publish']);
+        scopes.push(
+          ...['threads_basic', 'threads_content_publish', 'threads_delete'],
+        );
 
         if (permissions.includes('feeds')) {
           scopes.push('threads_manage_insights');

--- a/api/src/webhooks/dto/create-webhook.dto.ts
+++ b/api/src/webhooks/dto/create-webhook.dto.ts
@@ -8,6 +8,7 @@ export const eventValues: EventType[] = [
   'social.post.updated',
   'social.post.deleted',
   'social.post.result.created',
+  'social.post.result.deleted',
   'social.account.created',
   'social.account.updated',
 ];

--- a/api/supabase/migrations/20260723120000_add_deleting_statuses_to_social_posts.sql
+++ b/api/supabase/migrations/20260723120000_add_deleting_statuses_to_social_posts.sql
@@ -1,0 +1,8 @@
+ALTER TYPE social_post_status
+    ADD VALUE IF NOT EXISTS 'deleting';
+
+ALTER TYPE social_post_status
+    ADD VALUE IF NOT EXISTS 'deleted';
+
+ALTER TYPE social_post_status
+    ADD VALUE IF NOT EXISTS 'delete_failed';

--- a/api/supabase/migrations/20260723120001_add_delete_status_to_social_post_results.sql
+++ b/api/supabase/migrations/20260723120001_add_delete_status_to_social_post_results.sql
@@ -1,0 +1,15 @@
+--
+-- Social Post Result Delete Status
+CREATE TYPE social_post_result_delete_status AS enum(
+    'not_deleted',
+    'deleting',
+    'deleted',
+    'delete_failed'
+);
+
+--
+-- Social Post Results
+ALTER TABLE public.social_post_results
+    ADD COLUMN delete_status social_post_result_delete_status NOT NULL DEFAULT 'not_deleted',
+    ADD COLUMN delete_error_message text NULL,
+    ADD COLUMN deleted_at timestamptz NULL;

--- a/api/supabase/migrations/20260723120002_add_delete_webhook_events.sql
+++ b/api/supabase/migrations/20260723120002_add_delete_webhook_events.sql
@@ -1,0 +1,2 @@
+ALTER TYPE webhook_event_type
+    ADD VALUE IF NOT EXISTS 'social.post.result.deleted';

--- a/api/supabase/supabase.types.ts
+++ b/api/supabase/supabase.types.ts
@@ -4,1452 +4,1467 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
   cms: {
     Tables: {
       article_authors: {
         Row: {
-          article_id: string;
-          author_id: string;
-          position: number;
-        };
+          article_id: string
+          author_id: string
+          position: number
+        }
         Insert: {
-          article_id: string;
-          author_id: string;
-          position?: number;
-        };
+          article_id: string
+          author_id: string
+          position?: number
+        }
         Update: {
-          article_id?: string;
-          author_id?: string;
-          position?: number;
-        };
+          article_id?: string
+          author_id?: string
+          position?: number
+        }
         Relationships: [
           {
-            foreignKeyName: 'article_authors_article_id_fkey';
-            columns: ['article_id'];
-            isOneToOne: false;
-            referencedRelation: 'articles';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_authors_article_id_fkey"
+            columns: ["article_id"]
+            isOneToOne: false
+            referencedRelation: "articles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'article_authors_author_id_fkey';
-            columns: ['author_id'];
-            isOneToOne: false;
-            referencedRelation: 'authors';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_authors_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "authors"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       article_tags: {
         Row: {
-          article_id: string;
-          tag_id: string;
-        };
+          article_id: string
+          tag_id: string
+        }
         Insert: {
-          article_id: string;
-          tag_id: string;
-        };
+          article_id: string
+          tag_id: string
+        }
         Update: {
-          article_id?: string;
-          tag_id?: string;
-        };
+          article_id?: string
+          tag_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'article_tags_article_id_fkey';
-            columns: ['article_id'];
-            isOneToOne: false;
-            referencedRelation: 'articles';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_tags_article_id_fkey"
+            columns: ["article_id"]
+            isOneToOne: false
+            referencedRelation: "articles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'article_tags_tag_id_fkey';
-            columns: ['tag_id'];
-            isOneToOne: false;
-            referencedRelation: 'tags';
-            referencedColumns: ['id'];
+            foreignKeyName: "article_tags_tag_id_fkey"
+            columns: ["tag_id"]
+            isOneToOne: false
+            referencedRelation: "tags"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       articles: {
         Row: {
-          attribution: Json | null;
-          category_id: string | null;
-          content: string | null;
-          content_format: string;
-          cover_image_url: string | null;
-          cover_video_url: string | null;
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          featured: boolean;
-          id: string;
-          published_at: string | null;
-          slug: string;
-          status: string;
-          title: string;
-          updated_at: string;
-        };
+          attribution: Json | null
+          category_id: string | null
+          content: string | null
+          content_format: string
+          cover_image_url: string | null
+          cover_video_url: string | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          featured: boolean
+          id: string
+          published_at: string | null
+          slug: string
+          status: string
+          title: string
+          updated_at: string
+        }
         Insert: {
-          attribution?: Json | null;
-          category_id?: string | null;
-          content?: string | null;
-          content_format?: string;
-          cover_image_url?: string | null;
-          cover_video_url?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          featured?: boolean;
-          id?: string;
-          published_at?: string | null;
-          slug: string;
-          status?: string;
-          title: string;
-          updated_at?: string;
-        };
+          attribution?: Json | null
+          category_id?: string | null
+          content?: string | null
+          content_format?: string
+          cover_image_url?: string | null
+          cover_video_url?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          featured?: boolean
+          id?: string
+          published_at?: string | null
+          slug: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
         Update: {
-          attribution?: Json | null;
-          category_id?: string | null;
-          content?: string | null;
-          content_format?: string;
-          cover_image_url?: string | null;
-          cover_video_url?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          featured?: boolean;
-          id?: string;
-          published_at?: string | null;
-          slug?: string;
-          status?: string;
-          title?: string;
-          updated_at?: string;
-        };
+          attribution?: Json | null
+          category_id?: string | null
+          content?: string | null
+          content_format?: string
+          cover_image_url?: string | null
+          cover_video_url?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          featured?: boolean
+          id?: string
+          published_at?: string | null
+          slug?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'articles_category_id_fkey';
-            columns: ['category_id'];
-            isOneToOne: false;
-            referencedRelation: 'categories';
-            referencedColumns: ['id'];
+            foreignKeyName: "articles_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       authors: {
         Row: {
-          bio: string | null;
-          created_at: string;
-          deleted_at: string | null;
-          id: string;
-          image_url: string | null;
-          name: string;
-          role: string | null;
-          slug: string;
-          socials: Json;
-          updated_at: string;
-        };
+          bio: string | null
+          created_at: string
+          deleted_at: string | null
+          id: string
+          image_url: string | null
+          name: string
+          role: string | null
+          slug: string
+          socials: Json
+          updated_at: string
+        }
         Insert: {
-          bio?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          id?: string;
-          image_url?: string | null;
-          name: string;
-          role?: string | null;
-          slug: string;
-          socials?: Json;
-          updated_at?: string;
-        };
+          bio?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          image_url?: string | null
+          name: string
+          role?: string | null
+          slug: string
+          socials?: Json
+          updated_at?: string
+        }
         Update: {
-          bio?: string | null;
-          created_at?: string;
-          deleted_at?: string | null;
-          id?: string;
-          image_url?: string | null;
-          name?: string;
-          role?: string | null;
-          slug?: string;
-          socials?: Json;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          bio?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          image_url?: string | null
+          name?: string
+          role?: string | null
+          slug?: string
+          socials?: Json
+          updated_at?: string
+        }
+        Relationships: []
+      }
       categories: {
         Row: {
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          id: string;
-          name: string;
-          slug: string;
-          updated_at: string;
-        };
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          slug: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name: string;
-          slug: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          slug: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name?: string;
-          slug?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       tags: {
         Row: {
-          created_at: string;
-          deleted_at: string | null;
-          description: string | null;
-          id: string;
-          name: string;
-          slug: string;
-          updated_at: string;
-        };
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          slug: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name: string;
-          slug: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          slug: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          deleted_at?: string | null;
-          description?: string | null;
-          id?: string;
-          name?: string;
-          slug?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
-    };
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   graphql_public: {
     Tables: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json;
-          operationName?: string;
-          query?: string;
-          variables?: Json;
-        };
-        Returns: Json;
-      };
-    };
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       projects: {
         Row: {
-          auth_callback_url: string | null;
-          created_at: string | null;
-          created_by: string | null;
-          description: string | null;
-          id: string;
-          is_system: boolean;
-          name: string;
-          team_id: string;
-          updated_at: string | null;
-          updated_by: string | null;
-        };
+          auth_callback_url: string | null
+          created_at: string | null
+          created_by: string | null
+          description: string | null
+          id: string
+          is_system: boolean
+          name: string
+          team_id: string
+          updated_at: string | null
+          updated_by: string | null
+        }
         Insert: {
-          auth_callback_url?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          description?: string | null;
-          id?: string;
-          is_system?: boolean;
-          name: string;
-          team_id: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          auth_callback_url?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          is_system?: boolean
+          name: string
+          team_id: string
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Update: {
-          auth_callback_url?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          description?: string | null;
-          id?: string;
-          is_system?: boolean;
-          name?: string;
-          team_id?: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          auth_callback_url?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          is_system?: boolean
+          name?: string
+          team_id?: string
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'projects_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'projects_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'projects_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "projects_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_configurations: {
         Row: {
-          caption: string | null;
-          id: string;
-          post_id: string;
-          provider: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id: string | null;
-          provider_data: Json | null;
-        };
+          caption: string | null
+          id: string
+          post_id: string
+          provider: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id: string | null
+          provider_data: Json | null
+        }
         Insert: {
-          caption?: string | null;
-          id?: string;
-          post_id: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          provider_data?: Json | null;
-        };
+          caption?: string | null
+          id?: string
+          post_id: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          provider_data?: Json | null
+        }
         Update: {
-          caption?: string | null;
-          id?: string;
-          post_id?: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          provider_data?: Json | null;
-        };
+          caption?: string | null
+          id?: string
+          post_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          provider_data?: Json | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_configurations_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_configurations_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_configurations_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_configurations_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_media: {
         Row: {
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          meta_data: Json | null;
-          post_id: string;
-          provider: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id: string | null;
-          skip_processing: boolean | null;
-          tags: Json | null;
-          thumbnail_timestamp_ms: number | null;
-          thumbnail_url: string | null;
-          updated_at: string;
-          url: string;
-        };
+          created_at: string
+          external_id: string | null
+          id: string
+          meta_data: Json | null
+          post_id: string
+          provider: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id: string | null
+          skip_processing: boolean | null
+          tags: Json | null
+          thumbnail_timestamp_ms: number | null
+          thumbnail_url: string | null
+          updated_at: string
+          url: string
+        }
         Insert: {
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          meta_data?: Json | null;
-          post_id: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          skip_processing?: boolean | null;
-          tags?: Json | null;
-          thumbnail_timestamp_ms?: number | null;
-          thumbnail_url?: string | null;
-          updated_at?: string;
-          url: string;
-        };
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          meta_data?: Json | null
+          post_id: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url: string
+        }
         Update: {
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          meta_data?: Json | null;
-          post_id?: string;
-          provider?: Database['public']['Enums']['social_provider'] | null;
-          provider_connection_id?: string | null;
-          skip_processing?: boolean | null;
-          tags?: Json | null;
-          thumbnail_timestamp_ms?: number | null;
-          thumbnail_url?: string | null;
-          updated_at?: string;
-          url?: string;
-        };
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          meta_data?: Json | null
+          post_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"] | null
+          provider_connection_id?: string | null
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_media_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_media_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_media_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_media_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_provider_connections: {
         Row: {
-          created_at: string;
-          id: string;
-          post_id: string;
-          provider_connection_id: string;
-          updated_at: string;
-        };
+          created_at: string
+          id: string
+          post_id: string
+          provider_connection_id: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          post_id: string;
-          provider_connection_id: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          post_id: string
+          provider_connection_id: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          post_id?: string;
-          provider_connection_id?: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          post_id?: string
+          provider_connection_id?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_provider_connections_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_provider_connections_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_provider_connections_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_provider_connections_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_result_post_media: {
         Row: {
-          id: string;
-          social_post_media_id: string;
-          social_post_result_id: string;
-        };
+          id: string
+          social_post_media_id: string
+          social_post_result_id: string
+        }
         Insert: {
-          id?: string;
-          social_post_media_id: string;
-          social_post_result_id: string;
-        };
+          id?: string
+          social_post_media_id: string
+          social_post_result_id: string
+        }
         Update: {
-          id?: string;
-          social_post_media_id?: string;
-          social_post_result_id?: string;
-        };
+          id?: string
+          social_post_media_id?: string
+          social_post_result_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_result_post_media_social_post_media_id_fkey';
-            columns: ['social_post_media_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_post_media';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_result_post_media_social_post_media_id_fkey"
+            columns: ["social_post_media_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_media"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_result_post_media_social_post_result_id_fkey';
-            columns: ['social_post_result_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_post_results';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_result_post_media_social_post_result_id_fkey"
+            columns: ["social_post_result_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_results"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_results: {
         Row: {
-          created_at: string;
-          details: Json | null;
-          error_message: string | null;
-          id: string;
-          post_id: string;
-          provider_connection_id: string;
-          provider_post_id: string | null;
-          provider_post_url: string | null;
-          success: boolean;
-          updated_at: string;
-        };
+          created_at: string
+          delete_error_message: string | null
+          delete_status: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at: string | null
+          details: Json | null
+          error_message: string | null
+          id: string
+          post_id: string
+          provider_connection_id: string
+          provider_post_id: string | null
+          provider_post_url: string | null
+          success: boolean
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          details?: Json | null;
-          error_message?: string | null;
-          id?: string;
-          post_id: string;
-          provider_connection_id: string;
-          provider_post_id?: string | null;
-          provider_post_url?: string | null;
-          success: boolean;
-          updated_at?: string;
-        };
+          created_at?: string
+          delete_error_message?: string | null
+          delete_status?: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at?: string | null
+          details?: Json | null
+          error_message?: string | null
+          id?: string
+          post_id: string
+          provider_connection_id: string
+          provider_post_id?: string | null
+          provider_post_url?: string | null
+          success: boolean
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          details?: Json | null;
-          error_message?: string | null;
-          id?: string;
-          post_id?: string;
-          provider_connection_id?: string;
-          provider_post_id?: string | null;
-          provider_post_url?: string | null;
-          success?: boolean;
-          updated_at?: string;
-        };
+          created_at?: string
+          delete_error_message?: string | null
+          delete_status?: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at?: string | null
+          details?: Json | null
+          error_message?: string | null
+          id?: string
+          post_id?: string
+          provider_connection_id?: string
+          provider_post_id?: string | null
+          provider_post_url?: string | null
+          success?: boolean
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_results_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_posts';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_results_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'social_post_results_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_results_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_post_team_usage: {
         Row: {
-          count: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          team_id: string;
-        };
+          count: number
+          end_at: string
+          limit: number
+          start_at: string
+          team_id: string
+        }
         Insert: {
-          count?: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          team_id: string;
-        };
+          count?: number
+          end_at: string
+          limit: number
+          start_at: string
+          team_id: string
+        }
         Update: {
-          count?: number;
-          end_at?: string;
-          limit?: number;
-          start_at?: string;
-          team_id?: string;
-        };
+          count?: number
+          end_at?: string
+          limit?: number
+          start_at?: string
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_post_team_usage_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_post_team_usage_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_posts: {
         Row: {
-          api_key: string;
-          caption: string;
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          post_at: string;
-          project_id: string;
-          status: Database['public']['Enums']['social_post_status'];
-          updated_at: string;
-        };
+          api_key: string
+          caption: string
+          created_at: string
+          external_id: string | null
+          id: string
+          post_at: string
+          project_id: string
+          status: Database["public"]["Enums"]["social_post_status"]
+          updated_at: string
+        }
         Insert: {
-          api_key: string;
-          caption: string;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          post_at?: string;
-          project_id: string;
-          status?: Database['public']['Enums']['social_post_status'];
-          updated_at?: string;
-        };
+          api_key: string
+          caption: string
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          post_at?: string
+          project_id: string
+          status?: Database["public"]["Enums"]["social_post_status"]
+          updated_at?: string
+        }
         Update: {
-          api_key?: string;
-          caption?: string;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          post_at?: string;
-          project_id?: string;
-          status?: Database['public']['Enums']['social_post_status'];
-          updated_at?: string;
-        };
+          api_key?: string
+          caption?: string
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          post_at?: string
+          project_id?: string
+          status?: Database["public"]["Enums"]["social_post_status"]
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_posts_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_posts_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_app_credentials: {
         Row: {
-          app_id: string | null;
-          app_secret: string | null;
-          created_at: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string;
-        };
+          app_id: string | null
+          app_secret: string | null
+          created_at: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string
+        }
         Insert: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Update: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_app_credentials_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_app_credentials_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connection_oauth_data: {
         Row: {
-          created_at: string | null;
-          id: string;
-          key: string;
-          key_id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string | null;
-          value: string;
-        };
+          created_at: string | null
+          id: string
+          key: string
+          key_id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string | null
+          value: string
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          key: string;
-          key_id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string | null;
-          value: string;
-        };
+          created_at?: string | null
+          id?: string
+          key: string
+          key_id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string | null
+          value: string
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          key?: string;
-          key_id?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string | null;
-          value?: string;
-        };
+          created_at?: string | null
+          id?: string
+          key?: string
+          key_id?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string | null
+          value?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connection_oauth_data_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connection_oauth_data_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connection_pagination_data: {
         Row: {
-          created_at: string | null;
-          id: string;
-          metadata: Json;
-          provider_connection_id: string;
-          updated_at: string | null;
-        };
+          created_at: string | null
+          id: string
+          metadata: Json
+          provider_connection_id: string
+          updated_at: string | null
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          metadata: Json;
-          provider_connection_id: string;
-          updated_at?: string | null;
-        };
+          created_at?: string | null
+          id?: string
+          metadata: Json
+          provider_connection_id: string
+          updated_at?: string | null
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          metadata?: Json;
-          provider_connection_id?: string;
-          updated_at?: string | null;
-        };
+          created_at?: string | null
+          id?: string
+          metadata?: Json
+          provider_connection_id?: string
+          updated_at?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connection_paginati_provider_connection_id_fkey';
-            columns: ['provider_connection_id'];
-            isOneToOne: false;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connection_paginati_provider_connection_id_fkey"
+            columns: ["provider_connection_id"]
+            isOneToOne: false
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       social_provider_connections: {
         Row: {
-          access_token: string | null;
-          access_token_expires_at: string | null;
-          created_at: string;
-          external_id: string | null;
-          id: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          refresh_token: string | null;
-          refresh_token_expires_at: string | null;
-          social_provider_metadata: Json | null;
-          social_provider_profile_photo_url: string | null;
-          social_provider_user_id: string;
-          social_provider_user_name: string | null;
-          updated_at: string;
-        };
+          access_token: string | null
+          access_token_expires_at: string | null
+          created_at: string
+          external_id: string | null
+          id: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          refresh_token: string | null
+          refresh_token_expires_at: string | null
+          social_provider_metadata: Json | null
+          social_provider_profile_photo_url: string | null
+          social_provider_user_id: string
+          social_provider_user_name: string | null
+          updated_at: string
+        }
         Insert: {
-          access_token?: string | null;
-          access_token_expires_at?: string | null;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          project_id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          refresh_token?: string | null;
-          refresh_token_expires_at?: string | null;
-          social_provider_metadata?: Json | null;
-          social_provider_profile_photo_url?: string | null;
-          social_provider_user_id: string;
-          social_provider_user_name?: string | null;
-          updated_at?: string;
-        };
+          access_token?: string | null
+          access_token_expires_at?: string | null
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          project_id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          refresh_token?: string | null
+          refresh_token_expires_at?: string | null
+          social_provider_metadata?: Json | null
+          social_provider_profile_photo_url?: string | null
+          social_provider_user_id: string
+          social_provider_user_name?: string | null
+          updated_at?: string
+        }
         Update: {
-          access_token?: string | null;
-          access_token_expires_at?: string | null;
-          created_at?: string;
-          external_id?: string | null;
-          id?: string;
-          project_id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          refresh_token?: string | null;
-          refresh_token_expires_at?: string | null;
-          social_provider_metadata?: Json | null;
-          social_provider_profile_photo_url?: string | null;
-          social_provider_user_id?: string;
-          social_provider_user_name?: string | null;
-          updated_at?: string;
-        };
+          access_token?: string | null
+          access_token_expires_at?: string | null
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          project_id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          refresh_token?: string | null
+          refresh_token_expires_at?: string | null
+          social_provider_metadata?: Json | null
+          social_provider_profile_photo_url?: string | null
+          social_provider_user_id?: string
+          social_provider_user_name?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'social_provider_connections_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "social_provider_connections_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       system_social_provider_app_credentials: {
         Row: {
-          app_id: string | null;
-          app_secret: string | null;
-          created_at: string;
-          id: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at: string;
-        };
+          app_id: string | null
+          app_secret: string | null
+          created_at: string
+          id: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at: string
+        }
         Insert: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          id?: string;
-          provider: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          id?: string
+          provider: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
         Update: {
-          app_id?: string | null;
-          app_secret?: string | null;
-          created_at?: string;
-          id?: string;
-          provider?: Database['public']['Enums']['social_provider'];
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          app_id?: string | null
+          app_secret?: string | null
+          created_at?: string
+          id?: string
+          provider?: Database["public"]["Enums"]["social_provider"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
       team_addons: {
         Row: {
-          addon: Database['public']['Enums']['subscription_addon'];
-          expires_at: string;
-          id: string;
-          team_id: string;
-        };
+          addon: Database["public"]["Enums"]["subscription_addon"]
+          expires_at: string
+          id: string
+          team_id: string
+        }
         Insert: {
-          addon: Database['public']['Enums']['subscription_addon'];
-          expires_at: string;
-          id?: string;
-          team_id: string;
-        };
+          addon: Database["public"]["Enums"]["subscription_addon"]
+          expires_at: string
+          id?: string
+          team_id: string
+        }
         Update: {
-          addon?: Database['public']['Enums']['subscription_addon'];
-          expires_at?: string;
-          id?: string;
-          team_id?: string;
-        };
+          addon?: Database["public"]["Enums"]["subscription_addon"]
+          expires_at?: string
+          id?: string
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_addons_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_addons_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_notifications: {
         Row: {
-          created_at: string;
-          delivery_types: Database['public']['Enums']['delivery_type'][];
-          id: string;
-          message: string;
-          meta_data: Json | null;
-          notification_type: Database['public']['Enums']['notification_type'];
-          project_id: string | null;
-          team_id: string;
-        };
+          created_at: string
+          delivery_types: Database["public"]["Enums"]["delivery_type"][]
+          id: string
+          message: string
+          meta_data: Json | null
+          notification_type: Database["public"]["Enums"]["notification_type"]
+          project_id: string | null
+          team_id: string
+        }
         Insert: {
-          created_at?: string;
-          delivery_types: Database['public']['Enums']['delivery_type'][];
-          id?: string;
-          message: string;
-          meta_data?: Json | null;
-          notification_type: Database['public']['Enums']['notification_type'];
-          project_id?: string | null;
-          team_id: string;
-        };
+          created_at?: string
+          delivery_types: Database["public"]["Enums"]["delivery_type"][]
+          id?: string
+          message: string
+          meta_data?: Json | null
+          notification_type: Database["public"]["Enums"]["notification_type"]
+          project_id?: string | null
+          team_id: string
+        }
         Update: {
-          created_at?: string;
-          delivery_types?: Database['public']['Enums']['delivery_type'][];
-          id?: string;
-          message?: string;
-          meta_data?: Json | null;
-          notification_type?: Database['public']['Enums']['notification_type'];
-          project_id?: string | null;
-          team_id?: string;
-        };
+          created_at?: string
+          delivery_types?: Database["public"]["Enums"]["delivery_type"][]
+          id?: string
+          message?: string
+          meta_data?: Json | null
+          notification_type?: Database["public"]["Enums"]["notification_type"]
+          project_id?: string | null
+          team_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_notifications_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_notifications_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_notifications_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_notifications_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_social_post_meters: {
         Row: {
-          count: number;
-          day: number;
-          hour: number;
-          id: string;
-          minute: number;
-          month: number;
-          provider: Database['public']['Enums']['social_provider'];
-          team_id: string;
-          year: number;
-        };
+          count: number
+          day: number
+          hour: number
+          id: string
+          minute: number
+          month: number
+          provider: Database["public"]["Enums"]["social_provider"]
+          team_id: string
+          year: number
+        }
         Insert: {
-          count: number;
-          day: number;
-          hour: number;
-          id?: string;
-          minute: number;
-          month: number;
-          provider: Database['public']['Enums']['social_provider'];
-          team_id: string;
-          year: number;
-        };
+          count: number
+          day: number
+          hour: number
+          id?: string
+          minute: number
+          month: number
+          provider: Database["public"]["Enums"]["social_provider"]
+          team_id: string
+          year: number
+        }
         Update: {
-          count?: number;
-          day?: number;
-          hour?: number;
-          id?: string;
-          minute?: number;
-          month?: number;
-          provider?: Database['public']['Enums']['social_provider'];
-          team_id?: string;
-          year?: number;
-        };
+          count?: number
+          day?: number
+          hour?: number
+          id?: string
+          minute?: number
+          month?: number
+          provider?: Database["public"]["Enums"]["social_provider"]
+          team_id?: string
+          year?: number
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_social_post_meters_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_social_post_meters_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       team_users: {
         Row: {
-          created_at: string | null;
-          created_by: string | null;
-          team_id: string;
-          updated_at: string | null;
-          updated_by: string | null;
-          user_id: string;
-        };
+          created_at: string | null
+          created_by: string | null
+          team_id: string
+          updated_at: string | null
+          updated_by: string | null
+          user_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          created_by?: string | null;
-          team_id: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-          user_id: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          team_id: string
+          updated_at?: string | null
+          updated_by?: string | null
+          user_id: string
+        }
         Update: {
-          created_at?: string | null;
-          created_by?: string | null;
-          team_id?: string;
-          updated_at?: string | null;
-          updated_by?: string | null;
-          user_id?: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          team_id?: string
+          updated_at?: string | null
+          updated_by?: string | null
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'team_users_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_team_id_fkey';
-            columns: ['team_id'];
-            isOneToOne: false;
-            referencedRelation: 'teams';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'team_users_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "team_users_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       teams: {
         Row: {
-          billing_email: string | null;
-          created_at: string | null;
-          created_by: string | null;
-          id: string;
-          name: string;
-          stripe_customer_id: string | null;
-          updated_at: string | null;
-          updated_by: string | null;
-        };
+          billing_email: string | null
+          created_at: string | null
+          created_by: string | null
+          id: string
+          name: string
+          stripe_customer_id: string | null
+          updated_at: string | null
+          updated_by: string | null
+        }
         Insert: {
-          billing_email?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          id?: string;
-          name: string;
-          stripe_customer_id?: string | null;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          billing_email?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          name: string
+          stripe_customer_id?: string | null
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Update: {
-          billing_email?: string | null;
-          created_at?: string | null;
-          created_by?: string | null;
-          id?: string;
-          name?: string;
-          stripe_customer_id?: string | null;
-          updated_at?: string | null;
-          updated_by?: string | null;
-        };
+          billing_email?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          name?: string
+          stripe_customer_id?: string | null
+          updated_at?: string | null
+          updated_by?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'teams_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "teams_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'teams_updated_by_fkey';
-            columns: ['updated_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "teams_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       test_social_provider_connections: {
         Row: {
-          created_at: string | null;
-          created_by: string | null;
-          name: string | null;
-          social_provider_connection_id: string;
-        };
+          created_at: string | null
+          created_by: string | null
+          name: string | null
+          social_provider_connection_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          created_by?: string | null;
-          name?: string | null;
-          social_provider_connection_id: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          name?: string | null
+          social_provider_connection_id: string
+        }
         Update: {
-          created_at?: string | null;
-          created_by?: string | null;
-          name?: string | null;
-          social_provider_connection_id?: string;
-        };
+          created_at?: string | null
+          created_by?: string | null
+          name?: string | null
+          social_provider_connection_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'test_social_provider_connecti_social_provider_connection_i_fkey';
-            columns: ['social_provider_connection_id'];
-            isOneToOne: true;
-            referencedRelation: 'social_provider_connections';
-            referencedColumns: ['id'];
+            foreignKeyName: "test_social_provider_connecti_social_provider_connection_i_fkey"
+            columns: ["social_provider_connection_id"]
+            isOneToOne: true
+            referencedRelation: "social_provider_connections"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       users: {
         Row: {
-          email: string;
-          first_name: string | null;
-          id: string;
-          last_name: string | null;
-        };
+          email: string
+          first_name: string | null
+          id: string
+          last_name: string | null
+        }
         Insert: {
-          email: string;
-          first_name?: string | null;
-          id: string;
-          last_name?: string | null;
-        };
+          email: string
+          first_name?: string | null
+          id: string
+          last_name?: string | null
+        }
         Update: {
-          email?: string;
-          first_name?: string | null;
-          id?: string;
-          last_name?: string | null;
-        };
-        Relationships: [];
-      };
+          email?: string
+          first_name?: string | null
+          id?: string
+          last_name?: string | null
+        }
+        Relationships: []
+      }
       webhook_events: {
         Row: {
-          created_at: string | null;
-          data: Json;
-          id: string;
-          response: Json | null;
-          status: Database['public']['Enums']['webhook_event_status'];
-          type: Database['public']['Enums']['webhook_event_type'];
-          updated_at: string | null;
-          webhook_id: string;
-        };
+          created_at: string | null
+          data: Json
+          id: string
+          response: Json | null
+          status: Database["public"]["Enums"]["webhook_event_status"]
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at: string | null
+          webhook_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          data: Json;
-          id?: string;
-          response?: Json | null;
-          status: Database['public']['Enums']['webhook_event_status'];
-          type: Database['public']['Enums']['webhook_event_type'];
-          updated_at?: string | null;
-          webhook_id: string;
-        };
+          created_at?: string | null
+          data: Json
+          id?: string
+          response?: Json | null
+          status: Database["public"]["Enums"]["webhook_event_status"]
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at?: string | null
+          webhook_id: string
+        }
         Update: {
-          created_at?: string | null;
-          data?: Json;
-          id?: string;
-          response?: Json | null;
-          status?: Database['public']['Enums']['webhook_event_status'];
-          type?: Database['public']['Enums']['webhook_event_type'];
-          updated_at?: string | null;
-          webhook_id?: string;
-        };
+          created_at?: string | null
+          data?: Json
+          id?: string
+          response?: Json | null
+          status?: Database["public"]["Enums"]["webhook_event_status"]
+          type?: Database["public"]["Enums"]["webhook_event_type"]
+          updated_at?: string | null
+          webhook_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhook_events_webhook_id_fkey';
-            columns: ['webhook_id'];
-            isOneToOne: false;
-            referencedRelation: 'webhooks';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhook_events_webhook_id_fkey"
+            columns: ["webhook_id"]
+            isOneToOne: false
+            referencedRelation: "webhooks"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       webhook_subscribed_event_types: {
         Row: {
-          id: string;
-          type: Database['public']['Enums']['webhook_event_type'];
-          webhook_id: string;
-        };
+          id: string
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id: string
+        }
         Insert: {
-          id?: string;
-          type: Database['public']['Enums']['webhook_event_type'];
-          webhook_id: string;
-        };
+          id?: string
+          type: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id: string
+        }
         Update: {
-          id?: string;
-          type?: Database['public']['Enums']['webhook_event_type'];
-          webhook_id?: string;
-        };
+          id?: string
+          type?: Database["public"]["Enums"]["webhook_event_type"]
+          webhook_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhook_subscribed_event_types_webhook_id_fkey';
-            columns: ['webhook_id'];
-            isOneToOne: false;
-            referencedRelation: 'webhooks';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhook_subscribed_event_types_webhook_id_fkey"
+            columns: ["webhook_id"]
+            isOneToOne: false
+            referencedRelation: "webhooks"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       webhooks: {
         Row: {
-          created_at: string | null;
-          id: string;
-          project_id: string;
-          secret_key: string;
-          updated_at: string | null;
-          url: string;
-        };
+          created_at: string | null
+          id: string
+          project_id: string
+          secret_key: string
+          updated_at: string | null
+          url: string
+        }
         Insert: {
-          created_at?: string | null;
-          id?: string;
-          project_id: string;
-          secret_key: string;
-          updated_at?: string | null;
-          url: string;
-        };
+          created_at?: string | null
+          id?: string
+          project_id: string
+          secret_key: string
+          updated_at?: string | null
+          url: string
+        }
         Update: {
-          created_at?: string | null;
-          id?: string;
-          project_id?: string;
-          secret_key?: string;
-          updated_at?: string | null;
-          url?: string;
-        };
+          created_at?: string | null
+          id?: string
+          project_id?: string
+          secret_key?: string
+          updated_at?: string | null
+          url?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'webhooks_project_id_fkey';
-            columns: ['project_id'];
-            isOneToOne: false;
-            referencedRelation: 'projects';
-            referencedColumns: ['id'];
+            foreignKeyName: "webhooks_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Views: {
       v_tiktok_verification_files: {
         Row: {
-          bucket_id: string | null;
-          name: string | null;
-          project_id: string | null;
-        };
+          bucket_id: string | null
+          name: string | null
+          project_id: string | null
+        }
         Insert: {
-          bucket_id?: string | null;
-          name?: string | null;
-          project_id?: never;
-        };
+          bucket_id?: string | null
+          name?: string | null
+          project_id?: never
+        }
         Update: {
-          bucket_id?: string | null;
-          name?: string | null;
-          project_id?: never;
-        };
-        Relationships: [];
-      };
-    };
+          bucket_id?: string | null
+          name?: string | null
+          project_id?: never
+        }
+        Relationships: []
+      }
+    }
     Functions: {
       get_exceeded_team_usage_windows: {
-        Args: never;
+        Args: never
         Returns: {
-          count: number;
-          end_at: string;
-          limit: number;
-          start_at: string;
-          stripe_customer_id: string;
-          team_id: string;
-          team_name: string;
-        }[];
-      };
+          count: number
+          end_at: string
+          limit: number
+          start_at: string
+          stripe_customer_id: string
+          team_id: string
+          team_name: string
+        }[]
+      }
       increment_team_social_post_meter: {
         Args: {
-          p_day: number;
-          p_hour: number;
-          p_min: number;
-          p_month: number;
-          p_provider: Database['public']['Enums']['social_provider'];
-          p_team_id: string;
-          p_year: number;
-        };
-        Returns: undefined;
-      };
+          p_day: number
+          p_hour: number
+          p_min: number
+          p_month: number
+          p_provider: Database["public"]["Enums"]["social_provider"]
+          p_team_id: string
+          p_year: number
+        }
+        Returns: undefined
+      }
       increment_team_usage: {
         Args: {
-          p_end_at: string;
-          p_limit: number;
-          p_start_at: string;
-          p_team_id: string;
-        };
-        Returns: number;
-      };
+          p_end_at: string
+          p_limit: number
+          p_start_at: string
+          p_team_id: string
+        }
+        Returns: number
+      }
       is_system_project: {
-        Args: { project_id_param: string };
-        Returns: boolean;
-      };
-      is_team_member: { Args: { team_id: string }; Returns: boolean };
+        Args: { project_id_param: string }
+        Returns: boolean
+      }
+      is_team_member: { Args: { team_id: string }; Returns: boolean }
       nanoid: {
-        Args: { alphabet?: string; prefix: string; size?: number };
-        Returns: string;
-      };
-      user_has_post_access: { Args: { post_id: string }; Returns: boolean };
+        Args: { alphabet?: string; prefix: string; size?: number }
+        Returns: string
+      }
+      user_has_post_access: { Args: { post_id: string }; Returns: boolean }
       user_has_post_result_access: {
-        Args: { post_result_id: string };
-        Returns: boolean;
-      };
+        Args: { post_result_id: string }
+        Returns: boolean
+      }
       user_has_project_access: {
-        Args: { project_id: string };
-        Returns: boolean;
-      };
+        Args: { project_id: string }
+        Returns: boolean
+      }
       user_has_webhook_access: {
-        Args: { webhook_id: string };
-        Returns: boolean;
-      };
-    };
+        Args: { webhook_id: string }
+        Returns: boolean
+      }
+    }
     Enums: {
-      delivery_type: 'email';
-      notification_type: 'usage_alert' | 'general';
+      delivery_type: "email"
+      notification_type: "usage_alert" | "general"
+      social_post_result_delete_status:
+        | "not_deleted"
+        | "deleting"
+        | "deleted"
+        | "delete_failed"
       social_post_status:
-        | 'draft'
-        | 'scheduled'
-        | 'processing'
-        | 'posted'
-        | 'processed';
+        | "draft"
+        | "scheduled"
+        | "processing"
+        | "posted"
+        | "processed"
+        | "deleting"
+        | "deleted"
+        | "delete_failed"
       social_provider:
-        | 'facebook'
-        | 'instagram'
-        | 'x'
-        | 'tiktok'
-        | 'youtube'
-        | 'pinterest'
-        | 'linkedin'
-        | 'bluesky'
-        | 'threads'
-        | 'tiktok_business'
-        | 'instagram_w_facebook';
-      subscription_addon: 'managed_system_credentials';
-      webhook_event_status: 'pending' | 'processing' | 'completed' | 'failed';
+        | "facebook"
+        | "instagram"
+        | "x"
+        | "tiktok"
+        | "youtube"
+        | "pinterest"
+        | "linkedin"
+        | "bluesky"
+        | "threads"
+        | "tiktok_business"
+        | "instagram_w_facebook"
+      subscription_addon: "managed_system_credentials"
+      webhook_event_status: "pending" | "processing" | "completed" | "failed"
       webhook_event_type:
-        | 'social.post.created'
-        | 'social.post.updated'
-        | 'social.post.deleted'
-        | 'social.post.result.created'
-        | 'social.account.created'
-        | 'social.account.updated';
-    };
+        | "social.post.created"
+        | "social.post.updated"
+        | "social.post.deleted"
+        | "social.post.result.created"
+        | "social.account.created"
+        | "social.account.updated"
+        | "social.post.result.deleted"
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<
-  keyof Database,
-  'public'
->];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
-      Row: infer R;
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
-        DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] &
-        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R;
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
       }
       ? R
       : never
-    : never;
+    : never
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Insert: infer I;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
       }
       ? I
       : never
-    : never;
+    : never
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Update: infer U;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U;
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
       }
       ? U
       : never
-    : never;
+    : never
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-    : never;
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 
 export const Constants = {
   cms: {
@@ -1460,38 +1475,49 @@ export const Constants = {
   },
   public: {
     Enums: {
-      delivery_type: ['email'],
-      notification_type: ['usage_alert', 'general'],
+      delivery_type: ["email"],
+      notification_type: ["usage_alert", "general"],
+      social_post_result_delete_status: [
+        "not_deleted",
+        "deleting",
+        "deleted",
+        "delete_failed",
+      ],
       social_post_status: [
-        'draft',
-        'scheduled',
-        'processing',
-        'posted',
-        'processed',
+        "draft",
+        "scheduled",
+        "processing",
+        "posted",
+        "processed",
+        "deleting",
+        "deleted",
+        "delete_failed",
       ],
       social_provider: [
-        'facebook',
-        'instagram',
-        'x',
-        'tiktok',
-        'youtube',
-        'pinterest',
-        'linkedin',
-        'bluesky',
-        'threads',
-        'tiktok_business',
-        'instagram_w_facebook',
+        "facebook",
+        "instagram",
+        "x",
+        "tiktok",
+        "youtube",
+        "pinterest",
+        "linkedin",
+        "bluesky",
+        "threads",
+        "tiktok_business",
+        "instagram_w_facebook",
       ],
-      subscription_addon: ['managed_system_credentials'],
-      webhook_event_status: ['pending', 'processing', 'completed', 'failed'],
+      subscription_addon: ["managed_system_credentials"],
+      webhook_event_status: ["pending", "processing", "completed", "failed"],
       webhook_event_type: [
-        'social.post.created',
-        'social.post.updated',
-        'social.post.deleted',
-        'social.post.result.created',
-        'social.account.created',
-        'social.account.updated',
+        "social.post.created",
+        "social.post.updated",
+        "social.post.deleted",
+        "social.post.result.created",
+        "social.account.created",
+        "social.account.updated",
+        "social.post.result.deleted",
       ],
     },
   },
-} as const;
+} as const
+

--- a/dashboard/app/lib/.server/database.types.ts
+++ b/dashboard/app/lib/.server/database.types.ts
@@ -275,6 +275,9 @@ export type Database = {
       social_post_results: {
         Row: {
           created_at: string
+          delete_error_message: string | null
+          delete_status: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at: string | null
           details: Json | null
           error_message: string | null
           id: string
@@ -287,6 +290,9 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          delete_error_message?: string | null
+          delete_status?: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at?: string | null
           details?: Json | null
           error_message?: string | null
           id?: string
@@ -299,6 +305,9 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          delete_error_message?: string | null
+          delete_status?: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at?: string | null
           details?: Json | null
           error_message?: string | null
           id?: string
@@ -1054,12 +1063,20 @@ export type Database = {
     Enums: {
       delivery_type: "email"
       notification_type: "usage_alert" | "general"
+      social_post_result_delete_status:
+        | "not_deleted"
+        | "deleting"
+        | "deleted"
+        | "delete_failed"
       social_post_status:
         | "draft"
         | "scheduled"
         | "processing"
         | "posted"
         | "processed"
+        | "deleting"
+        | "deleted"
+        | "delete_failed"
       social_provider:
         | "facebook"
         | "instagram"
@@ -1081,6 +1098,7 @@ export type Database = {
         | "social.post.result.created"
         | "social.account.created"
         | "social.account.updated"
+        | "social.post.result.deleted"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1213,12 +1231,21 @@ export const Constants = {
     Enums: {
       delivery_type: ["email"],
       notification_type: ["usage_alert", "general"],
+      social_post_result_delete_status: [
+        "not_deleted",
+        "deleting",
+        "deleted",
+        "delete_failed",
+      ],
       social_post_status: [
         "draft",
         "scheduled",
         "processing",
         "posted",
         "processed",
+        "deleting",
+        "deleted",
+        "delete_failed",
       ],
       social_provider: [
         "facebook",
@@ -1242,6 +1269,7 @@ export const Constants = {
         "social.post.result.created",
         "social.account.created",
         "social.account.updated",
+        "social.post.result.deleted",
       ],
     },
   },

--- a/dashboard/app/lib/.server/social-accounts/providers/instagram-w-facebook.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/instagram-w-facebook.social-account.ts
@@ -43,6 +43,10 @@ export async function getInstagramWFacebookSocialProviderConnection({
 
   const accessToken = longLivedData.access_token;
 
+  // Persist the scopes the user actually granted so we can tell whether these
+  // accounts can be deleted from (requires `instagram_manage_contents`).
+  const grantedScopes = await fetchFacebookGrantedScopes(accessToken);
+
   const allPages: {
     instagram_business_account: {
       id: string;
@@ -87,10 +91,34 @@ export async function getInstagramWFacebookSocialProviderConnection({
           page.instagram_business_account.profile_picture_url,
         social_provider_metadata: {
           connection_type: "facebook",
+          granted_scopes: grantedScopes,
         },
       });
     }
   }
 
   return accounts;
+}
+
+/** Reads the granted (status === "granted") permissions for a Facebook access token. */
+async function fetchFacebookGrantedScopes(
+  accessToken: string,
+): Promise<string[]> {
+  try {
+    const response = await fetch(
+      `https://graph.facebook.com/v23.0/me/permissions?access_token=${accessToken}`,
+    );
+    if (!response.ok) {
+      return [];
+    }
+    const data = (await response.json()) as {
+      data?: { permission: string; status: string }[];
+    };
+    return (data.data ?? [])
+      .filter((p) => p.status === "granted")
+      .map((p) => p.permission);
+  } catch (error) {
+    console.error("Error fetching Facebook granted permissions", error);
+    return [];
+  }
 }

--- a/dashboard/app/lib/.server/social-accounts/providers/threads.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/threads.social-account.ts
@@ -42,6 +42,11 @@ export async function getThreadsSocialProviderConnection({
 
   const { access_token: shortLivedToken, user_id } = tokenData;
 
+  // Persist the scopes the user actually granted so we can tell whether this
+  // account can be deleted from (requires `threads_delete`). The short-lived
+  // token response carries the granted `permissions`.
+  const grantedScopes = normalizeGrantedScopes(tokenData.permissions);
+
   const longLivedTokenParams = new URLSearchParams([
     ["client_secret", appCredentials.appSecret!],
     ["grant_type", "th_exchange_token"],
@@ -92,6 +97,21 @@ export async function getThreadsSocialProviderConnection({
       refresh_token: longLivedToken,
       access_token_expires_at: new Date(Date.now() + expires_in * 1000),
       refresh_token_expires_at: new Date(Date.now() + expires_in * 1000),
+      social_provider_metadata: { granted_scopes: grantedScopes },
     },
   ];
+}
+
+/** Coerces a provider `permissions` value (array or comma/space string) to a scope list. */
+function normalizeGrantedScopes(permissions: unknown): string[] {
+  if (Array.isArray(permissions)) {
+    return permissions.map((p) => String(p)).filter(Boolean);
+  }
+  if (typeof permissions === "string") {
+    return permissions
+      .split(/[,\s]+/)
+      .map((p) => p.trim())
+      .filter(Boolean);
+  }
+  return [];
 }

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_columns.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_columns.tsx
@@ -41,9 +41,11 @@ import { format } from "date-fns";
 function badgeVariant(status: string) {
   switch (status) {
     case "error":
+    case "delete_failed":
       return "destructive";
     case "posted":
     case "processed":
+    case "deleted":
       return "affirmative";
     default:
       return "secondary";
@@ -62,7 +64,12 @@ const statusIcons: Partial<
   failed: TriangleExclamationIcon,
   error: TriangleExclamationIcon,
   cancelled: CrossLargeIcon,
+  deleting: LoadingCircleIcon,
+  deleted: CrossLargeIcon,
+  delete_failed: TriangleExclamationIcon,
 };
+
+const DELETE_UNSUPPORTED_PLATFORMS = new Set(["tiktok", "tiktok_business"]);
 
 const providerColors = {
   facebook: "bg-blue-500",
@@ -287,7 +294,14 @@ export const columns: ColumnDef<PostWithConnections>[] = [
 ];
 
 function PostRowActions({ post }: { post: PostWithConnections }) {
-  const canDelete = post.status === "draft" || post.status === "scheduled";
+  const isProcessed = post.status === "processed";
+  const hasUnsupportedPlatform = (post.social_accounts || []).some((account) =>
+    DELETE_UNSUPPORTED_PLATFORMS.has(account.platform),
+  );
+  const canDelete =
+    post.status === "draft" ||
+    post.status === "scheduled" ||
+    (isProcessed && !hasUnsupportedPlatform);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const revalidator = useRevalidator();
 
@@ -354,7 +368,9 @@ function PostRowActions({ post }: { post: PostWithConnections }) {
           <DialogHeader>
             <DialogTitle>Delete this post?</DialogTitle>
             <DialogDescription>
-              This will permanently delete the post. This cannot be undone.
+              {isProcessed
+                ? "This will delete the post from every connected platform it was published to. This cannot be undone."
+                : "This will permanently delete the post. This cannot be undone."}
             </DialogDescription>
           </DialogHeader>
 

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_columns.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_columns.tsx
@@ -69,8 +69,6 @@ const statusIcons: Partial<
   delete_failed: TriangleExclamationIcon,
 };
 
-const DELETE_UNSUPPORTED_PLATFORMS = new Set(["tiktok", "tiktok_business"]);
-
 const providerColors = {
   facebook: "bg-blue-500",
   instagram: "bg-pink-500",
@@ -295,13 +293,21 @@ export const columns: ColumnDef<PostWithConnections>[] = [
 
 function PostRowActions({ post }: { post: PostWithConnections }) {
   const isProcessed = post.status === "processed";
-  const hasUnsupportedPlatform = (post.social_accounts || []).some((account) =>
-    DELETE_UNSUPPORTED_PLATFORMS.has(account.platform),
-  );
-  const canDelete =
-    post.status === "draft" ||
-    post.status === "scheduled" ||
-    (isProcessed && !hasUnsupportedPlatform);
+  // Platforms the post was published to that can't be deleted from — either the
+  // platform doesn't support deletion or the account needs reconnecting to grant
+  // the deletion permission. Deletion is all-or-nothing, so any one blocks it.
+  const blockedPlatforms = isProcessed
+    ? Array.from(
+        new Set(
+          (post.social_accounts || [])
+            .filter((account) => account.delete_supported === false)
+            .map((account) => account.platform),
+        ),
+      )
+    : [];
+  const isDeleteBlocked = blockedPlatforms.length > 0;
+  const isDeletableStatus =
+    post.status === "draft" || post.status === "scheduled" || isProcessed;
   const [deleteOpen, setDeleteOpen] = useState(false);
   const revalidator = useRevalidator();
 
@@ -340,7 +346,7 @@ function PostRowActions({ post }: { post: PostWithConnections }) {
           >
             Copy post ID
           </DropdownMenuItem>
-          {canDelete ? (
+          {isDeletableStatus ? (
             <>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -366,32 +372,56 @@ function PostRowActions({ post }: { post: PostWithConnections }) {
       >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Delete this post?</DialogTitle>
+            <DialogTitle>
+              {isDeleteBlocked ? "Can't delete this post" : "Delete this post?"}
+            </DialogTitle>
             <DialogDescription>
-              {isProcessed
-                ? "This will delete the post from every connected platform it was published to. This cannot be undone."
-                : "This will permanently delete the post. This cannot be undone."}
+              {isDeleteBlocked
+                ? `This post can't be deleted because it was published to ${blockedPlatforms.join(
+                    ", ",
+                  )}, which ${
+                    blockedPlatforms.length > 1 ? "don't" : "doesn't"
+                  } support deletion or need the account reconnected to grant the deletion permission.`
+                : isProcessed
+                  ? "This will delete the post from every connected platform it was published to. This cannot be undone."
+                  : "This will permanently delete the post. This cannot be undone."}
             </DialogDescription>
           </DialogHeader>
 
-          <fetcher.Form method="post">
-            <input type="hidden" name="action" value="delete-post" />
-            <input type="hidden" name="postId" value={post.id} />
-
+          {isDeleteBlocked ? (
             <DialogFooter>
               <Button
                 type="button"
                 variant="outline"
                 onClick={() => setDeleteOpen(false)}
-                disabled={isSubmitting}
               >
-                Cancel
-              </Button>
-              <Button type="submit" variant="destructive" disabled={isSubmitting}>
-                {isSubmitting ? "Deleting..." : "Delete"}
+                Close
               </Button>
             </DialogFooter>
-          </fetcher.Form>
+          ) : (
+            <fetcher.Form method="post">
+              <input type="hidden" name="action" value="delete-post" />
+              <input type="hidden" name="postId" value={post.id} />
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setDeleteOpen(false)}
+                  disabled={isSubmitting}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  variant="destructive"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? "Deleting..." : "Delete"}
+                </Button>
+              </DialogFooter>
+            </fetcher.Form>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_types.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_types.ts
@@ -2,7 +2,18 @@ export interface Post {
   id: string;
   project_id: string;
   external_id: string | null;
-  status: "draft" | "scheduled" | "posting" | "posted" | "failed" | "cancelled";
+  status:
+    | "draft"
+    | "scheduled"
+    | "posting"
+    | "posted"
+    | "failed"
+    | "cancelled"
+    | "processing"
+    | "processed"
+    | "deleting"
+    | "deleted"
+    | "delete_failed";
   caption: string;
   scheduled_at: string;
   created_at: string;

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_types.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_types.ts
@@ -33,6 +33,12 @@ export interface PostProviderConnection {
   username: string | null;
   platform: string;
   external_id: string | null;
+  /**
+   * Whether a published post on this account can be deleted from the platform.
+   * `false` when the platform doesn't support deletion, or the account must be
+   * reconnected to grant the deletion permission. Absent on older payloads.
+   */
+  delete_supported?: boolean;
 }
 
 export interface PostMedia {

--- a/trigger/delete-from-platform.ts
+++ b/trigger/delete-from-platform.ts
@@ -1,0 +1,163 @@
+import { createClient } from "@supabase/supabase-js";
+import { logger, task, tags, tasks } from "@trigger.dev/sdk";
+import { createPostClient } from "./posting/create-post-client";
+import {
+  handleTokenRefresh,
+  platformsToAlwaysRefresh,
+} from "./posting/token-refresh";
+import { DeleteFromPlatformData, DeleteResult, SocialAccount } from "./posting/post.types";
+import { differenceInDays } from "date-fns";
+import { Database } from "./supabase.types";
+
+const supabaseClient = createClient<Database>(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+export const deleteFromPlatform = task({
+  id: "delete-from-platform",
+  maxDuration: 3600,
+  retry: {
+    maxAttempts: 2,
+  },
+  machine: "small-2x",
+  run: async (payload: DeleteFromPlatformData): Promise<DeleteResult> => {
+    const { resultId, postId, projectId, platform, account, providerPostId, appCredentials } =
+      payload;
+    let deleteResult: DeleteResult | null = null;
+
+    try {
+      await tags.add(`${account.id}`);
+
+      logger.info("Starting platform delete", { ...payload });
+
+      const postClient = createPostClient({
+        supabaseClient,
+        platformName: platform,
+        appCredentials,
+      });
+
+      if (
+        platformsToAlwaysRefresh.includes(account.provider) ||
+        differenceInDays(
+          account.access_token_expires_at || new Date(),
+          new Date(),
+        ) <= 7
+      ) {
+        logger.info("Refreshing Token", {
+          platform: account.provider,
+          account,
+        });
+        const refreshed = await handleTokenRefresh({
+          supabaseClient,
+          postClient,
+          account: account as SocialAccount,
+        });
+
+        if (!refreshed.success) {
+          logger.error("Failed to refresh token", {
+            account,
+            error: refreshed.error,
+          });
+          deleteResult = {
+            provider_connection_id: account.id,
+            success: false,
+            error_message: refreshed.error,
+          };
+
+          throw new Error("Invalid Token");
+        }
+      }
+
+      deleteResult = await postClient.delete({ account, providerPostId });
+    } catch (error) {
+      logger.error("Failed Deleting Platform Post", { error });
+
+      if (!deleteResult) {
+        deleteResult = {
+          provider_connection_id: account.id,
+          success: false,
+          error_message:
+            "Unexpected Error: Delete Status Unavailable, Please check the social account.",
+          details: { error },
+        };
+      }
+    }
+
+    await tags.add(`result_${deleteResult.success ? "deleted" : "delete_error"}`);
+
+    logger.info("Saving delete result", { deleteResult });
+    const { error: updateResultError } = await supabaseClient
+      .from("social_post_results")
+      .update({
+        delete_status: deleteResult.success ? "deleted" : "delete_failed",
+        delete_error_message: deleteResult.error_message ?? null,
+        deleted_at: deleteResult.success ? new Date().toISOString() : null,
+      })
+      .eq("id", resultId);
+
+    if (updateResultError) {
+      logger.error("Failed to update post result", { updateResultError });
+    }
+
+    await tasks.trigger("process-webhooks", {
+      projectId,
+      eventType: "social.post.result.deleted",
+      eventData: {
+        id: resultId,
+        post_id: postId,
+        social_account_id: account.id,
+        success: deleteResult.success,
+        error: deleteResult.error_message,
+        details: deleteResult.details,
+      },
+    });
+
+    const { data: remainingResults, error: remainingResultsError } =
+      await supabaseClient
+        .from("social_post_results")
+        .select("delete_status")
+        .eq("post_id", postId);
+
+    if (remainingResultsError) {
+      logger.error("Failed to load remaining results for finalization", {
+        remainingResultsError,
+      });
+    } else {
+      const stillPending = remainingResults.some((r) =>
+        ["not_deleted", "deleting"].includes(r.delete_status),
+      );
+
+      if (!stillPending) {
+        const allDeleted = remainingResults.every(
+          (r) => r.delete_status === "deleted",
+        );
+
+        const { data: finalizedPosts, error: finalizeError } =
+          await supabaseClient
+            .from("social_posts")
+            .update({
+              status: allDeleted ? "deleted" : "delete_failed",
+            })
+            .eq("id", postId)
+            .eq("status", "deleting")
+            .select();
+
+        if (finalizeError) {
+          logger.error("Failed to finalize post delete status", {
+            finalizeError,
+          });
+        } else if (finalizedPosts && finalizedPosts.length > 0) {
+          await tasks.trigger("process-webhooks", {
+            projectId,
+            eventType: "social.post.deleted",
+            eventData: finalizedPosts[0],
+          });
+        }
+      }
+    }
+
+    logger.info("Platform delete complete", { ...deleteResult });
+    return deleteResult;
+  },
+});

--- a/trigger/delete-from-platform.ts
+++ b/trigger/delete-from-platform.ts
@@ -8,7 +8,7 @@ import {
 import { DeleteFromPlatformData, DeleteResult, SocialAccount } from "./posting/post.types";
 import { differenceInDays } from "date-fns";
 import { Database } from "./supabase.types";
-import { transformPostData } from "./posting/transform-post-data";
+import { finalizePostDeleteIfComplete } from "./posting/finalize-post-delete";
 
 const supabaseClient = createClient<Database>(
   process.env.SUPABASE_URL!,
@@ -135,81 +135,7 @@ export const deleteFromPlatform = task({
       },
     });
 
-    const { data: remainingResults, error: remainingResultsError } =
-      await supabaseClient
-        .from("social_post_results")
-        .select("delete_status")
-        .eq("post_id", postId);
-
-    if (remainingResultsError) {
-      logger.error("Failed to load remaining results for finalization", {
-        remainingResultsError,
-      });
-    } else {
-      const stillPending = remainingResults.some(
-        (r) => r.delete_status === "deleting",
-      );
-
-      if (!stillPending) {
-        // Only results that were actually queued for deletion decide the
-        // outcome; `not_deleted` results (original publish failures, missing
-        // app credentials) were never attempted and must not block or fail
-        // finalization.
-        const attempted = remainingResults.filter(
-          (r) => r.delete_status !== "not_deleted",
-        );
-        const allDeleted =
-          attempted.length > 0 &&
-          attempted.every((r) => r.delete_status === "deleted");
-
-        const { data: finalizedPosts, error: finalizeError } =
-          await supabaseClient
-            .from("social_posts")
-            .update({
-              status: allDeleted ? "deleted" : "delete_failed",
-            })
-            .eq("id", postId)
-            .eq("status", "deleting")
-            .select(
-              `
-              *,
-              social_post_provider_connections (
-                social_provider_connections (
-                  *
-                )
-              ),
-              social_post_media (
-                url,
-                thumbnail_url,
-                thumbnail_timestamp_ms,
-                provider,
-                provider_connection_id,
-                tags
-              ),
-              social_post_configurations (
-                caption,
-                provider,
-                provider_connection_id,
-                provider_data
-              )
-              `,
-            );
-
-        if (finalizeError) {
-          logger.error("Failed to finalize post delete status", {
-            finalizeError,
-          });
-        } else if (finalizedPosts && finalizedPosts.length > 0) {
-          await tasks.trigger("process-webhooks", {
-            projectId,
-            eventType: "social.post.deleted",
-            // Emit the same post shape as `social.post.updated` so every
-            // post-level webhook carries an identical schema.
-            eventData: transformPostData(finalizedPosts[0]),
-          });
-        }
-      }
-    }
+    await finalizePostDeleteIfComplete({ supabaseClient, postId, projectId });
 
     logger.info("Platform delete complete", { ...deleteResult });
     return deleteResult;

--- a/trigger/delete-from-platform.ts
+++ b/trigger/delete-from-platform.ts
@@ -8,6 +8,7 @@ import {
 import { DeleteFromPlatformData, DeleteResult, SocialAccount } from "./posting/post.types";
 import { differenceInDays } from "date-fns";
 import { Database } from "./supabase.types";
+import { transformPostData } from "./posting/transform-post-data";
 
 const supabaseClient = createClient<Database>(
   process.env.SUPABASE_URL!,
@@ -31,45 +32,66 @@ export const deleteFromPlatform = task({
 
       logger.info("Starting platform delete", { ...payload });
 
-      const postClient = createPostClient({
-        supabaseClient,
-        platformName: platform,
-        appCredentials,
-      });
+      // Platform deletes are not idempotent: deleting an already-deleted post
+      // returns an error on most platforms, which would flip a previously
+      // successful `deleted` result to `delete_failed` on a task retry. If this
+      // result was already deleted on a prior attempt, skip the platform call
+      // and let the finalization logic below run idempotently.
+      const { data: existingResult } = await supabaseClient
+        .from("social_post_results")
+        .select("delete_status")
+        .eq("id", resultId)
+        .maybeSingle();
 
-      if (
-        platformsToAlwaysRefresh.includes(account.provider) ||
-        differenceInDays(
-          account.access_token_expires_at || new Date(),
-          new Date(),
-        ) <= 7
-      ) {
-        logger.info("Refreshing Token", {
-          platform: account.provider,
-          account,
+      if (existingResult?.delete_status === "deleted") {
+        logger.info("Result already deleted on a prior attempt; skipping platform delete", {
+          resultId,
         });
-        const refreshed = await handleTokenRefresh({
+        deleteResult = {
+          provider_connection_id: account.id,
+          success: true,
+        };
+      } else {
+        const postClient = createPostClient({
           supabaseClient,
-          postClient,
-          account: account as SocialAccount,
+          platformName: platform,
+          appCredentials,
         });
 
-        if (!refreshed.success) {
-          logger.error("Failed to refresh token", {
+        if (
+          platformsToAlwaysRefresh.includes(account.provider) ||
+          differenceInDays(
+            account.access_token_expires_at || new Date(),
+            new Date(),
+          ) <= 7
+        ) {
+          logger.info("Refreshing Token", {
+            platform: account.provider,
             account,
-            error: refreshed.error,
           });
-          deleteResult = {
-            provider_connection_id: account.id,
-            success: false,
-            error_message: refreshed.error,
-          };
+          const refreshed = await handleTokenRefresh({
+            supabaseClient,
+            postClient,
+            account: account as SocialAccount,
+          });
 
-          throw new Error("Invalid Token");
+          if (!refreshed.success) {
+            logger.error("Failed to refresh token", {
+              account,
+              error: refreshed.error,
+            });
+            deleteResult = {
+              provider_connection_id: account.id,
+              success: false,
+              error_message: refreshed.error,
+            };
+
+            throw new Error("Invalid Token");
+          }
         }
-      }
 
-      deleteResult = await postClient.delete({ account, providerPostId });
+        deleteResult = await postClient.delete({ account, providerPostId });
+      }
     } catch (error) {
       logger.error("Failed Deleting Platform Post", { error });
 
@@ -148,7 +170,30 @@ export const deleteFromPlatform = task({
             })
             .eq("id", postId)
             .eq("status", "deleting")
-            .select();
+            .select(
+              `
+              *,
+              social_post_provider_connections (
+                social_provider_connections (
+                  *
+                )
+              ),
+              social_post_media (
+                url,
+                thumbnail_url,
+                thumbnail_timestamp_ms,
+                provider,
+                provider_connection_id,
+                tags
+              ),
+              social_post_configurations (
+                caption,
+                provider,
+                provider_connection_id,
+                provider_data
+              )
+              `,
+            );
 
         if (finalizeError) {
           logger.error("Failed to finalize post delete status", {
@@ -158,7 +203,9 @@ export const deleteFromPlatform = task({
           await tasks.trigger("process-webhooks", {
             projectId,
             eventType: "social.post.deleted",
-            eventData: finalizedPosts[0],
+            // Emit the same post shape as `social.post.updated` so every
+            // post-level webhook carries an identical schema.
+            eventData: transformPostData(finalizedPosts[0]),
           });
         }
       }

--- a/trigger/delete-from-platform.ts
+++ b/trigger/delete-from-platform.ts
@@ -124,14 +124,21 @@ export const deleteFromPlatform = task({
         remainingResultsError,
       });
     } else {
-      const stillPending = remainingResults.some((r) =>
-        ["not_deleted", "deleting"].includes(r.delete_status),
+      const stillPending = remainingResults.some(
+        (r) => r.delete_status === "deleting",
       );
 
       if (!stillPending) {
-        const allDeleted = remainingResults.every(
-          (r) => r.delete_status === "deleted",
+        // Only results that were actually queued for deletion decide the
+        // outcome; `not_deleted` results (original publish failures, missing
+        // app credentials) were never attempted and must not block or fail
+        // finalization.
+        const attempted = remainingResults.filter(
+          (r) => r.delete_status !== "not_deleted",
         );
+        const allDeleted =
+          attempted.length > 0 &&
+          attempted.every((r) => r.delete_status === "deleted");
 
         const { data: finalizedPosts, error: finalizeError } =
           await supabaseClient

--- a/trigger/post-to-platform.ts
+++ b/trigger/post-to-platform.ts
@@ -1,20 +1,13 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@supabase/supabase-js";
 import { idempotencyKeys, logger, task, tags, tasks } from "@trigger.dev/sdk";
-import { PostClient } from "./posting/post-client";
-import { TwitterPostClient } from "./posting/platforms/twitter-post-client";
-import { InstagramPostClient } from "./posting/platforms/instagram-post-client";
-import { FacebookPostClient } from "./posting/platforms/facebook-post-client";
-import { LinkedInPostClient } from "./posting/platforms/linkedin-post-client";
-import { TikTokPostClient } from "./posting/platforms/tiktok-post-client";
-import { BlueskyPostClient } from "./posting/platforms/bluesky-post-client";
-import { ThreadsPostClient } from "./posting/platforms/threads-post-client";
-import { PinterestPostClient } from "./posting/platforms/pinterest-post-client";
-import { YouTubePostClient } from "./posting/platforms/youtube-post-client";
-import { TikTokBusinessPostClient } from "./posting/platforms/tiktok_business-post-client";
+import { createPostClient } from "./posting/create-post-client";
+import {
+  handleTokenRefresh,
+  platformsToAlwaysRefresh,
+} from "./posting/token-refresh";
 
 import {
   IndividualPostData,
-  PlatformAppCredentials,
   PostResult,
   SocialAccount,
 } from "./posting/post.types";
@@ -29,108 +22,6 @@ const supabaseClient = createClient<Database>(
   process.env.SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
-
-const createPostClient = ({
-  supabaseClient,
-  platformName,
-  appCredentials,
-}: {
-  supabaseClient: SupabaseClient;
-  platformName: string;
-  appCredentials: PlatformAppCredentials;
-}): PostClient => {
-  switch (platformName) {
-    case "x":
-      return new TwitterPostClient(supabaseClient, appCredentials);
-    case "instagram":
-      return new InstagramPostClient(supabaseClient, appCredentials);
-    case "facebook":
-      return new FacebookPostClient(supabaseClient, appCredentials);
-    case "linkedin":
-      return new LinkedInPostClient(supabaseClient, appCredentials);
-    case "tiktok":
-      return new TikTokPostClient(supabaseClient, appCredentials);
-    case "bluesky":
-      return new BlueskyPostClient(supabaseClient, appCredentials);
-    case "threads":
-      return new ThreadsPostClient(supabaseClient, appCredentials);
-    case "pinterest":
-      return new PinterestPostClient(supabaseClient, appCredentials);
-    case "youtube":
-      return new YouTubePostClient(supabaseClient, appCredentials);
-    case "tiktok_business":
-      return new TikTokBusinessPostClient(supabaseClient, appCredentials);
-    default:
-      throw Error("Invalid Platform");
-  }
-};
-
-const platformsToAlwaysRefresh = ["youtube", "bluesky"];
-
-const handleTokenRefresh = async ({
-  postClient,
-  account,
-}: {
-  postClient: PostClient;
-  account: SocialAccount;
-}): Promise<{ success: boolean; error?: string }> => {
-  try {
-    const { access_token, expires_at, refresh_token } =
-      await postClient.refreshAccessToken(account);
-
-    if (!access_token) {
-      console.error(
-        `Failed to refresh ${account.provider} token for account ${account.id}`,
-      );
-
-      return {
-        success: false,
-        error: `Failed to refresh ${account.provider} token for account ${account.id}`,
-      };
-    }
-
-    const updateData: {
-      access_token?: string;
-      access_token_expires_at?: string;
-      refresh_token?: string;
-    } = {
-      access_token,
-      access_token_expires_at: expires_at,
-    };
-
-    account.access_token = access_token;
-    account.access_token_expires_at = new Date(expires_at);
-
-    if (refresh_token) {
-      updateData.refresh_token = refresh_token;
-      account.refresh_token = refresh_token;
-    }
-
-    const { error } = await supabaseClient
-      .from("social_provider_connections")
-      .update(updateData)
-      .eq("id", account.id);
-
-    if (error) {
-      console.error(error);
-
-      return {
-        success: false,
-        error: error.message,
-      };
-    }
-  } catch (refreshError) {
-    console.error(refreshError);
-    return {
-      success: false,
-      error: refreshError.message,
-    };
-  }
-
-  return {
-    success: true,
-  };
-};
 
 export const postToPlatform = task({
   id: "post-to-platform",
@@ -180,6 +71,7 @@ export const postToPlatform = task({
           account,
         });
         const refreshed = await handleTokenRefresh({
+          supabaseClient,
           postClient,
           account: account as SocialAccount,
         });

--- a/trigger/posting/create-post-client.ts
+++ b/trigger/posting/create-post-client.ts
@@ -1,0 +1,48 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { PostClient } from "./post-client";
+import { TwitterPostClient } from "./platforms/twitter-post-client";
+import { InstagramPostClient } from "./platforms/instagram-post-client";
+import { FacebookPostClient } from "./platforms/facebook-post-client";
+import { LinkedInPostClient } from "./platforms/linkedin-post-client";
+import { TikTokPostClient } from "./platforms/tiktok-post-client";
+import { BlueskyPostClient } from "./platforms/bluesky-post-client";
+import { ThreadsPostClient } from "./platforms/threads-post-client";
+import { PinterestPostClient } from "./platforms/pinterest-post-client";
+import { YouTubePostClient } from "./platforms/youtube-post-client";
+import { TikTokBusinessPostClient } from "./platforms/tiktok_business-post-client";
+import { PlatformAppCredentials } from "./post.types";
+
+export const createPostClient = ({
+  supabaseClient,
+  platformName,
+  appCredentials,
+}: {
+  supabaseClient: SupabaseClient;
+  platformName: string;
+  appCredentials: PlatformAppCredentials;
+}): PostClient => {
+  switch (platformName) {
+    case "x":
+      return new TwitterPostClient(supabaseClient, appCredentials);
+    case "instagram":
+      return new InstagramPostClient(supabaseClient, appCredentials);
+    case "facebook":
+      return new FacebookPostClient(supabaseClient, appCredentials);
+    case "linkedin":
+      return new LinkedInPostClient(supabaseClient, appCredentials);
+    case "tiktok":
+      return new TikTokPostClient(supabaseClient, appCredentials);
+    case "bluesky":
+      return new BlueskyPostClient(supabaseClient, appCredentials);
+    case "threads":
+      return new ThreadsPostClient(supabaseClient, appCredentials);
+    case "pinterest":
+      return new PinterestPostClient(supabaseClient, appCredentials);
+    case "youtube":
+      return new YouTubePostClient(supabaseClient, appCredentials);
+    case "tiktok_business":
+      return new TikTokBusinessPostClient(supabaseClient, appCredentials);
+    default:
+      throw Error("Invalid Platform");
+  }
+};

--- a/trigger/posting/delete-capability.ts
+++ b/trigger/posting/delete-capability.ts
@@ -1,0 +1,44 @@
+// Vendored copy of api/src/social-posts/delete-capability.ts (dumb-monorepo: no
+// cross-sibling imports). Keep the two in sync. Used to stamp `delete_supported`
+// on webhook `social_accounts` so the webhook payload matches the API response.
+
+const DELETE_SUPPORTED_PROVIDERS = [
+  "x",
+  "instagram",
+  "facebook",
+  "linkedin",
+  "bluesky",
+  "threads",
+  "pinterest",
+  "youtube",
+];
+
+const REQUIRED_DELETE_SCOPE: Record<string, string> = {
+  instagram: "instagram_manage_contents",
+  threads: "threads_delete",
+};
+
+export function connectionSupportsDelete({
+  provider,
+  connectionType,
+  grantedScopes,
+}: {
+  provider: string | null | undefined;
+  connectionType?: string | null;
+  grantedScopes?: string[] | null;
+}): boolean {
+  if (!provider || !DELETE_SUPPORTED_PROVIDERS.includes(provider)) {
+    return false;
+  }
+
+  if (provider === "instagram" && connectionType === "instagram") {
+    return false;
+  }
+
+  const requiredScope = REQUIRED_DELETE_SCOPE[provider];
+  if (requiredScope && !(grantedScopes ?? []).includes(requiredScope)) {
+    return false;
+  }
+
+  return true;
+}

--- a/trigger/posting/finalize-post-delete.ts
+++ b/trigger/posting/finalize-post-delete.ts
@@ -1,0 +1,97 @@
+import { logger, tasks } from "@trigger.dev/sdk";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { transformPostData } from "./transform-post-data";
+
+const POST_WITH_RELATIONS_SELECT = `
+  *,
+  social_post_provider_connections (
+    social_provider_connections (
+      *
+    )
+  ),
+  social_post_media (
+    url,
+    thumbnail_url,
+    thumbnail_timestamp_ms,
+    provider,
+    provider_connection_id,
+    tags
+  ),
+  social_post_configurations (
+    caption,
+    provider,
+    provider_connection_id,
+    provider_data
+  )
+`;
+
+/**
+ * Finalizes a post that is being deleted from its platforms: if no result is
+ * still `deleting`, flips the post from `deleting` to `deleted`/`delete_failed`
+ * and emits `social.post.deleted`. Only results that were actually attempted
+ * (`deleting`/`deleted`/`delete_failed`) decide the outcome — `not_deleted`
+ * results (never queued: original publish failures) are ignored. The
+ * `.eq("status", "deleting")` guard ensures exactly one caller wins, so this is
+ * safe to call from every parallel delete task and from the reconciliation cron.
+ */
+export async function finalizePostDeleteIfComplete({
+  supabaseClient,
+  postId,
+  projectId,
+}: {
+  supabaseClient: SupabaseClient;
+  postId: string;
+  projectId: string;
+}): Promise<void> {
+  const { data: remainingResults, error: remainingResultsError } =
+    await supabaseClient
+      .from("social_post_results")
+      .select("delete_status")
+      .eq("post_id", postId);
+
+  if (remainingResultsError) {
+    logger.error("Failed to load remaining results for finalization", {
+      remainingResultsError,
+    });
+    return;
+  }
+
+  const stillPending = (remainingResults ?? []).some(
+    (r) => r.delete_status === "deleting",
+  );
+
+  if (stillPending) {
+    return;
+  }
+
+  const attempted = (remainingResults ?? []).filter(
+    (r) => r.delete_status !== "not_deleted",
+  );
+  const allDeleted =
+    attempted.length > 0 &&
+    attempted.every((r) => r.delete_status === "deleted");
+
+  const { data: finalizedPosts, error: finalizeError } = await supabaseClient
+    .from("social_posts")
+    .update({
+      status: allDeleted ? "deleted" : "delete_failed",
+    })
+    .eq("id", postId)
+    .eq("status", "deleting")
+    .select(POST_WITH_RELATIONS_SELECT);
+
+  if (finalizeError) {
+    logger.error("Failed to finalize post delete status", { finalizeError });
+    return;
+  }
+
+  if (finalizedPosts && finalizedPosts.length > 0) {
+    await tasks.trigger("process-webhooks", {
+      projectId,
+      eventType: "social.post.deleted",
+      // Emit the same post shape as `social.post.updated` so every post-level
+      // webhook carries an identical schema.
+      eventData: transformPostData(finalizedPosts[0]),
+    });
+  }
+}

--- a/trigger/posting/platforms/bluesky-post-client.ts
+++ b/trigger/posting/platforms/bluesky-post-client.ts
@@ -224,6 +224,57 @@ export class BlueskyPostClient extends PostClient {
     }
   }
 
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }) {
+    try {
+      this.#requests.push({ deleteRequest: { uri: providerPostId } });
+
+      const match = providerPostId.match(/^at:\/\/([^/]+)\/([^/]+)\/([^/]+)$/);
+      if (!match) {
+        throw new Error(`Invalid Bluesky post URI: ${providerPostId}`);
+      }
+
+      const [, repo, collection, rkey] = match;
+
+      await this.#agent.com.atproto.repo.deleteRecord({
+        repo,
+        collection,
+        rkey,
+      });
+
+      this.#responses.push({ deleteResponse: "deleted" });
+
+      return {
+        success: true,
+        provider_connection_id: account.id,
+        details: {
+          requests: this.#requests,
+          responses: this.#responses,
+        },
+      };
+    } catch (error) {
+      console.error(
+        `Failed to delete Bluesky post ${providerPostId} for account: ${account.id}`,
+        error,
+      );
+      return {
+        success: false,
+        provider_connection_id: account.id,
+        error_message: `Failed to delete Bluesky post: ${error.message}`,
+        details: {
+          error,
+          requests: this.#requests,
+          responses: this.#responses,
+        },
+      };
+    }
+  }
+
   async #processVideo({ medium }: { medium: PostMedia }): Promise<{
     video: BlobRef;
     aspectRatio: {

--- a/trigger/posting/platforms/facebook-post-client.ts
+++ b/trigger/posting/platforms/facebook-post-client.ts
@@ -242,6 +242,46 @@ export class FacebookPostClient extends PostClient {
     }
   }
 
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }) {
+    try {
+      const response = await axios.delete(
+        `https://graph.facebook.com/v20.0/${providerPostId}`,
+        {
+          params: { access_token: account.access_token },
+        },
+      );
+
+      if (response.data.error) {
+        throw new Error(response.data.error.message as string);
+      }
+
+      return {
+        success: !!response.data.success,
+        provider_connection_id: account.id,
+        details: { response: response.data },
+      };
+    } catch (error) {
+      console.error(
+        `Error deleting Facebook post ${providerPostId} for account ${account.id} :`,
+        error.response?.data || error,
+      );
+      return {
+        success: false,
+        provider_connection_id: account.id,
+        error_message: `Failed to delete Facebook post: ${
+          error.response?.data?.error?.message || error.message
+        }`,
+        details: { error },
+      };
+    }
+  }
+
   async #createTextPost({
     account,
     caption,

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -311,6 +311,46 @@ export class InstagramPostClient extends PostClient {
     }
   }
 
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }) {
+    try {
+      const response = await axios.delete(
+        `${this.getApiBaseUrl(account)}/${providerPostId}`,
+        {
+          params: { access_token: account.access_token },
+        },
+      );
+
+      if (response.data.error) {
+        throw new Error(response.data.error.message as string);
+      }
+
+      return {
+        success: !!response.data.success,
+        provider_connection_id: account.id,
+        details: { response: response.data },
+      };
+    } catch (error) {
+      console.error(
+        `Error deleting Instagram post ${providerPostId} for account ${account.id} :`,
+        error,
+      );
+      return {
+        success: false,
+        provider_connection_id: account.id,
+        error_message: `Failed to delete Instagram post: ${
+          error.response?.data?.error?.message || error.message
+        }`,
+        details: { error },
+      };
+    }
+  }
+
   async #processMedia({
     account,
     media,

--- a/trigger/posting/platforms/linkedin-post-client.ts
+++ b/trigger/posting/platforms/linkedin-post-client.ts
@@ -179,6 +179,51 @@ export class LinkedInPostClient extends PostClient {
     }
   }
 
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }) {
+    try {
+      const urn = this.#toUgcPostUrn(providerPostId);
+      const response = await fetch(
+        `https://api.linkedin.com/v2/ugcPosts/${encodeURIComponent(urn)}`,
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${account.access_token}`,
+            "X-Restli-Protocol-Version": "2.0.0",
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          `LinkedIn API error: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      return {
+        success: true,
+        provider_connection_id: account.id,
+        details: { status: response.status },
+      };
+    } catch (error) {
+      console.error(
+        `Failed to delete LinkedIn post ${providerPostId} for account: ${account.id}`,
+        error,
+      );
+      return {
+        success: false,
+        provider_connection_id: account.id,
+        error_message: `Failed to delete LinkedIn post: ${error.message}`,
+        details: { error },
+      };
+    }
+  }
+
   #extractFirstUrl(text: string) {
     const urlRegex = /(https?:\/\/|www\.)[^\s]+/g;
     const matches = text.match(urlRegex);

--- a/trigger/posting/platforms/pinterest-post-client.ts
+++ b/trigger/posting/platforms/pinterest-post-client.ts
@@ -160,6 +160,57 @@ export class PinterestPostClient extends PostClient {
     }
   }
 
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }) {
+    let deleteUrl = `https://api.pinterest.com/v5/pins/${providerPostId}`;
+    if (account.social_provider_metadata?.is_sandbox) {
+      deleteUrl = `https://api-sandbox.pinterest.com/v5/pins/${providerPostId}`;
+    }
+
+    try {
+      this.#requests.push({ deleteRequest: deleteUrl });
+
+      const response = await axios.delete(deleteUrl, {
+        headers: {
+          Authorization: `Bearer ${account.access_token}`,
+        },
+      });
+
+      this.#responses.push({ deleteResponse: response.status });
+
+      return {
+        success: response.status === 204 || response.status === 200,
+        provider_connection_id: account.id,
+        details: {
+          requests: this.#requests,
+          responses: this.#responses,
+        },
+      };
+    } catch (error) {
+      console.error(
+        `Failed to delete Pinterest pin ${providerPostId} for account: ${account.id}`,
+        error.response?.data || error,
+      );
+      return {
+        success: false,
+        provider_connection_id: account.id,
+        error_message: `Failed to delete Pinterest pin: ${
+          error.response?.data?.message || error.message
+        }`,
+        details: {
+          error: error.response?.data || error.message,
+          requests: this.#requests,
+          responses: this.#responses,
+        },
+      };
+    }
+  }
+
   async #getOrCreateBoardId(account: SocialAccount): Promise<string> {
     let boardsUrl = "https://api.pinterest.com/v5/boards";
     if (account.social_provider_metadata?.is_sandbox) {

--- a/trigger/posting/platforms/threads-post-client.ts
+++ b/trigger/posting/platforms/threads-post-client.ts
@@ -208,6 +208,63 @@ export class ThreadsPostClient extends PostClient {
     }
   }
 
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }) {
+    try {
+      this.#requests.push({
+        deleteRequest: {
+          url: `https://graph.threads.net/v1.0/${providerPostId}`,
+        },
+      });
+
+      const response = await axios.delete(
+        `https://graph.threads.net/v1.0/${providerPostId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${account.access_token}`,
+          },
+        },
+      );
+
+      this.#responses.push({ deleteResponse: response.data });
+
+      if (response.data?.error) {
+        throw new Error(response.data.error.message as string);
+      }
+
+      return {
+        success: !!response.data?.success,
+        provider_connection_id: account.id,
+        details: {
+          requests: this.#requests,
+          responses: this.#responses,
+        },
+      };
+    } catch (error: any) {
+      console.error(
+        `Failed to delete Threads post ${providerPostId} for account: ${account.id}`,
+        error.response?.data || error,
+      );
+      return {
+        success: false,
+        provider_connection_id: account.id,
+        error_message: `Failed to delete Threads post: ${
+          error.response?.data?.error?.message || error.message
+        }`,
+        details: {
+          error: error.response?.data || error.message,
+          requests: this.#requests,
+          responses: this.#responses,
+        },
+      };
+    }
+  }
+
   async #processText(
     account: SocialAccount,
     caption: string,

--- a/trigger/posting/platforms/twitter-post-client.ts
+++ b/trigger/posting/platforms/twitter-post-client.ts
@@ -159,6 +159,42 @@ export class TwitterPostClient extends PostClient {
     }
   }
 
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }) {
+    try {
+      const twitterClient = new TwitterApi({
+        appKey: this.#appKey,
+        appSecret: this.#appSecret,
+        accessToken: account.access_token,
+        accessSecret: account.refresh_token,
+      } as TwitterApiTokens);
+
+      const result = await twitterClient.v2.deleteTweet(providerPostId);
+
+      return {
+        success: !!result.data?.deleted,
+        provider_connection_id: account.id,
+        details: { response: result },
+      };
+    } catch (error) {
+      console.error(
+        `Error deleting Twitter post ${providerPostId} for account ${account.id} :`,
+        error,
+      );
+      return {
+        success: false,
+        provider_connection_id: account.id,
+        error_message: `Failed to delete Twitter post: ${error.message}`,
+        details: { error },
+      };
+    }
+  }
+
   async #processMedia({
     twitterClient,
     media,

--- a/trigger/posting/platforms/youtube-post-client.ts
+++ b/trigger/posting/platforms/youtube-post-client.ts
@@ -273,6 +273,62 @@ export class YouTubePostClient extends PostClient {
     }
   }
 
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }) {
+    try {
+      const oauth2Client = new google.auth.OAuth2(
+        this.#googleClientId,
+        this.#googleClientSecret,
+        `${process.env.NEXTAUTH_URL}/api/youtube-auth/callback`,
+      );
+
+      oauth2Client.setCredentials({
+        access_token: account.access_token,
+        refresh_token: account.refresh_token,
+      });
+
+      const youtube = google.youtube({
+        version: "v3",
+        auth: oauth2Client,
+      }) as youtube_v3.Youtube;
+
+      this.#requests.push({ deleteRequest: { id: providerPostId } });
+
+      await youtube.videos.delete({ id: providerPostId });
+
+      this.#responses.push({ deleteResponse: "deleted" });
+
+      return {
+        success: true,
+        provider_connection_id: account.id,
+        details: {
+          requests: this.#requests,
+          responses: this.#responses,
+        },
+      };
+    } catch (error: any) {
+      console.error(
+        `Failed to delete YouTube video ${providerPostId} for account: ${account.id}`,
+        error?.response?.data || error,
+      );
+      return {
+        success: false,
+        provider_connection_id: account.id,
+        error_message: `Failed to delete YouTube video: ${error.message}`,
+        details: {
+          error: error?.response?.data || error,
+          requests: this.#requests,
+          responses: this.#responses,
+        },
+      };
+    }
+  }
+
   async #pollProcessingDetails(
     youtube: youtube_v3.Youtube,
     videoId: string,

--- a/trigger/posting/post-client.ts
+++ b/trigger/posting/post-client.ts
@@ -9,6 +9,7 @@ import { pipeline } from "stream/promises";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
   BlueskyConfiguration,
+  DeleteResult,
   FacebookConfiguration,
   InstagramConfiguration,
   LinkedinConfiguration,
@@ -79,6 +80,22 @@ export class PostClient {
       post_id: postId,
       provider_connection_id: account.id,
       success: false,
+    };
+  }
+
+  async delete({
+    account,
+    providerPostId,
+  }: {
+    account: SocialAccount;
+    providerPostId: string;
+  }): Promise<DeleteResult> {
+    //Implement at platform level
+    console.log(account, providerPostId);
+    return {
+      provider_connection_id: account.id,
+      success: false,
+      error_message: "Delete not implemented for this platform",
     };
   }
 

--- a/trigger/posting/post.types.ts
+++ b/trigger/posting/post.types.ts
@@ -8,6 +8,13 @@ export interface PostResult {
   details?: any;
 }
 
+export interface DeleteResult {
+  provider_connection_id: string;
+  success: boolean;
+  error_message?: string;
+  details?: any;
+}
+
 export interface UserTag {
   id: string;
   type: string;
@@ -240,5 +247,15 @@ export interface IndividualPostData {
   account: SocialAccount;
   projectId: string;
   platformConfig: PlatformConfiguration;
+  appCredentials: PlatformAppCredentials;
+}
+
+export interface DeleteFromPlatformData {
+  resultId: string;
+  postId: string;
+  projectId: string;
+  platform: string;
+  account: SocialAccount;
+  providerPostId: string;
   appCredentials: PlatformAppCredentials;
 }

--- a/trigger/posting/token-refresh.ts
+++ b/trigger/posting/token-refresh.ts
@@ -1,0 +1,72 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { PostClient } from "./post-client";
+import { SocialAccount } from "./post.types";
+
+export const platformsToAlwaysRefresh = ["youtube", "bluesky"];
+
+export const handleTokenRefresh = async ({
+  supabaseClient,
+  postClient,
+  account,
+}: {
+  supabaseClient: SupabaseClient;
+  postClient: PostClient;
+  account: SocialAccount;
+}): Promise<{ success: boolean; error?: string }> => {
+  try {
+    const { access_token, expires_at, refresh_token } =
+      await postClient.refreshAccessToken(account);
+
+    if (!access_token) {
+      console.error(
+        `Failed to refresh ${account.provider} token for account ${account.id}`,
+      );
+
+      return {
+        success: false,
+        error: `Failed to refresh ${account.provider} token for account ${account.id}`,
+      };
+    }
+
+    const updateData: {
+      access_token?: string;
+      access_token_expires_at?: string;
+      refresh_token?: string;
+    } = {
+      access_token,
+      access_token_expires_at: expires_at,
+    };
+
+    account.access_token = access_token;
+    account.access_token_expires_at = new Date(expires_at);
+
+    if (refresh_token) {
+      updateData.refresh_token = refresh_token;
+      account.refresh_token = refresh_token;
+    }
+
+    const { error } = await supabaseClient
+      .from("social_provider_connections")
+      .update(updateData)
+      .eq("id", account.id);
+
+    if (error) {
+      console.error(error);
+
+      return {
+        success: false,
+        error: error.message,
+      };
+    }
+  } catch (refreshError) {
+    console.error(refreshError);
+    return {
+      success: false,
+      error: refreshError.message,
+    };
+  }
+
+  return {
+    success: true,
+  };
+};

--- a/trigger/posting/transform-post-data.ts
+++ b/trigger/posting/transform-post-data.ts
@@ -1,0 +1,130 @@
+import type { PlatformConfiguration } from "./post.types";
+import type { Database, Json } from "../supabase.types";
+
+/**
+ * Maps a raw `social_posts` row (with its provider-connection, media and
+ * configuration relations) into the public post shape used for
+ * `social.post.*` webhook payloads. Shared by process-post (`social.post.updated`)
+ * and delete-from-platform (`social.post.deleted`) so every post-level webhook
+ * emits an identical schema.
+ */
+export const transformPostData = (data: {
+  caption: string;
+  created_at: string;
+  external_id: string | null;
+  id: string;
+  post_at: string;
+  project_id: string;
+  status: Database["public"]["Enums"]["social_post_status"];
+  updated_at: string;
+  social_post_provider_connections: {
+    social_provider_connections: {
+      provider: string;
+      id: string;
+      social_provider_user_name: string | null | undefined;
+      social_provider_user_id: string;
+      access_token: string | null | undefined;
+      refresh_token: string | null | undefined;
+      access_token_expires_at: string | null | undefined;
+      refresh_token_expires_at: string | null | undefined;
+      external_id: string | null | undefined;
+    };
+  }[];
+  social_post_media: {
+    url: string;
+    thumbnail_url: string | null;
+    thumbnail_timestamp_ms: number | null;
+    provider: string | null;
+    provider_connection_id: string | null;
+    tags?: Json;
+  }[];
+  social_post_configurations: {
+    caption: string | null;
+    provider: string | null;
+    provider_connection_id: string | null;
+    provider_data: any;
+  }[];
+}) => {
+  const postMedia = data.social_post_media
+    .filter((media) => !media.provider && !media.provider_connection_id)
+    .map((media) => ({
+      url: media.url,
+      thumbnail_url: media.thumbnail_url,
+      thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+      tags: media.tags as any[],
+    }));
+
+  const accountConfigurations = data.social_post_configurations
+    .filter((config) => config.provider_connection_id)
+    .map((config) => {
+      const configData: PlatformConfiguration =
+        config.provider_data as PlatformConfiguration;
+
+      return {
+        social_account_id: config.provider_connection_id!, //Social account id is always defined
+        configuration: {
+          caption: config.caption,
+          media: data.social_post_media
+            .filter((media) => media.provider_connection_id)
+            .map((media) => ({
+              url: media.url,
+              thumbnail_url: media.thumbnail_url,
+              thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+              tags: media.tags as any[],
+            })),
+          ...configData,
+        },
+      };
+    });
+
+  const platformConfigurations: any = {};
+
+  data.social_post_configurations
+    .filter((config) => config.provider)
+    .map((config) => {
+      platformConfigurations[config.provider!] = {
+        caption: config.caption,
+        media: data.social_post_media
+          .filter((media) => media.provider_connection_id)
+          .map((media) => ({
+            url: media.url,
+            thumbnail_url: media.thumbnail_url,
+            thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+            tags: media.tags as any[],
+          })),
+        ...(config.provider_data as PlatformConfiguration),
+      };
+    });
+
+  const socialAccounts = data.social_post_provider_connections.map(
+    (connection) => ({
+      id: connection.social_provider_connections.id,
+      platform: connection.social_provider_connections.provider!,
+      username:
+        connection.social_provider_connections.social_provider_user_name,
+      user_id: connection.social_provider_connections.social_provider_user_id,
+      access_token: connection.social_provider_connections.access_token || "",
+      refresh_token: connection.social_provider_connections.refresh_token,
+      access_token_expires_at:
+        connection.social_provider_connections.access_token_expires_at ||
+        new Date().toISOString(),
+      refresh_token_expires_at:
+        connection.social_provider_connections.refresh_token_expires_at,
+      external_id: connection.social_provider_connections.external_id,
+    }),
+  );
+
+  return {
+    id: data.id,
+    external_id: data.external_id,
+    caption: data.caption,
+    status: data.status,
+    media: postMedia,
+    platform_configurations: platformConfigurations,
+    account_configurations: accountConfigurations,
+    social_accounts: socialAccounts,
+    scheduled_at: data.post_at,
+    created_at: data.created_at,
+    updated_at: data.updated_at,
+  };
+};

--- a/trigger/posting/transform-post-data.ts
+++ b/trigger/posting/transform-post-data.ts
@@ -1,5 +1,6 @@
 import type { PlatformConfiguration } from "./post.types";
 import type { Database, Json } from "../supabase.types";
+import { connectionSupportsDelete } from "./delete-capability";
 
 /**
  * Maps a raw `social_posts` row (with its provider-connection, media and
@@ -28,6 +29,7 @@ export const transformPostData = (data: {
       access_token_expires_at: string | null | undefined;
       refresh_token_expires_at: string | null | undefined;
       external_id: string | null | undefined;
+      social_provider_metadata?: Json;
     };
   }[];
   social_post_media: {
@@ -97,21 +99,34 @@ export const transformPostData = (data: {
     });
 
   const socialAccounts = data.social_post_provider_connections.map(
-    (connection) => ({
-      id: connection.social_provider_connections.id,
-      platform: connection.social_provider_connections.provider!,
-      username:
-        connection.social_provider_connections.social_provider_user_name,
-      user_id: connection.social_provider_connections.social_provider_user_id,
-      access_token: connection.social_provider_connections.access_token || "",
-      refresh_token: connection.social_provider_connections.refresh_token,
-      access_token_expires_at:
-        connection.social_provider_connections.access_token_expires_at ||
-        new Date().toISOString(),
-      refresh_token_expires_at:
-        connection.social_provider_connections.refresh_token_expires_at,
-      external_id: connection.social_provider_connections.external_id,
-    }),
+    (connection) => {
+      const metadata = connection.social_provider_connections
+        .social_provider_metadata as {
+        connection_type?: string;
+        granted_scopes?: string[];
+      } | null;
+
+      return {
+        id: connection.social_provider_connections.id,
+        platform: connection.social_provider_connections.provider!,
+        username:
+          connection.social_provider_connections.social_provider_user_name,
+        user_id: connection.social_provider_connections.social_provider_user_id,
+        access_token: connection.social_provider_connections.access_token || "",
+        refresh_token: connection.social_provider_connections.refresh_token,
+        access_token_expires_at:
+          connection.social_provider_connections.access_token_expires_at ||
+          new Date().toISOString(),
+        refresh_token_expires_at:
+          connection.social_provider_connections.refresh_token_expires_at,
+        external_id: connection.social_provider_connections.external_id,
+        delete_supported: connectionSupportsDelete({
+          provider: connection.social_provider_connections.provider,
+          connectionType: metadata?.connection_type,
+          grantedScopes: metadata?.granted_scopes,
+        }),
+      };
+    },
   );
 
   return {

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -10,133 +10,13 @@ import type {
 } from "./posting/post.types";
 import { Unkey } from "@unkey/api";
 
-import { Database, Json } from "./supabase.types";
+import { Database } from "./supabase.types";
+import { transformPostData } from "./posting/transform-post-data";
 
 const supabaseClient = createClient<Database>(
   process.env.SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
-
-const transformPostData = (data: {
-  caption: string;
-  created_at: string;
-  external_id: string | null;
-  id: string;
-  post_at: string;
-  project_id: string;
-  status: Database["public"]["Enums"]["social_post_status"];
-  updated_at: string;
-  social_post_provider_connections: {
-    social_provider_connections: {
-      provider: string;
-      id: string;
-      social_provider_user_name: string | null | undefined;
-      social_provider_user_id: string;
-      access_token: string | null | undefined;
-      refresh_token: string | null | undefined;
-      access_token_expires_at: string | null | undefined;
-      refresh_token_expires_at: string | null | undefined;
-      external_id: string | null | undefined;
-    };
-  }[];
-  social_post_media: {
-    url: string;
-    thumbnail_url: string | null;
-    thumbnail_timestamp_ms: number | null;
-    provider: string | null;
-    provider_connection_id: string | null;
-    tags?: Json;
-  }[];
-  social_post_configurations: {
-    caption: string | null;
-    provider: string | null;
-    provider_connection_id: string | null;
-    provider_data: any;
-  }[];
-}) => {
-  const postMedia = data.social_post_media
-    .filter((media) => !media.provider && !media.provider_connection_id)
-    .map((media) => ({
-      url: media.url,
-      thumbnail_url: media.thumbnail_url,
-      thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
-      tags: media.tags as any[],
-    }));
-
-  const accountConfigurations = data.social_post_configurations
-    .filter((config) => config.provider_connection_id)
-    .map((config) => {
-      const configData: PlatformConfiguration =
-        config.provider_data as PlatformConfiguration;
-
-      return {
-        social_account_id: config.provider_connection_id!, //Social account id is always defined
-        configuration: {
-          caption: config.caption,
-          media: data.social_post_media
-            .filter((media) => media.provider_connection_id)
-            .map((media) => ({
-              url: media.url,
-              thumbnail_url: media.thumbnail_url,
-              thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
-              tags: media.tags as any[],
-            })),
-          ...configData,
-        },
-      };
-    });
-
-  const platformConfigurations: any = {};
-
-  data.social_post_configurations
-    .filter((config) => config.provider)
-    .map((config) => {
-      platformConfigurations[config.provider!] = {
-        caption: config.caption,
-        media: data.social_post_media
-          .filter((media) => media.provider_connection_id)
-          .map((media) => ({
-            url: media.url,
-            thumbnail_url: media.thumbnail_url,
-            thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
-            tags: media.tags as any[],
-          })),
-        ...(config.provider_data as PlatformConfiguration),
-      };
-    });
-
-  const socialAccounts = data.social_post_provider_connections.map(
-    (connection) => ({
-      id: connection.social_provider_connections.id,
-      platform: connection.social_provider_connections.provider!,
-      username:
-        connection.social_provider_connections.social_provider_user_name,
-      user_id: connection.social_provider_connections.social_provider_user_id,
-      access_token: connection.social_provider_connections.access_token || "",
-      refresh_token: connection.social_provider_connections.refresh_token,
-      access_token_expires_at:
-        connection.social_provider_connections.access_token_expires_at ||
-        new Date().toISOString(),
-      refresh_token_expires_at:
-        connection.social_provider_connections.refresh_token_expires_at,
-      external_id: connection.social_provider_connections.external_id,
-    }),
-  );
-
-  return {
-    id: data.id,
-    external_id: data.external_id,
-    caption: data.caption,
-    status: data.status,
-    media: postMedia,
-    platform_configurations: platformConfigurations,
-    account_configurations: accountConfigurations,
-    social_accounts: socialAccounts,
-    scheduled_at: data.post_at,
-    created_at: data.created_at,
-    updated_at: data.updated_at,
-  };
-};
 
 const unkey = new Unkey({ rootKey: process.env.UNKEY_ROOT_KEY! });
 

--- a/trigger/reconcile-stuck-deletes.ts
+++ b/trigger/reconcile-stuck-deletes.ts
@@ -1,0 +1,105 @@
+import { logger, schedules, tasks } from "@trigger.dev/sdk";
+import { createClient } from "@supabase/supabase-js";
+import { Database } from "./supabase.types";
+import { finalizePostDeleteIfComplete } from "./posting/finalize-post-delete";
+
+const supabaseClient = createClient<Database>(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+// Must exceed the delete-from-platform task's maxDuration (1h) so we never race
+// a delete that is still legitimately running or retrying.
+const STUCK_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+
+// Fail-out reconciliation for posts stuck in `deleting`. A post only leaves
+// `deleting` when a delete task runs finalization; if a task is dropped/killed
+// before writing its result, the post would otherwise stay `deleting` forever.
+export const reconcileStuckDeletes = schedules.task({
+  cron: { pattern: "*/10 * * * *", environments: ["PRODUCTION"] },
+  id: "reconcile-stuck-deletes",
+  maxDuration: 3600,
+  retry: { maxAttempts: 1 },
+  run: async () => {
+    const cutoff = new Date(Date.now() - STUCK_THRESHOLD_MS).toISOString();
+
+    const { data: stuckPosts, error } = await supabaseClient
+      .from("social_posts")
+      .select("id, project_id")
+      .eq("status", "deleting")
+      .lt("updated_at", cutoff)
+      .limit(100);
+
+    if (error) {
+      logger.error("Failed to load stuck deletes", { error });
+      throw new Error(error.message);
+    }
+
+    if (!stuckPosts || stuckPosts.length === 0) {
+      logger.info("No stuck deletes to reconcile");
+      return;
+    }
+
+    logger.info("Reconciling stuck deletes", { count: stuckPosts.length });
+
+    for (const post of stuckPosts) {
+      // Any result still `deleting` past the threshold had its delete task die
+      // before reporting back — fail it out so the post can finalize.
+      const { data: stuckResults, error: stuckResultsError } =
+        await supabaseClient
+          .from("social_post_results")
+          .select("id, post_id, provider_connection_id")
+          .eq("post_id", post.id)
+          .eq("delete_status", "deleting");
+
+      if (stuckResultsError) {
+        logger.error("Failed to load stuck results", {
+          postId: post.id,
+          stuckResultsError,
+        });
+        continue;
+      }
+
+      if (stuckResults && stuckResults.length > 0) {
+        const { error: updateError } = await supabaseClient
+          .from("social_post_results")
+          .update({
+            delete_status: "delete_failed",
+            delete_error_message: "Deletion timed out",
+          })
+          .in(
+            "id",
+            stuckResults.map((r) => r.id),
+          );
+
+        if (updateError) {
+          logger.error("Failed to fail-out stuck results", {
+            postId: post.id,
+            updateError,
+          });
+          continue;
+        }
+
+        for (const result of stuckResults) {
+          await tasks.trigger("process-webhooks", {
+            projectId: post.project_id,
+            eventType: "social.post.result.deleted",
+            eventData: {
+              id: result.id,
+              post_id: result.post_id,
+              social_account_id: result.provider_connection_id,
+              success: false,
+              error: "Deletion timed out",
+            },
+          });
+        }
+      }
+
+      await finalizePostDeleteIfComplete({
+        supabaseClient,
+        postId: post.id,
+        projectId: post.project_id,
+      });
+    }
+  },
+});

--- a/trigger/supabase.types.ts
+++ b/trigger/supabase.types.ts
@@ -275,6 +275,9 @@ export type Database = {
       social_post_results: {
         Row: {
           created_at: string
+          delete_error_message: string | null
+          delete_status: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at: string | null
           details: Json | null
           error_message: string | null
           id: string
@@ -287,6 +290,9 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          delete_error_message?: string | null
+          delete_status?: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at?: string | null
           details?: Json | null
           error_message?: string | null
           id?: string
@@ -299,6 +305,9 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          delete_error_message?: string | null
+          delete_status?: Database["public"]["Enums"]["social_post_result_delete_status"]
+          deleted_at?: string | null
           details?: Json | null
           error_message?: string | null
           id?: string
@@ -1054,12 +1063,20 @@ export type Database = {
     Enums: {
       delivery_type: "email"
       notification_type: "usage_alert" | "general"
+      social_post_result_delete_status:
+        | "not_deleted"
+        | "deleting"
+        | "deleted"
+        | "delete_failed"
       social_post_status:
         | "draft"
         | "scheduled"
         | "processing"
         | "posted"
         | "processed"
+        | "deleting"
+        | "deleted"
+        | "delete_failed"
       social_provider:
         | "facebook"
         | "instagram"
@@ -1081,6 +1098,7 @@ export type Database = {
         | "social.post.result.created"
         | "social.account.created"
         | "social.account.updated"
+        | "social.post.result.deleted"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1213,12 +1231,21 @@ export const Constants = {
     Enums: {
       delivery_type: ["email"],
       notification_type: ["usage_alert", "general"],
+      social_post_result_delete_status: [
+        "not_deleted",
+        "deleting",
+        "deleted",
+        "delete_failed",
+      ],
       social_post_status: [
         "draft",
         "scheduled",
         "processing",
         "posted",
         "processed",
+        "deleting",
+        "deleted",
+        "delete_failed",
       ],
       social_provider: [
         "facebook",
@@ -1242,6 +1269,7 @@ export const Constants = {
         "social.post.result.created",
         "social.account.created",
         "social.account.updated",
+        "social.post.result.deleted",
       ],
     },
   },


### PR DESCRIPTION
## Summary

Closes a gap in `DELETE /v1/social-posts/:id`: today it only removes the local DB row and rejects anything except `draft`/`scheduled` posts, so a published post can never actually be taken down from the platform it was posted to. This adds asynchronous, per-platform deletion for published (`processed`) posts, with per-platform outcomes tracked so partial failures stay visible instead of being silently swallowed.

## Changes

### Core deletion flow
- **Migrations** (`api/supabase/migrations/`): adds `deleting` / `deleted` / `delete_failed` to `social_post_status`; adds a `social_post_result_delete_status` enum plus `delete_status` / `delete_error_message` / `deleted_at` columns to `social_post_results`; adds `social.post.result.deleted` to `webhook_event_type`. Regenerated Supabase types in `api/`, `trigger/`, and `dashboard/`.
- **Per-platform `delete()`**: added a `delete()` method to the base `PostClient` (default "unsupported" response) and real implementations for Twitter/X, Instagram, Facebook, LinkedIn, Bluesky, Threads, Pinterest, and YouTube, each using that platform's existing auth/HTTP conventions. TikTok and TikTok Business are intentionally left unimplemented — their public APIs don't support delete, and the API layer blocks those requests before any platform call is attempted.
- **New trigger task** (`trigger/delete-from-platform.ts`): mirrors `post-to-platform.ts` — refreshes tokens if needed, calls the platform's `delete()`, updates the `social_post_results` row, fires a `social.post.result.deleted` webhook, and finalizes the parent post's status (`deleted`/`delete_failed`) once every platform result has resolved. Extracted `createPostClient` and `handleTokenRefresh`/`platformsToAlwaysRefresh` into shared modules (`trigger/posting/create-post-client.ts`, `trigger/posting/token-refresh.ts`) so both tasks use identical logic.
- **API** (`social-posts.controller.ts` / `.service.ts` / `.module.ts`): `DELETE /v1/social-posts/:id` now branches on status — `draft`/`scheduled` keep the existing immediate hard-delete behavior; `processed` posts get a pre-flight capability check (see below), otherwise soft-delete (`status: 'deleting'`) and fan out one `delete-from-platform` task per platform result via `tasks.batchTrigger`. Added `SocialProviderAppCredentialsModule` to resolve per-account app credentials.
- **`social-post-results`**: exposes the new `delete_status` / `delete_error_message` / `deleted_at` fields.

### Correctness & robustness fixes
- **Finalization no longer strands partial-publish posts**: a post is marked `processed` even when some platforms failed to publish, leaving those results at `delete_status = 'not_deleted'`. Finalization now keys off only the results actually queued for deletion (`deleting`/`deleted`/`delete_failed`), so a never-attempted result can't block the post in `deleting` forever or falsely fail it. Shared logic extracted to `trigger/posting/finalize-post-delete.ts`.
- **Retry-safe deletes**: platform deletes aren't idempotent (deleting an already-deleted post errors on most platforms), so a task retry could flip a successful `deleted` back to `delete_failed`. The task now short-circuits if the result was already deleted on a prior attempt.
- **Consistent webhook payloads**: `social.post.deleted` from the trigger now emits the same `transformPostData` shape as `social.post.updated` / the API, instead of a bare DB row. Extracted the shared mapper to `trigger/posting/transform-post-data.ts`.
- **Enqueue-failure rollback**: if `batchTrigger` throws after the statuses are set to `deleting`, the API rolls the post back to `processed` and results to `not_deleted` so nothing is stranded.
- **Stuck-delete reconciliation** (`trigger/reconcile-stuck-deletes.ts`): a new `schedules.task` (every 10 min, 2h threshold > the delete task's 1h `maxDuration`) fails out any result stuck in `deleting` whose task died before reporting back, emits `social.post.result.deleted`, and finalizes the post — so no post can stay in `deleting` indefinitely. `updated_at` is now stamped when entering `deleting` to give the sweep a reliable clock.

### Instagram & Threads deletion permissions
Both platforms support API deletion but require a permission the app didn't request, so no existing token could delete:
- **Scopes** (`auth-url.helper.ts`): request `instagram_manage_contents` (Instagram via Login with Facebook) and `threads_delete` (Threads) by default. Instagram deletion is Facebook-Login only — Instagram-Login accounts can't delete via the API at all.
- **Granted-scope capture**: OAuth connect now persists the scopes the user actually granted into `social_provider_metadata.granted_scopes` (Threads from the token response's `permissions`; Instagram-with-Facebook via `/me/permissions`).
- **Capability model** (`api/src/social-posts/delete-capability.ts`, vendored to `trigger/posting/delete-capability.ts`): a single source of truth for whether a connection can be deleted from (provider supported, not Instagram-Login, and the required scope granted). Backend gating (`getUndeletableReasons`) returns human-readable reasons, so the `DELETE` 400 explains exactly what needs reconnecting.

### Dashboard
- The post list's Delete action now works for `processed` posts. Each account carries a `delete_supported` flag from the API; when a processed post includes an account that can't be deleted from, the confirm dialog explains which platforms are unsupported or need reconnecting instead of silently hiding the action.
- Status badge/icon map covers the three new statuses.

No new external dependencies or env vars.

## Rollout note

Existing Instagram/Threads connections have no `granted_scopes` recorded, so they'll correctly report "reconnect required" until re-authorized — the feature only becomes available for those two platforms after the account is reconnected with the new scopes. All other platforms (Facebook, LinkedIn, Pinterest, YouTube, X, Bluesky) already carry delete-capable scopes and work immediately.

## Testing

- `bun run typecheck` / `tsc --noEmit` and `bun run lint` pass clean in `api/`, `trigger/`, and `dashboard/`.
- Applied the migrations locally (`supabase db reset`) and regenerated types in all three siblings.
- Booted the NestJS API locally and confirmed `SocialPostsModule` resolves and `DELETE /social-posts/:id` is mapped correctly.
- Verified the capability/gating query shape and the delete-fanout query (per-result + joined connection + metadata) against seeded data.
- **Not exercised end-to-end**: live deletes against real platform accounts, and the reconciliation cron / OAuth granted-scope capture against live provider responses — no sandbox credentials in this environment. Platform `delete()` calls and scope capture are implemented against each provider's documented endpoints/response shapes but haven't been run against live accounts.

## Notes

- TikTok / TikTok Business are excluded by design (no public delete API); deletion is all-or-nothing, so the API rejects the whole request up front if any target platform can't be deleted from rather than partially deleting.
- Stripe usage/meter side effects from publishing are intentionally not mirrored (no refund/decrement on delete) — out of scope.
- Webhook payloads for `social.post.deleted` include the account's tokens via `social_accounts`, consistent with the pre-existing `SocialAccountDto` contract and `social.post.updated`.

Closes PFM-427

🤖 Generated with AI
