### PR TITLE
fix(dashboard): preserve platform errors on failed social account connections

### DIFF
--- a/dashboard/app/lib/.server/social-accounts/providers/facebook.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/facebook.social-account.ts
@@ -49,6 +49,13 @@ export async function getFacebookSocialProviderConnection({
 
   const longLivedData = await longLivedResponse.json();
 
+  if (!longLivedData?.access_token) {
+    console.error("Error fetching long-lived access token", longLivedData);
+    throw Error(
+      `Error fetching long-lived access token ${longLivedData?.error?.message || ""}`,
+    );
+  }
+
   const accessToken = longLivedData.access_token;
 
   let accountsUrl = `https://graph.facebook.com/v23.0/me/accounts?fields=name,access_token,picture&limit=100&access_token=${accessToken}`;

--- a/dashboard/app/lib/.server/social-accounts/providers/instagram-w-facebook.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/instagram-w-facebook.social-account.ts
@@ -28,6 +28,13 @@ export async function getInstagramWFacebookSocialProviderConnection({
   });
   const tokenData = await tokenResponse.json();
 
+  if (!tokenData?.access_token) {
+    console.error("Error fetching access token", tokenData);
+    throw Error(
+      `Error fetching access token ${tokenData?.error?.message || ""}`,
+    );
+  }
+
   const longLivedTokenParams = new URLSearchParams([
     ["grant_type", "fb_exchange_token"],
     ["client_id", appCredentials.appId!],
@@ -40,6 +47,13 @@ export async function getInstagramWFacebookSocialProviderConnection({
   );
 
   const longLivedData = await longLivedResponse.json();
+
+  if (!longLivedData?.access_token) {
+    console.error("Error fetching long-lived access token", longLivedData);
+    throw Error(
+      `Error fetching long-lived access token ${longLivedData?.error?.message || ""}`,
+    );
+  }
 
   const accessToken = longLivedData.access_token;
 

--- a/dashboard/app/lib/.server/social-accounts/providers/instagram.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/instagram.social-account.ts
@@ -52,6 +52,13 @@ export async function getInstagramSocialProviderConnection({
 
   const longLivedData = await longLivedResponse.json();
 
+  if (!longLivedData?.access_token) {
+    console.error("Error fetching long-lived access token", longLivedData);
+    throw Error(
+      `Error fetching long-lived access token ${longLivedData?.error_message || ""}`,
+    );
+  }
+
   const accessToken = longLivedData.access_token;
 
   let profileData: {

--- a/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/linkedin.social-account.ts
@@ -34,6 +34,13 @@ export async function getLinkedInSocialProviderConnection({
 
   const tokenData = await tokenResponse.json();
 
+  if (!tokenData?.access_token) {
+    console.error("Error fetching access token", tokenData);
+    throw Error(
+      `Error fetching access token ${tokenData?.error_description || tokenData?.error || ""}`,
+    );
+  }
+
   const accessToken = tokenData.access_token;
   const accessTokenExpiresAt: Date = new Date(
     Date.now() + (tokenData.expires_in - 86400) * 1000,

--- a/dashboard/app/lib/.server/social-accounts/providers/pinterest.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/pinterest.social-account.ts
@@ -35,6 +35,11 @@ export async function getPinterestSocialProviderConnection({
   });
   const tokenData = await tokenResponse.json();
 
+  if (!tokenData?.access_token) {
+    console.error("Error fetching access token", tokenData);
+    throw Error(`Error fetching access token ${tokenData?.message || ""}`);
+  }
+
   const { access_token, refresh_token, expires_in } = tokenData;
 
   const userResponse = await fetch(

--- a/dashboard/app/lib/.server/social-accounts/providers/tiktok-business.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/tiktok-business.social-account.ts
@@ -8,66 +8,68 @@ export async function getTikTokBusinessSocialProviderConnection({
   request,
   appCredentials,
 }: SocialProviderInfo): Promise<SocialProviderConnection[]> {
-  try {
-    const url = new URL(request.url);
+  const url = new URL(request.url);
 
-    const code = url.searchParams.get("code");
+  const code = url.searchParams.get("code");
 
-    if (!code) {
-      throw Error("No code provided");
-    }
-    const tokenUrl =
-      "https://business-api.tiktok.com/open_api/v1.3/tt_user/oauth2/token/";
-
-    const tokenParams = {
-      grant_type: "authorization_code",
-      client_id: appCredentials.appId!,
-      client_secret: appCredentials.appSecret!,
-      auth_code: code,
-      redirect_uri: redirectUri,
-    };
-
-    const tokenResponse = await fetch(tokenUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(tokenParams),
-    });
-    const tokenResponseData = await tokenResponse.json();
-
-    const userInfoResponse = await fetch(
-      `https://business-api.tiktok.com/open_api/v1.3/business/get/?business_id=${tokenResponseData.data.open_id}&fields=["display_name", "profile_image", "username"]`,
-      {
-        headers: {
-          "Access-Token": `${tokenResponseData.data.access_token}`,
-        },
-      },
-    );
-    const userInfoResponseData = await userInfoResponse.json();
-
-    const profilePhotoUrl = userInfoResponseData?.data?.profile_image;
-    const publicProfilePhotoUrl = profilePhotoUrl;
-
-    return [
-      {
-        social_provider_user_name:
-          userInfoResponseData?.data?.username ||
-          userInfoResponseData?.data?.display_name,
-        social_provider_user_id: tokenResponseData.data.open_id,
-        social_provider_photo_url: publicProfilePhotoUrl,
-        access_token: tokenResponseData.data.access_token,
-        refresh_token: tokenResponseData.data.refresh_token,
-        access_token_expires_at: new Date(
-          Date.now() + tokenResponseData.data.expires_in * 1000,
-        ),
-        refresh_token_expires_at: new Date(
-          Date.now() + tokenResponseData.data.refresh_token_expires_in * 1000,
-        ),
-      },
-    ];
-  } catch (e) {
-    console.error(e);
-    return [];
+  if (!code) {
+    throw Error("No code provided");
   }
+  const tokenUrl =
+    "https://business-api.tiktok.com/open_api/v1.3/tt_user/oauth2/token/";
+
+  const tokenParams = {
+    grant_type: "authorization_code",
+    client_id: appCredentials.appId!,
+    client_secret: appCredentials.appSecret!,
+    auth_code: code,
+    redirect_uri: redirectUri,
+  };
+
+  const tokenResponse = await fetch(tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(tokenParams),
+  });
+  const tokenResponseData = await tokenResponse.json();
+
+  if (!tokenResponseData?.data?.access_token) {
+    console.error("Error fetching access token", tokenResponseData);
+    throw Error(
+      `Error fetching access token ${tokenResponseData?.message || ""}`,
+    );
+  }
+
+  const userInfoResponse = await fetch(
+    `https://business-api.tiktok.com/open_api/v1.3/business/get/?business_id=${tokenResponseData.data.open_id}&fields=["display_name", "profile_image", "username"]`,
+    {
+      headers: {
+        "Access-Token": `${tokenResponseData.data.access_token}`,
+      },
+    },
+  );
+  const userInfoResponseData = await userInfoResponse.json();
+
+  const profilePhotoUrl = userInfoResponseData?.data?.profile_image;
+  const publicProfilePhotoUrl = profilePhotoUrl;
+
+  return [
+    {
+      social_provider_user_name:
+        userInfoResponseData?.data?.username ||
+        userInfoResponseData?.data?.display_name,
+      social_provider_user_id: tokenResponseData.data.open_id,
+      social_provider_photo_url: publicProfilePhotoUrl,
+      access_token: tokenResponseData.data.access_token,
+      refresh_token: tokenResponseData.data.refresh_token,
+      access_token_expires_at: new Date(
+        Date.now() + tokenResponseData.data.expires_in * 1000,
+      ),
+      refresh_token_expires_at: new Date(
+        Date.now() + tokenResponseData.data.refresh_token_expires_in * 1000,
+      ),
+    },
+  ];
 }

--- a/dashboard/app/lib/.server/social-accounts/providers/youtube.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/youtube.social-account.ts
@@ -25,8 +25,9 @@ export async function getYoutubeSocialProviderConnection({
   const { tokens } = await oauth2Client.getToken(code);
   oauth2Client.setCredentials(tokens);
 
-  if (!tokens.access_token) {
-    return [];
+  if (!tokens?.access_token) {
+    console.error("Error fetching access token", tokens);
+    throw Error("Error fetching access token");
   }
 
   const youtube = google.youtube({ version: "v3", auth: oauth2Client });

--- a/dashboard/app/lib/.server/social-accounts/social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.ts
@@ -187,38 +187,33 @@ async function getSocialProviderConnections(
   provider: string,
   info: SocialProviderInfo,
 ): Promise<SocialProviderConnection[]> {
-  try {
-    switch (provider) {
-      case "tiktok":
-        return getTikTokSocialProviderConnection(info);
-      case "instagram":
-        return getInstagramSocialProviderConnection(info);
-      case "facebook":
-        return getFacebookSocialProviderConnection(info);
-      case "x":
-        return getXSocialProviderConnection(info);
-      case "x_oauth2":
-        return getXOAuth2SocialProviderConnection(info);
-      case "youtube":
-        return getYoutubeSocialProviderConnection(info);
-      case "linkedin":
-        return getLinkedInSocialProviderConnection(info);
-      case "pinterest":
-        return getPinterestSocialProviderConnection(info);
-      case "bluesky":
-        return getBlueskySocialProviderConnection(info);
-      case "threads":
-        return getThreadsSocialProviderConnection(info);
-      case "tiktok_business":
-        return getTikTokBusinessSocialProviderConnection(info);
-      case "instagram_w_facebook":
-        return getInstagramWFacebookSocialProviderConnection(info);
-      default:
-        return [];
-    }
-  } catch (error) {
-    console.error(error);
-    return [];
+  switch (provider) {
+    case "tiktok":
+      return getTikTokSocialProviderConnection(info);
+    case "instagram":
+      return getInstagramSocialProviderConnection(info);
+    case "facebook":
+      return getFacebookSocialProviderConnection(info);
+    case "x":
+      return getXSocialProviderConnection(info);
+    case "x_oauth2":
+      return getXOAuth2SocialProviderConnection(info);
+    case "youtube":
+      return getYoutubeSocialProviderConnection(info);
+    case "linkedin":
+      return getLinkedInSocialProviderConnection(info);
+    case "pinterest":
+      return getPinterestSocialProviderConnection(info);
+    case "bluesky":
+      return getBlueskySocialProviderConnection(info);
+    case "threads":
+      return getThreadsSocialProviderConnection(info);
+    case "tiktok_business":
+      return getTikTokBusinessSocialProviderConnection(info);
+    case "instagram_w_facebook":
+      return getInstagramWFacebookSocialProviderConnection(info);
+    default:
+      return [];
   }
 }
 


### PR DESCRIPTION
## Summary

Users connecting Instagram (Business Login) accounts were seeing a nonsensical `error=Invalid time value` in the OAuth callback with no account created, instead of the actual reason Instagram rejected the connection. This addresses PFM-617's ask to preserve the social platform's real error message on failed connections.

## Changes

- **`providers/instagram.social-account.ts`** — root cause fix: the `ig_exchange_token` long-lived token exchange response was never validated. When it failed, `expires_in` was `undefined`, producing an invalid `Date` that later crashed with `RangeError: Invalid time value` on `.toISOString()`. Now validated and throws Instagram's real error message instead.
- **`social-account.ts`** — removed a swallow-catch in `getSocialProviderConnections` that discarded every thrown provider error into a generic "No valid accounts found". Both call sites process exactly one provider per request, so this served no purpose beyond hiding real errors (including the Instagram fix above — without this, the new descriptive error would still get swallowed). Errors now propagate to the existing route-loader catch, which already surfaces `error.message` in the callback redirect.
- **`providers/instagram-w-facebook.social-account.ts`, `facebook.social-account.ts`, `linkedin.social-account.ts`, `pinterest.social-account.ts`, `tiktok-business.social-account.ts`** — same missing-validation shape existed on their token exchanges (using `access_token`/`expires_in` without checking the exchange succeeded). Added the same guard pattern, throwing a descriptive error that includes the platform's own error text when available.
- **`tiktok-business.social-account.ts`** — also removed its own local swallow-catch, which would have absorbed the new throw back into a silent `[]`.
- **`providers/youtube.social-account.ts`** — changed the missing-access-token case from a silent `return []` to a throw, for the same reason.

No env vars, dependencies, or migrations involved.

## Testing

- `cd dashboard && bun run typecheck` — passes.
- `cd dashboard && bun run lint` — passes.
- `cd dashboard && bun run test` — no test files exist in this package yet (pre-existing, unrelated to this change), so the script exits non-zero for that reason only.
- Not yet verified against a live failing Instagram OAuth exchange (would require a real/test Instagram Business account currently in the failing state) — recommend the reporting user retries their connection once this ships so we can see Instagram's actual error message and confirm the root cause.

## Notes

Once deployed, the real platform error (e.g. a scope or account-type issue) should surface in place of "Invalid time value" — that message will tell us definitively why the exchange is failing for these Business Login accounts, in case further follow-up is needed.

Closes PFM-617

🤖 Generated with [Claude Code](https://claude.com/claude-code)