### PR TITLE
fix(dashboard): show correct X OAuth 2 callback URL

### DIFF
--- a/dashboard/app/routes/_protected.$teamId.$projectId.setup.$provider._index/route.loader.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.setup.$provider._index/route.loader.ts
@@ -55,11 +55,13 @@ export const loader = withSupabase(async ({ supabase, params }) => {
     appSecret: credential?.data?.app_secret || "",
   };
 
+  const callbackProvider = provider === "x_oauth2" ? "x" : provider;
+
   return data({
     provider,
     credential: providerCredential,
     authCallbackUrl: project.data?.auth_callback_url || "",
     setupGuideUrl: `https://www.postforme.dev/resources/getting-started-with-the-${provider}-api`,
-    redirectUrl: `https://app.postforme.dev/callback/${projectId}/${provider}/account`,
+    redirectUrl: `https://app.postforme.dev/callback/${projectId}/${callbackProvider}/account`,
   });
 });


### PR DESCRIPTION
Display the normalized `/x/account` callback URL that the X OAuth 2 authorization flow actually uses.