### PR TITLE
fix(api): refresh access tokens before returning social account data

### DIFF
--- a/api/src/social-account-feeds/social-account-feeds.service.ts
+++ b/api/src/social-account-feeds/social-account-feeds.service.ts
@@ -13,7 +13,7 @@ import {
 } from '../lib/dto/global.dto';
 import { SocialPlatformService } from '../lib/social-provider-service';
 import { TikTokBusinessService } from '../tiktok-business/tiktok-business.service';
-import { YouTubeError, YouTubeService } from '../youtube/youtube.service';
+import { YouTubeService } from '../youtube/youtube.service';
 import { TikTokService } from '../tiktok/tiktok.service';
 import { InstagramService } from '../instagram/instagram.service';
 import { FacebookService } from '../facebook/facebook.service';
@@ -22,8 +22,8 @@ import { PinterestService } from '../pinterest/pinterest.service';
 import { ThreadsService } from '../threads/threads.service';
 import { TwitterService } from '../twitter/twitter.service';
 import { BlueskyService } from '../bluesky/bluesky.service';
-import { differenceInDays } from 'date-fns';
 import { PlatformPostDto } from './dto/platform-post.dto';
+import { TokenRefreshService } from '../token-refresh/token-refresh.service';
 
 type TikTokPostResultCandidateSocialPost = {
   external_id: string | null;
@@ -44,7 +44,6 @@ type TikTokPostResultCandidate = {
 
 @Injectable()
 export class SocialAccountFeedsService {
-  platformsToAlwaysRefresh = ['youtube', 'bluesky'];
   facebookMetricsLimitCap: number;
   constructor(
     private readonly configService: ConfigService,
@@ -60,6 +59,7 @@ export class SocialAccountFeedsService {
     private readonly threadsService: ThreadsService,
     private readonly twitterService: TwitterService,
     private readonly blueskyService: BlueskyService,
+    private readonly tokenRefreshService: TokenRefreshService,
   ) {
     const configuredCap = Number(
       this.configService.get<string>('FacebookFeedMetricsLimitCap') ?? 10,
@@ -211,7 +211,7 @@ export class SocialAccountFeedsService {
       projectId,
     });
 
-    const socialAccount: SocialAccount = {
+    let socialAccount: SocialAccount = {
       provider: account.provider,
       id: account.id,
       social_provider_user_name: account.social_provider_user_name,
@@ -227,49 +227,10 @@ export class SocialAccountFeedsService {
       social_provider_metadata: account.social_provider_metadata,
     };
 
-    if (
-      this.platformsToAlwaysRefresh.includes(account.provider) ||
-      differenceInDays(
-        new Date(account.access_token_expires_at || new Date()),
-        new Date(),
-      ) <= 7
-    ) {
-      try {
-        const updatedAccount =
-          await platformService.refreshAccessToken(socialAccount);
-
-        if (updatedAccount) {
-          await this.supabaseService.supabaseClient
-            .from('social_provider_connections')
-            .update({
-              access_token: updatedAccount.access_token,
-              refresh_token: updatedAccount.refresh_token,
-              access_token_expires_at:
-                updatedAccount.access_token_expires_at?.toISOString(),
-              refresh_token_expires_at:
-                updatedAccount.refresh_token_expires_at?.toISOString(),
-            })
-            .eq('id', account.id);
-        }
-      } catch (error) {
-        if (
-          account.provider === 'youtube' &&
-          error instanceof YouTubeError &&
-          !error.metadata.authFailure &&
-          error.metadata.retryable
-        ) {
-          console.warn('Proceeding with existing YouTube access token', {
-            provider: error.metadata.provider,
-            operation: error.metadata.operation,
-            code: error.metadata.code,
-            status: error.metadata.status,
-            message: error.message,
-          });
-        } else {
-          throw error;
-        }
-      }
-    }
+    socialAccount = await this.tokenRefreshService.refreshIfNeeded({
+      account: socialAccount,
+      projectId,
+    });
 
     // Determine if metrics should be included
     let includeMetrics = false;

--- a/api/src/social-provider-connections/social-provider-connections.controller.ts
+++ b/api/src/social-provider-connections/social-provider-connections.controller.ts
@@ -110,6 +110,7 @@ export class SocialAccountsController {
       socialAccount = await this.socialAccountsService.getSocialAccountById({
         id: params.id,
         projectId: user.projectId,
+        withTokenRefresh: true,
       });
     } catch (e) {
       console.error('/social-accounts/:id', e);

--- a/api/src/social-provider-connections/social-provider-connections.module.ts
+++ b/api/src/social-provider-connections/social-provider-connections.module.ts
@@ -3,9 +3,14 @@ import { SocialAccountsController } from './social-provider-connections.controll
 import { SocialAccountsService } from './social-provider-connections.service';
 import { PaginationModule } from '../pagination/pagination.module';
 import { SocialProviderAppCredentialsModule } from '../social-provider-app-credentials/social-provider-app-credentials.module';
+import { TokenRefreshModule } from '../token-refresh/token-refresh.module';
 
 @Module({
-  imports: [PaginationModule, SocialProviderAppCredentialsModule],
+  imports: [
+    PaginationModule,
+    SocialProviderAppCredentialsModule,
+    TokenRefreshModule,
+  ],
   controllers: [SocialAccountsController],
   providers: [SocialAccountsService],
 })

--- a/api/src/social-provider-connections/social-provider-connections.service.ts
+++ b/api/src/social-provider-connections/social-provider-connections.service.ts
@@ -15,15 +15,48 @@ import {
   SocialAccountMetadata,
 } from './dto/create-social-account.dto';
 import { Database } from '../../supabase';
+import { TokenRefreshService } from '../token-refresh/token-refresh.service';
+import { SocialAccount } from '../lib/dto/global.dto';
+import { mapWithConcurrency } from '../lib/async.utils';
 
 type ProviderEnum = Database['public']['Enums']['social_provider'];
+const TOKEN_REFRESH_CONCURRENCY = 5;
 
 @Injectable()
 export class SocialAccountsService {
   constructor(
     private readonly supabaseService: SupabaseService,
     private readonly configService: ConfigService,
+    private readonly tokenRefreshService: TokenRefreshService,
   ) {}
+
+  private toSocialAccountEntity(row: {
+    id: string;
+    provider: string | null;
+    social_provider_user_name: string | null;
+    access_token: string | null;
+    refresh_token: string | null;
+    access_token_expires_at: string | null;
+    refresh_token_expires_at: string | null;
+    social_provider_user_id: string | null;
+    social_provider_metadata: unknown;
+  }): SocialAccount {
+    return {
+      provider: row.provider as SocialAccount['provider'],
+      id: row.id,
+      social_provider_user_name: row.social_provider_user_name,
+      access_token: row.access_token || '',
+      refresh_token: row.refresh_token,
+      access_token_expires_at: row.access_token_expires_at
+        ? new Date(row.access_token_expires_at)
+        : null,
+      refresh_token_expires_at: row.refresh_token_expires_at
+        ? new Date(row.refresh_token_expires_at)
+        : null,
+      social_provider_user_id: row.social_provider_user_id || '',
+      social_provider_metadata: row.social_provider_metadata,
+    };
+  }
 
   async getSocialAccounts(
     queryParams: SocialAccountQueryDto,
@@ -155,7 +188,34 @@ export class SocialAccountsService {
       throw error;
     }
 
-    const transformedData: SocialAccountDto[] = data.map((raw) => ({
+    const refreshedRows = await mapWithConcurrency(
+      data,
+      async (raw) => {
+        if (!raw.access_token) {
+          return raw;
+        }
+
+        const refreshed = await this.tokenRefreshService.refreshIfNeeded({
+          account: this.toSocialAccountEntity(raw),
+          projectId,
+        });
+
+        return {
+          ...raw,
+          access_token: refreshed.access_token,
+          refresh_token: refreshed.refresh_token,
+          access_token_expires_at:
+            refreshed.access_token_expires_at?.toISOString() ??
+            raw.access_token_expires_at,
+          refresh_token_expires_at:
+            refreshed.refresh_token_expires_at?.toISOString() ??
+            raw.refresh_token_expires_at,
+        };
+      },
+      TOKEN_REFRESH_CONCURRENCY,
+    );
+
+    const transformedData: SocialAccountDto[] = refreshedRows.map((raw) => ({
       id: raw.id,
       platform: raw.provider || '',
       username: raw.social_provider_user_name || '',
@@ -201,6 +261,27 @@ export class SocialAccountsService {
       return null;
     }
 
+    let accessToken = socialAccount.data.access_token;
+    let refreshToken = socialAccount.data.refresh_token;
+    let accessTokenExpiresAt = socialAccount.data.access_token_expires_at;
+    let refreshTokenExpiresAt = socialAccount.data.refresh_token_expires_at;
+
+    if (accessToken) {
+      const refreshed = await this.tokenRefreshService.refreshIfNeeded({
+        account: this.toSocialAccountEntity(socialAccount.data),
+        projectId,
+      });
+
+      accessToken = refreshed.access_token;
+      refreshToken = refreshed.refresh_token;
+      accessTokenExpiresAt =
+        refreshed.access_token_expires_at?.toISOString() ??
+        accessTokenExpiresAt;
+      refreshTokenExpiresAt =
+        refreshed.refresh_token_expires_at?.toISOString() ??
+        refreshTokenExpiresAt;
+    }
+
     return {
       id: socialAccount.data.id,
       platform: socialAccount.data.provider || '',
@@ -209,11 +290,10 @@ export class SocialAccountsService {
       profile_photo_url: socialAccount.data.social_provider_profile_photo_url,
       status: socialAccount.data.access_token ? 'connected' : 'disconnected',
       external_id: socialAccount.data.external_id,
-      access_token: socialAccount.data.access_token || '',
-      refresh_token: socialAccount.data.refresh_token || '',
-      access_token_expires_at:
-        socialAccount.data.access_token_expires_at || new Date().toISOString(),
-      refresh_token_expires_at: socialAccount.data.refresh_token_expires_at,
+      access_token: accessToken || '',
+      refresh_token: refreshToken || '',
+      access_token_expires_at: accessTokenExpiresAt || new Date().toISOString(),
+      refresh_token_expires_at: refreshTokenExpiresAt,
       metadata: socialAccount.data
         .social_provider_metadata as SocialAccountMetadata,
     };

--- a/api/src/social-provider-connections/social-provider-connections.service.ts
+++ b/api/src/social-provider-connections/social-provider-connections.service.ts
@@ -198,6 +198,7 @@ export class SocialAccountsService {
         const refreshed = await this.tokenRefreshService.refreshIfNeeded({
           account: this.toSocialAccountEntity(raw),
           projectId,
+          throwOnError: false,
         });
 
         return {
@@ -240,9 +241,11 @@ export class SocialAccountsService {
   async getSocialAccountById({
     id,
     projectId,
+    withTokenRefresh = false,
   }: {
     id: string;
     projectId: string;
+    withTokenRefresh?: boolean;
   }): Promise<SocialAccountDto | null> {
     const socialAccount = await this.supabaseService.supabaseClient
       .from('social_provider_connections')
@@ -266,10 +269,11 @@ export class SocialAccountsService {
     let accessTokenExpiresAt = socialAccount.data.access_token_expires_at;
     let refreshTokenExpiresAt = socialAccount.data.refresh_token_expires_at;
 
-    if (accessToken) {
+    if (withTokenRefresh && accessToken) {
       const refreshed = await this.tokenRefreshService.refreshIfNeeded({
         account: this.toSocialAccountEntity(socialAccount.data),
         projectId,
+        throwOnError: false,
       });
 
       accessToken = refreshed.access_token;
@@ -288,7 +292,7 @@ export class SocialAccountsService {
       username: socialAccount.data.social_provider_user_name || '',
       user_id: socialAccount.data.social_provider_user_id || '',
       profile_photo_url: socialAccount.data.social_provider_profile_photo_url,
-      status: socialAccount.data.access_token ? 'connected' : 'disconnected',
+      status: accessToken ? 'connected' : 'disconnected',
       external_id: socialAccount.data.external_id,
       access_token: accessToken || '',
       refresh_token: refreshToken || '',

--- a/api/src/token-refresh/token-refresh.module.ts
+++ b/api/src/token-refresh/token-refresh.module.ts
@@ -1,8 +1,5 @@
 import { Module } from '@nestjs/common';
-
-import { PaginationModule } from '../pagination/pagination.module';
-import { SocialAccountFeedsController } from './social-account-feeds.controller';
-import { SocialAccountFeedsService } from './social-account-feeds.service';
+import { TokenRefreshService } from './token-refresh.service';
 import { TikTokBusinessModule } from '../tiktok-business/tiktok-business.module';
 import { YouTubeModule } from '../youtube/youtube.module';
 import { TikTokModule } from '../tiktok/tiktok.module';
@@ -13,11 +10,9 @@ import { PinterestModule } from '../pinterest/pinterest.module';
 import { ThreadsModule } from '../threads/threads.module';
 import { TwitterModule } from '../twitter/twitter.module';
 import { BlueskyModule } from '../bluesky/bluesky.module';
-import { TokenRefreshModule } from '../token-refresh/token-refresh.module';
 
 @Module({
   imports: [
-    PaginationModule,
     TikTokBusinessModule,
     YouTubeModule,
     TikTokModule,
@@ -28,9 +23,8 @@ import { TokenRefreshModule } from '../token-refresh/token-refresh.module';
     ThreadsModule,
     TwitterModule,
     BlueskyModule,
-    TokenRefreshModule,
   ],
-  controllers: [SocialAccountFeedsController],
-  providers: [SocialAccountFeedsService],
+  providers: [TokenRefreshService],
+  exports: [TokenRefreshService],
 })
-export class SocialAccountFeedsModule {}
+export class TokenRefreshModule {}

--- a/api/src/token-refresh/token-refresh.service.ts
+++ b/api/src/token-refresh/token-refresh.service.ts
@@ -1,0 +1,177 @@
+import { Injectable } from '@nestjs/common';
+import { differenceInDays } from 'date-fns';
+import { SupabaseService } from '../supabase/supabase.service';
+import { SocialAccount } from '../lib/dto/global.dto';
+import { SocialPlatformService } from '../lib/social-provider-service';
+import { TikTokBusinessService } from '../tiktok-business/tiktok-business.service';
+import { YouTubeError, YouTubeService } from '../youtube/youtube.service';
+import { TikTokService } from '../tiktok/tiktok.service';
+import { InstagramService } from '../instagram/instagram.service';
+import { FacebookService } from '../facebook/facebook.service';
+import { LinkedInService } from '../linkedin/linkedin.service';
+import { PinterestService } from '../pinterest/pinterest.service';
+import { ThreadsService } from '../threads/threads.service';
+import { TwitterService } from '../twitter/twitter.service';
+import { BlueskyService } from '../bluesky/bluesky.service';
+
+@Injectable()
+export class TokenRefreshService {
+  platformsToAlwaysRefresh = ['youtube', 'bluesky'];
+
+  constructor(
+    private readonly supabaseService: SupabaseService,
+    private readonly tiktokBusinessService: TikTokBusinessService,
+    private readonly youtubeService: YouTubeService,
+    private readonly tiktokService: TikTokService,
+    private readonly instagramService: InstagramService,
+    private readonly facebookService: FacebookService,
+    private readonly linkedinService: LinkedInService,
+    private readonly pinterestService: PinterestService,
+    private readonly threadsService: ThreadsService,
+    private readonly twitterService: TwitterService,
+    private readonly blueskyService: BlueskyService,
+  ) {}
+
+  resolvePlatformName(account: {
+    provider: SocialAccount['provider'];
+    access_token: string | null;
+    social_provider_metadata: unknown;
+  }): string {
+    let platformName = account.provider as string;
+
+    if (
+      platformName === 'instagram' &&
+      !account.access_token?.startsWith('IG')
+    ) {
+      platformName = 'instagram_w_facebook';
+    }
+
+    if (
+      platformName === 'x' &&
+      (account.social_provider_metadata as { connection_type?: string } | null)
+        ?.connection_type === 'oauth2'
+    ) {
+      platformName = 'x_oauth2';
+    }
+
+    return platformName;
+  }
+
+  async getPlatformService({
+    platform,
+    projectId,
+  }: {
+    platform: string;
+    projectId: string;
+  }): Promise<SocialPlatformService> {
+    switch (platform) {
+      case 'tiktok_business':
+        await this.tiktokBusinessService.initService(projectId);
+        return this.tiktokBusinessService;
+      case 'youtube':
+        await this.youtubeService.initService(projectId);
+        return this.youtubeService;
+      case 'tiktok':
+        await this.tiktokService.initService(projectId);
+        return this.tiktokService;
+      case 'instagram':
+        await this.instagramService.initService(projectId);
+        return this.instagramService;
+      case 'instagram_w_facebook':
+        await this.instagramService.initFacebookService(projectId);
+        return this.instagramService;
+      case 'facebook':
+        await this.facebookService.initService(projectId);
+        return this.facebookService;
+      case 'linkedin':
+        await this.linkedinService.initService(projectId);
+        return this.linkedinService;
+      case 'pinterest':
+        await this.pinterestService.initService(projectId);
+        return this.pinterestService;
+      case 'threads':
+        await this.threadsService.initService(projectId);
+        return this.threadsService;
+      case 'x':
+        await this.twitterService.initService(projectId);
+        return this.twitterService;
+      case 'x_oauth2':
+        await this.twitterService.initOAuth2Service(projectId);
+        return this.twitterService;
+      case 'bluesky':
+        await this.blueskyService.initService();
+        return this.blueskyService;
+    }
+    throw new Error('Unable to create platform service');
+  }
+
+  async refreshIfNeeded({
+    account,
+    projectId,
+  }: {
+    account: SocialAccount;
+    projectId: string;
+  }): Promise<SocialAccount> {
+    if (!account.access_token) {
+      return account;
+    }
+
+    const needsRefresh =
+      this.platformsToAlwaysRefresh.includes(account.provider as string) ||
+      differenceInDays(
+        account.access_token_expires_at || new Date(),
+        new Date(),
+      ) <= 7;
+
+    if (!needsRefresh) {
+      return account;
+    }
+
+    const platformName = this.resolvePlatformName(account);
+
+    try {
+      const platformService = await this.getPlatformService({
+        platform: platformName,
+        projectId,
+      });
+
+      const updatedAccount = await platformService.refreshAccessToken(account);
+
+      if (!updatedAccount) {
+        return account;
+      }
+
+      await this.supabaseService.supabaseClient
+        .from('social_provider_connections')
+        .update({
+          access_token: updatedAccount.access_token,
+          refresh_token: updatedAccount.refresh_token,
+          access_token_expires_at:
+            updatedAccount.access_token_expires_at?.toISOString(),
+          refresh_token_expires_at:
+            updatedAccount.refresh_token_expires_at?.toISOString(),
+        })
+        .eq('id', account.id);
+
+      return updatedAccount;
+    } catch (error) {
+      if (
+        account.provider === 'youtube' &&
+        error instanceof YouTubeError &&
+        !error.metadata.authFailure &&
+        error.metadata.retryable
+      ) {
+        console.warn('Proceeding with existing YouTube access token', {
+          provider: error.metadata.provider,
+          operation: error.metadata.operation,
+          code: error.metadata.code,
+          status: error.metadata.status,
+          message: error.message,
+        });
+        return account;
+      }
+
+      throw error;
+    }
+  }
+}

--- a/api/src/token-refresh/token-refresh.service.ts
+++ b/api/src/token-refresh/token-refresh.service.ts
@@ -108,9 +108,11 @@ export class TokenRefreshService {
   async refreshIfNeeded({
     account,
     projectId,
+    throwOnError = true,
   }: {
     account: SocialAccount;
     projectId: string;
+    throwOnError?: boolean;
   }): Promise<SocialAccount> {
     if (!account.access_token) {
       return account;
@@ -129,12 +131,15 @@ export class TokenRefreshService {
 
     const platformName = this.resolvePlatformName(account);
 
-    try {
-      const platformService = await this.getPlatformService({
-        platform: platformName,
-        projectId,
-      });
+    // Resolved outside the try block so a platform-resolution/config error
+    // (a code bug, not a per-account refresh failure) always propagates,
+    // regardless of `throwOnError`.
+    const platformService = await this.getPlatformService({
+      platform: platformName,
+      projectId,
+    });
 
+    try {
       const updatedAccount = await platformService.refreshAccessToken(account);
 
       if (!updatedAccount) {
@@ -168,6 +173,23 @@ export class TokenRefreshService {
           status: error.metadata.status,
           message: error.message,
         });
+        return account;
+      }
+
+      const isYouTubeAuthFailure =
+        account.provider === 'youtube' &&
+        error instanceof YouTubeError &&
+        error.metadata.authFailure;
+
+      if (!throwOnError && !isYouTubeAuthFailure) {
+        console.warn(
+          'Proceeding with existing access token after refresh failure',
+          {
+            provider: account.provider,
+            accountId: account.id,
+            message: error instanceof Error ? error.message : String(error),
+          },
+        );
         return account;
       }
 

--- a/dashboard/app/lib/.server/social-accounts/providers/youtube.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/youtube.social-account.ts
@@ -54,7 +54,7 @@ export async function getYoutubeSocialProviderConnection({
         access_token: tokens.access_token!,
         refresh_token: tokens.refresh_token ?? "",
         access_token_expires_at: new Date(
-          Date.now() + (tokens.expiry_date ?? 1000),
+          tokens.expiry_date ?? Date.now() + 1000,
         ),
       };
     });

--- a/trigger/posting/platforms/youtube-post-client.ts
+++ b/trigger/posting/platforms/youtube-post-client.ts
@@ -56,7 +56,7 @@ export class YouTubePostClient extends PostClient {
     this.#oauth2Client.setCredentials({
       access_token: account.access_token,
       refresh_token: account.refresh_token,
-      expiry_date: new Date(account.refresh_token_expires_at!).getTime(),
+      expiry_date: new Date(account.access_token_expires_at!).getTime(),
     });
 
     const { credentials } = await this.#oauth2Client.refreshAccessToken();

--- a/trigger/refresh-account-tokens.ts
+++ b/trigger/refresh-account-tokens.ts
@@ -212,7 +212,13 @@ export const refreshAccountTokens = schedules.task({
         .from("social_provider_connections")
         .select("*")
         .lte("access_token_expires_at", sevenDaysFromNow.toISOString())
-        .in("provider", ["facebook", "instagram", "threads", "pinterest"])
+        .in("provider", [
+          "facebook",
+          "instagram",
+          "threads",
+          "pinterest",
+          "youtube",
+        ])
         .order("access_token_expires_at", { ascending: true })
         .limit(50);
 


### PR DESCRIPTION
## Summary

A customer using `GET /v1/social-accounts/{id}` to drive direct YouTube API calls (updating video title/description, playlists, thumbnails — since PFM doesn't support editing a published post) reported the returned `access_token` is almost always already expired, even though `access_token_expires_at` correctly showed it was in the past. Root cause: the account-lookup endpoints never refreshed — they echoed the DB row as-is. They also flagged some accounts reporting `access_token_expires_at` in 2082/2083.

## Changes

- **`api/src/token-refresh/`** (new) — extracts the refresh-decision/refresh/persist logic that previously lived only inside `social-account-feeds.service.ts` (used for the platform-post-feed read path) into a shared `TokenRefreshService`, so it can be reused instead of re-implementing a second 10-provider switch statement.
- **`social-account-feeds.service.ts`** — now calls the shared `TokenRefreshService` instead of its own inline refresh block (no behavior change, same policy: always refresh youtube/bluesky, others within 7 days of expiry).
- **`social-provider-connections.service.ts`** — `getSocialAccountById` and `getSocialAccounts` (list) now refresh eligible accounts before mapping to the response DTO. List refreshes run concurrently (capped at 5) via the existing `mapWithConcurrency` helper so a page full of YouTube accounts doesn't serialize N Google token round-trips.
- **`dashboard/.../youtube.social-account.ts`** — fixes the actual cause of the 2082/2083 timestamps: `google-auth-library`'s `getToken()` already returns `tokens.expiry_date` as an absolute epoch-ms timestamp, but the code was doing `Date.now() + tokens.expiry_date`, effectively doubling the epoch value. Now uses `tokens.expiry_date` directly, matching how every other provider computes this.
- **`trigger/refresh-account-tokens.ts`** — the 12h proactive-refresh cron excluded `youtube` from its batch query, so YouTube tokens were never refreshed ahead of time, only reactively when something happened to read them. Added `youtube` to the provider list.
- **`trigger/posting/platforms/youtube-post-client.ts`** — fixes a field mixup seeding the OAuth client's `expiry_date` from `refresh_token_expires_at` instead of `access_token_expires_at` before a refresh call during publishing.

No DB backfill needed for existing 2082/2083 rows — `youtube` is (and remains) in the "always refresh" list, so the next read of any such account overwrites the bad timestamp with a correct one.

## Follow-up fixes (review round 2)

Code review of the initial version of this PR surfaced two behavior regressions from wiring refresh into `SocialAccountsService`, both addressed here:

- **`getSocialAccountById` no longer refreshes on every call.** It's reused as a plain existence check by `updateSocialAccount`, `disconnectSocialAccount`, and `deleteSocialAccount` — none of which need a live token. Added a `withTokenRefresh` param (default `false`); only the `GET /:id` read endpoint passes `true`. The three mutation endpoints no longer trigger a provider OAuth round-trip (and can no longer fail with a 500 just because a token happened to be unrefreshable) when all they're doing is checking the account exists.
- **A single account's refresh failure no longer fails the whole list.** `getSocialAccounts` refreshes accounts concurrently via `Promise.all`, so one broken/revoked token used to fail the entire `GET /v1/social-accounts` page. `TokenRefreshService.refreshIfNeeded` gained a `throwOnError` param (default `true`, so the existing feed-read call site is unaffected); the list and by-id read paths pass `throwOnError: false` and degrade gracefully to stale-but-valid data on failure instead of erroring.
- Tightened what `throwOnError: false` is allowed to swallow: platform-resolution/config errors (a code bug, not a per-account issue) always propagate regardless of the flag, and a YouTube `authFailure` (genuinely revoked/broken auth) is never silently absorbed either — only ambiguous/transient refresh failures degrade gracefully now.
- Fixed `getSocialAccountById`'s `status` field, which was computed from the pre-refresh DB value while `access_token`/`access_token_expires_at` in the same response used the post-refresh value — could report `status: 'connected'` alongside an empty `access_token` if a refresh nulled out the token without throwing.

## Testing

- `cd api && bun run lint` — clean (one unrelated pre-existing error in a gitignored local Supabase temp file, not part of this diff)
- `cd api && bunx tsc --noEmit` — clean
- `cd trigger && bun run typecheck` — clean
- `cd dashboard && bun run typecheck` — clean
- Not tested: a live end-to-end run against real Google OAuth credentials (no dev Google credentials available in this environment). Recommend confirming on the next real YouTube connect/reconnect, and by hitting `GET /v1/social-accounts/{id}` for an existing stale YouTube account against local Supabase.

## Notes

Spans `api`, `dashboard`, and `trigger` in one PR since the root causes are the same underlying bug across those three siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
