### PR TITLE
feat: make Facebook/Instagram Graph API versions env-configurable, fix deprecated v20.0

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -31,7 +31,13 @@ TRIGGER_SECRET_KEY=
 FacebookFeedMetricsLimitCap=
 
 # Optional Graph API version override. Defaults to v25.0 when unset.
+# Also used for the graph.facebook.com host in instagram.service.ts
+# (Instagram-via-Facebook-Page connections).
 FACEBOOK_API_VERSION=
+
+# Optional override for the graph.instagram.com host used by direct
+# Instagram business login connections. Defaults to v23.0 when unset.
+INSTAGRAM_API_VERSION=
 
 # Stripe — used by /private/webhooks/stripe and the manual sync CLI
 # (`bun run scripts/stripe-sync.ts --env=path/to/.env`). The webhook

--- a/api/src/instagram/instagram.service.ts
+++ b/api/src/instagram/instagram.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Scope } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { SocialPlatformService } from '../lib/social-provider-service';
 import type {
   PlatformPost,
@@ -21,12 +22,31 @@ import type {
 import { mapWithConcurrency } from '../lib/async.utils';
 
 const INSTAGRAM_METRICS_CONCURRENCY = 3;
+const DEFAULT_FACEBOOK_API_VERSION = 'v25.0';
+const DEFAULT_INSTAGRAM_API_VERSION = 'v23.0';
 
 @Injectable({ scope: Scope.REQUEST })
 export class InstagramService implements SocialPlatformService {
   appCredentials: SocialProviderAppCredentials;
 
-  constructor(private readonly supabaseService: SupabaseService) {}
+  constructor(
+    private readonly supabaseService: SupabaseService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  private get facebookApiVersion(): string {
+    return (
+      this.configService.get<string>('FACEBOOK_API_VERSION') ||
+      DEFAULT_FACEBOOK_API_VERSION
+    );
+  }
+
+  private get instagramApiVersion(): string {
+    return (
+      this.configService.get<string>('INSTAGRAM_API_VERSION') ||
+      DEFAULT_INSTAGRAM_API_VERSION
+    );
+  }
 
   getApiBaseUrl(account: SocialAccount) {
     // Use graph.instagram.com for direct IG tokens, graph.facebook.com otherwise
@@ -37,9 +57,9 @@ export class InstagramService implements SocialPlatformService {
       accountMetaData?.connection_type === 'instagram' ||
       (account.access_token && account.access_token.startsWith('IG'))
     ) {
-      return 'https://graph.instagram.com/v23.0';
+      return `https://graph.instagram.com/${this.instagramApiVersion}`;
     }
-    return 'https://graph.facebook.com/v23.0';
+    return `https://graph.facebook.com/${this.facebookApiVersion}`;
   }
 
   async initService(projectId: string): Promise<void> {
@@ -114,7 +134,7 @@ export class InstagramService implements SocialPlatformService {
         }
       } else {
         const response = await axios.get<FacebookRefreshTokenResponse>(
-          'https://graph.facebook.com/v20.0/oauth/access_token',
+          `https://graph.facebook.com/${this.facebookApiVersion}/oauth/access_token`,
           {
             params: {
               grant_type: 'fb_exchange_token',

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -39,3 +39,11 @@ POST_HOG_API_HOST=
 # META_PIXEL_ID is the numeric Dataset ID from Events Manager.
 GOOGLE_ADS_TAG_ID=
 META_PIXEL_ID=
+
+# Facebook / Instagram Graph API overrides used by the OAuth connection
+# callbacks in app/lib/.server/social-accounts/providers/. All optional;
+# each falls back to the default shown if unset.
+FACEBOOK_GRAPH_API_URL= # default: https://graph.facebook.com
+FACEBOOK_API_VERSION= # default: v25.0
+INSTAGRAM_GRAPH_API_URL= # default: https://graph.instagram.com
+INSTAGRAM_API_VERSION= # default: v23.0

--- a/dashboard/app/lib/.server/social-accounts/providers/facebook.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/facebook.social-account.ts
@@ -2,6 +2,10 @@ import type {
   SocialProviderConnection,
   SocialProviderInfo,
 } from "../social-account.types";
+import {
+  FACEBOOK_API_VERSION,
+  FACEBOOK_GRAPH_API_URL,
+} from "../social-account.constants";
 
 export async function getFacebookSocialProviderConnection({
   redirectUri,
@@ -16,7 +20,7 @@ export async function getFacebookSocialProviderConnection({
     throw Error("No code provided");
   }
 
-  const tokenUrl = `https://graph.facebook.com/v23.0/oauth/access_token`;
+  const tokenUrl = `${FACEBOOK_GRAPH_API_URL}/${FACEBOOK_API_VERSION}/oauth/access_token`;
   const tokenParams = new URLSearchParams([
     ["client_id", appCredentials.appId!],
     ["client_secret", appCredentials.appSecret!],
@@ -51,7 +55,7 @@ export async function getFacebookSocialProviderConnection({
 
   const accessToken = longLivedData.access_token;
 
-  let accountsUrl = `https://graph.facebook.com/v23.0/me/accounts?fields=name,access_token,picture&limit=100&access_token=${accessToken}`;
+  let accountsUrl = `${FACEBOOK_GRAPH_API_URL}/${FACEBOOK_API_VERSION}/me/accounts?fields=name,access_token,picture&limit=100&access_token=${accessToken}`;
 
   const accounts: SocialProviderConnection[] = [];
 

--- a/dashboard/app/lib/.server/social-accounts/providers/instagram-w-facebook.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/instagram-w-facebook.social-account.ts
@@ -2,6 +2,10 @@ import type {
   SocialProviderConnection,
   SocialProviderInfo,
 } from "../social-account.types";
+import {
+  FACEBOOK_API_VERSION,
+  FACEBOOK_GRAPH_API_URL,
+} from "../social-account.constants";
 
 export async function getInstagramWFacebookSocialProviderConnection({
   redirectUri,
@@ -16,7 +20,7 @@ export async function getInstagramWFacebookSocialProviderConnection({
     throw Error("No code provided");
   }
 
-  const tokenUrl = `https://graph.facebook.com/v23.0/oauth/access_token`;
+  const tokenUrl = `${FACEBOOK_GRAPH_API_URL}/${FACEBOOK_API_VERSION}/oauth/access_token`;
   const tokenParams = new URLSearchParams([
     ["client_id", appCredentials.appId!],
     ["client_secret", appCredentials.appSecret!],
@@ -51,7 +55,7 @@ export async function getInstagramWFacebookSocialProviderConnection({
       profile_picture_url: string;
     };
   }[] = [];
-  let pagesUrl = `https://graph.facebook.com/v23.0/me/accounts?fields=name,access_token,instagram_business_account{id,name,username,profile_picture_url}&limit=100&access_token=${accessToken}`;
+  let pagesUrl = `${FACEBOOK_GRAPH_API_URL}/${FACEBOOK_API_VERSION}/me/accounts?fields=name,access_token,instagram_business_account{id,name,username,profile_picture_url}&limit=100&access_token=${accessToken}`;
 
   try {
     while (pagesUrl) {

--- a/dashboard/app/lib/.server/social-accounts/providers/instagram.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/instagram.social-account.ts
@@ -2,6 +2,10 @@ import type {
   SocialProviderConnection,
   SocialProviderInfo,
 } from "../social-account.types";
+import {
+  INSTAGRAM_API_VERSION,
+  INSTAGRAM_GRAPH_API_URL,
+} from "../social-account.constants";
 
 export async function getInstagramSocialProviderConnection({
   redirectUri,
@@ -47,7 +51,7 @@ export async function getInstagramSocialProviderConnection({
   ]);
 
   const longLivedResponse = await fetch(
-    `https://graph.instagram.com/access_token?${longLivedTokenParams.toString()}`,
+    `${INSTAGRAM_GRAPH_API_URL}/access_token?${longLivedTokenParams.toString()}`,
   );
 
   const longLivedData = await longLivedResponse.json();
@@ -62,7 +66,7 @@ export async function getInstagramSocialProviderConnection({
 
   try {
     const profileResponse = await fetch(
-      `https://graph.instagram.com/v23.0/me?fields=user_id,username,profile_picture_url&access_token=${accessToken}`,
+      `${INSTAGRAM_GRAPH_API_URL}/${INSTAGRAM_API_VERSION}/me?fields=user_id,username,profile_picture_url&access_token=${accessToken}`,
       {
         method: "GET",
       },

--- a/dashboard/app/lib/.server/social-accounts/social-account.constants.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.constants.ts
@@ -1,2 +1,11 @@
 export const SOCIAL_ACCOUNT_PHOTO_BUCKET_NAME = "social-account-photos";
 export const REDIRECT_APP_URL = process.env.APP_URL || "http://localhost:5173";
+
+export const FACEBOOK_GRAPH_API_URL =
+  process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com";
+export const FACEBOOK_API_VERSION =
+  process.env.FACEBOOK_API_VERSION || "v25.0";
+export const INSTAGRAM_GRAPH_API_URL =
+  process.env.INSTAGRAM_GRAPH_API_URL || "https://graph.instagram.com";
+export const INSTAGRAM_API_VERSION =
+  process.env.INSTAGRAM_API_VERSION || "v23.0";

--- a/trigger/.env.example
+++ b/trigger/.env.example
@@ -3,3 +3,13 @@
 # dashboard/marketing so events attribute to the same teams/people.
 POST_HOG_API_KEY=
 POST_HOG_API_HOST=
+
+# Facebook / Instagram Graph API overrides used by
+# posting/platforms/facebook-post-client.ts and instagram-post-client.ts.
+# All optional; each falls back to the default shown if unset.
+FACEBOOK_GRAPH_API_URL= # default: https://graph.facebook.com
+FACEBOOK_GRAPH_VIDEO_API_URL= # default: https://graph-video.facebook.com
+INSTAGRAM_GRAPH_API_URL= # default: https://graph.instagram.com
+FACEBOOK_API_VERSION= # default: v25.0
+INSTAGRAM_API_VERSION= # default: v23.0
+FACEBOOK_OAUTH_API_VERSION= # default: v20.0

--- a/trigger/posting/platforms/facebook-post-client.ts
+++ b/trigger/posting/platforms/facebook-post-client.ts
@@ -25,10 +25,13 @@ export class FacebookPostClient extends PostClient {
     "upload_complete",
   ];
 
-  #graphApiUrl = "https://graph.facebook.com";
-  #graphVideoApiUrl = "https://graph-video.facebook.com";
-  #apiVersion = "v25.0";
-  #oauthApiVersion = "v20.0";
+  #graphApiUrl =
+    process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com";
+  #graphVideoApiUrl =
+    process.env.FACEBOOK_GRAPH_VIDEO_API_URL ||
+    "https://graph-video.facebook.com";
+  #apiVersion = process.env.FACEBOOK_API_VERSION || "v25.0";
+  #oauthApiVersion = process.env.FACEBOOK_OAUTH_API_VERSION || "v20.0";
 
   get #baseUrl(): string {
     return `${this.#graphApiUrl}/${this.#apiVersion}`;

--- a/trigger/posting/platforms/facebook-post-client.ts
+++ b/trigger/posting/platforms/facebook-post-client.ts
@@ -25,6 +25,19 @@ export class FacebookPostClient extends PostClient {
     "upload_complete",
   ];
 
+  #graphApiUrl = "https://graph.facebook.com";
+  #graphVideoApiUrl = "https://graph-video.facebook.com";
+  #apiVersion = "v25.0";
+  #oauthApiVersion = "v20.0";
+
+  get #baseUrl(): string {
+    return `${this.#graphApiUrl}/${this.#apiVersion}`;
+  }
+
+  get #videoBaseUrl(): string {
+    return `${this.#graphVideoApiUrl}/${this.#apiVersion}`;
+  }
+
   constructor(
     supabaseClient: SupabaseClient,
     appCredentials: PlatformAppCredentials,
@@ -44,11 +57,11 @@ export class FacebookPostClient extends PostClient {
         fb_exchange_token: account.access_token,
       };
       this.#requests.push({
-        refreshRequest: "https://graph.facebook.com/v20.0/oauth/access_token",
+        refreshRequest: `${this.#graphApiUrl}/${this.#oauthApiVersion}/oauth/access_token`,
         params: refreshParams,
       });
       const response = await axios.get(
-        "https://graph.facebook.com/v20.0/oauth/access_token",
+        `${this.#graphApiUrl}/${this.#oauthApiVersion}/oauth/access_token`,
         {
           params: refreshParams,
         },
@@ -188,7 +201,7 @@ export class FacebookPostClient extends PostClient {
       if (!platformUrl) {
         this.#requests.push({
           postRequest: {
-            url: `https://graph.facebook.com/v20.0/${platformId}`,
+            url: `${this.#baseUrl}/${platformId}`,
             params: {
               fields: "permalink_url",
               access_token: account.access_token,
@@ -197,7 +210,7 @@ export class FacebookPostClient extends PostClient {
         });
         // Get the permalink URL for non-video posts
         const postResponse = await axios.get(
-          `https://graph.facebook.com/v20.0/${platformId}`,
+          `${this.#baseUrl}/${platformId}`,
           {
             params: {
               fields: "permalink_url",
@@ -273,13 +286,13 @@ export class FacebookPostClient extends PostClient {
 
     this.#requests.push({
       createTextRequest: {
-        url: `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/feed`,
+        url: `${this.#baseUrl}/${account.social_provider_user_id}/feed`,
         body: postData,
       },
     });
 
     const response = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/feed`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/feed`,
       postData,
     );
 
@@ -333,12 +346,12 @@ export class FacebookPostClient extends PostClient {
 
     this.#requests.push({
       photoRequest: {
-        url: `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
+        url: `${this.#videoBaseUrl}/${account.social_provider_user_id}/photos`,
         data: payload,
       },
     });
     const photoResponse = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/photos`,
       payload,
     );
 
@@ -402,12 +415,12 @@ export class FacebookPostClient extends PostClient {
 
       this.#requests.push({
         photoRequest: {
-          url: `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
+          url: `${this.#videoBaseUrl}/${account.social_provider_user_id}/photos`,
           data: payload,
         },
       });
       const photoResponse = await axios.post(
-        `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
+        `${this.#baseUrl}/${account.social_provider_user_id}/photos`,
         payload,
       );
 
@@ -422,7 +435,7 @@ export class FacebookPostClient extends PostClient {
 
     this.#requests.push({
       createCarouselPostRequest: {
-        url: `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/feed`,
+        url: `${this.#baseUrl}/${account.social_provider_user_id}/feed`,
         body: {
           message: caption,
           access_token: account.access_token,
@@ -449,7 +462,7 @@ export class FacebookPostClient extends PostClient {
     }
     // Create the carousel post
     const response = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/feed`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/feed`,
       carouselBody,
     );
 
@@ -476,7 +489,7 @@ export class FacebookPostClient extends PostClient {
     const fileUrl = await this.getSignedUrlForFile(medium);
     this.#requests.push({
       videoRequest: {
-        url: `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/videos`,
+        url: `${this.#videoBaseUrl}/${account.social_provider_user_id}/videos`,
         data: {
           file_url: fileUrl,
           description: caption,
@@ -485,7 +498,7 @@ export class FacebookPostClient extends PostClient {
       },
     });
     const videoResponse = await axios.post(
-      `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/videos`,
+      `${this.#videoBaseUrl}/${account.social_provider_user_id}/videos`,
       {
         file_url: fileUrl,
         description: caption,
@@ -513,11 +526,11 @@ export class FacebookPostClient extends PostClient {
     while (status === "processing" && attempts < maxAttempts) {
       this.#requests.push({
         statusRequest: {
-          url: `https://graph.facebook.com/${videoResponseData.id}?fields=status`,
+          url: `${this.#graphApiUrl}/${videoResponseData.id}?fields=status`,
         },
       });
       statusResponse = await axios.get(
-        `https://graph.facebook.com/${videoResponseData.id}?fields=status`,
+        `${this.#graphApiUrl}/${videoResponseData.id}?fields=status`,
         {
           headers: {
             Authorization: `OAuth ${account.access_token}`,
@@ -549,7 +562,7 @@ export class FacebookPostClient extends PostClient {
     medium: PostMedia;
   }): Promise<string> {
     const uploadSessionResponse = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/video_stories`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/video_stories`,
       {
         upload_phase: "start",
         access_token: account.access_token,
@@ -599,7 +612,7 @@ export class FacebookPostClient extends PostClient {
       vidoeAttempts < videoMaxAttempts
     ) {
       videoStatusResponse = await axios.get(
-        `https://graph.facebook.com/${uploadSessionResponseData.video_id}?fields=status`,
+        `${this.#graphApiUrl}/${uploadSessionResponseData.video_id}?fields=status`,
         {
           headers: {
             Authorization: `OAuth ${account.access_token}`,
@@ -627,7 +640,7 @@ export class FacebookPostClient extends PostClient {
     const createdMediaId = uploadSessionResponseData.video_id;
 
     const storyResponse = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/video_stories`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/video_stories`,
       {
         video_id: createdMediaId,
         upload_phase: "finish",
@@ -657,7 +670,7 @@ export class FacebookPostClient extends PostClient {
     ) {
       try {
         statusResponse = await axios.get(
-          `https://graph.facebook.com/${createdMediaId}?fields=status`,
+          `${this.#graphApiUrl}/${createdMediaId}?fields=status`,
           {
             headers: {
               Authorization: `OAuth ${account.access_token}`,
@@ -737,12 +750,12 @@ export class FacebookPostClient extends PostClient {
 
     this.#requests.push({
       photoRequest: {
-        url: `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
+        url: `${this.#videoBaseUrl}/${account.social_provider_user_id}/photos`,
         data: payload,
       },
     });
     const photoResponse = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/photos`,
       payload,
     );
 
@@ -756,7 +769,7 @@ export class FacebookPostClient extends PostClient {
     const createdMediaId = photoResponse.data.id;
 
     const storyResponse = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/photo_stories`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/photo_stories`,
       {
         photo_id: createdMediaId,
         access_token: account.access_token,
@@ -784,7 +797,7 @@ export class FacebookPostClient extends PostClient {
     accessToken: string;
   }): Promise<string | undefined> {
     const postResponse = await axios.get(
-      `https://graph.facebook.com/v20.0/${platformId}?fields=url&access_token=${accessToken}`,
+      `${this.#baseUrl}/${platformId}?fields=url&access_token=${accessToken}`,
     );
 
     const postResponseData = postResponse.data as {
@@ -806,7 +819,7 @@ export class FacebookPostClient extends PostClient {
     platformConfig: FacebookConfiguration;
   }) {
     const uploadSessionResponse = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/video_reels`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/video_reels`,
       {
         upload_phase: "start",
         access_token: account.access_token,
@@ -856,7 +869,7 @@ export class FacebookPostClient extends PostClient {
       vidoeAttempts < videoMaxAttempts
     ) {
       videoStatusResponse = await axios.get(
-        `https://graph.facebook.com/${uploadSessionResponseData.video_id}?fields=status`,
+        `${this.#graphApiUrl}/${uploadSessionResponseData.video_id}?fields=status`,
         {
           headers: {
             Authorization: `OAuth ${account.access_token}`,
@@ -911,7 +924,7 @@ export class FacebookPostClient extends PostClient {
     }
 
     const reelResponse = await axios.post(
-      `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/video_reels`,
+      `${this.#baseUrl}/${account.social_provider_user_id}/video_reels`,
       reelBody,
     );
 
@@ -937,7 +950,7 @@ export class FacebookPostClient extends PostClient {
     ) {
       try {
         statusResponse = await axios.get(
-          `https://graph.facebook.com/${createdMediaId}?fields=status`,
+          `${this.#graphApiUrl}/${createdMediaId}?fields=status`,
           {
             headers: {
               Authorization: `OAuth ${account.access_token}`,
@@ -977,7 +990,7 @@ export class FacebookPostClient extends PostClient {
       for (const collaborator of platformConfig.collaborators) {
         try {
           const collaboratorResponse = await axios.post(
-            `https://graph.facebook.com/v20.0/${createdMediaId}/collaborators`,
+            `${this.#baseUrl}/${createdMediaId}/collaborators`,
             {
               target_id: collaborator,
               access_token: account.access_token,
@@ -1026,7 +1039,7 @@ export class FacebookPostClient extends PostClient {
       contentType: file.type,
     });
 
-    await fetch(`https://graph.facebook.com/v20.0/${videoId}/thumbnails`, {
+    await fetch(`${this.#baseUrl}/${videoId}/thumbnails`, {
       method: "POST",
       body: form,
       headers: {

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -33,15 +33,23 @@ export class InstagramPostClient extends PostClient {
   #bucket: string = "post-media";
   #appCredentials: PlatformAppCredentials;
 
+  #graphApiUrl =
+    process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com";
+  #graphInstagramApiUrl =
+    process.env.INSTAGRAM_GRAPH_API_URL || "https://graph.instagram.com";
+  #apiVersion = process.env.FACEBOOK_API_VERSION || "v25.0";
+  #instagramApiVersion = process.env.INSTAGRAM_API_VERSION || "v23.0";
+  #oauthApiVersion = process.env.FACEBOOK_OAUTH_API_VERSION || "v20.0";
+
   getApiBaseUrl(account: SocialAccount) {
     // Use graph.instagram.com for direct IG tokens, graph.facebook.com otherwise
     if (
       account.social_provider_metadata?.connection_type === "instagram" ||
       (account.access_token && account.access_token.startsWith("IG"))
     ) {
-      return "https://graph.instagram.com/v23.0";
+      return `${this.#graphInstagramApiUrl}/${this.#instagramApiVersion}`;
     }
-    return "https://graph.facebook.com/v23.0";
+    return `${this.#graphApiUrl}/${this.#apiVersion}`;
   }
 
   constructor(
@@ -63,14 +71,14 @@ export class InstagramPostClient extends PostClient {
           `Refreshing direct Instagram token (via connection_type) for account: ${account.id}`,
         );
         this.#requests.push({
-          refreshRequest: "https://graph.instagram.com/refresh_access_token",
+          refreshRequest: `${this.#graphInstagramApiUrl}/refresh_access_token`,
           params: {
             grant_type: "ig_refresh_token",
             access_token: account.access_token,
           },
         });
         const response = await axios.get(
-          `https://graph.instagram.com/refresh_access_token`,
+          `${this.#graphInstagramApiUrl}/refresh_access_token`,
           {
             params: {
               grant_type: "ig_refresh_token",
@@ -106,11 +114,11 @@ export class InstagramPostClient extends PostClient {
         };
 
         this.#requests.push({
-          refreshRequest: "https://graph.facebook.com/v20.0/oauth/access_token",
+          refreshRequest: `${this.#graphApiUrl}/${this.#oauthApiVersion}/oauth/access_token`,
           params: refreshTokenParams,
         });
         const response = await axios.get(
-          `https://graph.facebook.com/v20.0/oauth/access_token`,
+          `${this.#graphApiUrl}/${this.#oauthApiVersion}/oauth/access_token`,
           {
             params: refreshTokenParams,
           },


### PR DESCRIPTION
## Summary

Facebook video posts (stories, reels, and default timeline video) were failing with "Invalid parameter" for a connected Page, while photo posts on the same Page succeeded and a direct manual Graph API call with the same file worked fine. Root cause: `trigger/posting/platforms/facebook-post-client.ts`, the actual publish path, was hardcoded to Graph API `v20.0` — past its ~2-year support window — while other parts of the codebase had already moved on to `v23.0`/`v25.0`. This PR fixes that, and sweeps every remaining hardcoded Facebook/Instagram Graph API host and version across all three siblings that touch these APIs (`api/`, `trigger/`, `dashboard/`) so future deprecation cycles are a config change instead of a code change.

## Changes

**`trigger/posting/platforms/facebook-post-client.ts`**
- Bumped every publish/query endpoint from `v20.0` → `v25.0` (feed, photos, videos, stories, reels, collaborators, thumbnails).
- Extracted the hardcoded URLs/versions into private fields, sourced from `process.env` with the previous hardcoded values as fallback defaults: `FACEBOOK_GRAPH_API_URL`, `FACEBOOK_GRAPH_VIDEO_API_URL`, `FACEBOOK_API_VERSION` (default `v25.0`), `FACEBOOK_OAUTH_API_VERSION` (default `v20.0`).

**`trigger/posting/platforms/instagram-post-client.ts`**
- Same treatment: `getApiBaseUrl()` and both OAuth refresh branches now read `FACEBOOK_GRAPH_API_URL`, `INSTAGRAM_GRAPH_API_URL`, `FACEBOOK_API_VERSION`, `INSTAGRAM_API_VERSION` (default `v23.0`), and `FACEBOOK_OAUTH_API_VERSION` from env instead of hardcoding `v23.0`/`v20.0`.
- Documented all six vars in `trigger/.env.example`.

**`api/src/instagram/instagram.service.ts`**
- Was hardcoded to `v23.0` for both `graph.instagram.com` and `graph.facebook.com`, plus a stray `v20.0` on the Facebook oauth refresh call — none of it configurable, unlike `facebook.service.ts` and `auth-url.helper.ts`.
- Injected `ConfigService` and wired the `graph.facebook.com` branch + oauth refresh to the existing `FACEBOOK_API_VERSION` env var (default `v25.0`, matching `facebook.service.ts`).
- Added a new `INSTAGRAM_API_VERSION` env var (default `v23.0`) for the `graph.instagram.com` branch, since that's a separate host/product surface worth tuning independently.
- Documented both vars in `api/.env.example`.

`api/src/facebook/facebook.service.ts` needed no changes — every endpoint there, including `/feed`, already read `FACEBOOK_API_VERSION` from `ConfigService`.

**`dashboard/app/lib/.server/social-accounts/providers/{facebook,instagram,instagram-w-facebook}.social-account.ts`**
- The OAuth connection callbacks (token exchange + page/account listing during account connect) hardcoded `v23.0` and the `graph.facebook.com` / `graph.instagram.com` hosts directly in each file.
- Added `FACEBOOK_GRAPH_API_URL`, `FACEBOOK_API_VERSION`, `INSTAGRAM_GRAPH_API_URL`, `INSTAGRAM_API_VERSION` to `social-account.constants.ts` (dashboard's existing convention for `process.env.X || default` config), and wired all three provider files to them.
- Left `https://api.instagram.com/oauth/access_token` (the initial Instagram code exchange) untouched — it's a distinct, unversioned host unrelated to Graph API version deprecation.
- Documented the four vars in `dashboard/.env.example`.

## Testing

- `cd trigger && bun run typecheck && bun run lint` — passes
- `cd api && bun run typecheck && bun run lint` — passes (one unrelated pre-existing lint error from a gitignored local Supabase temp file, reproduced identically on `main` before this change)
- `cd dashboard && bun run typecheck && bun run lint` — passes
- Not yet verified end-to-end against a live Facebook/Instagram account — would need a connected test account to confirm the version bump resolves the "Invalid parameter" error in production.

## Notes

Root-caused via PFM-960: the reporter proved the same hosted video URL, Page, and token succeeded when posted manually via Graph API `v21.0`, isolating the bug to our stale `v20.0` pin rather than the file/encoding/Page config (all of which they had already ruled out).

Closes PFM-960

🤖 Generated with [Claude Code](https://claude.com/claude-code)