### PR TITLE
feat(x): capture display name and full-res photo in OAuth metadata

### DIFF
--- a/api/src/social-provider-connections/dto/create-social-account.dto.ts
+++ b/api/src/social-provider-connections/dto/create-social-account.dto.ts
@@ -8,8 +8,18 @@ export class SocialAccountMetadata {
 
   is_sandbox?: boolean;
 
+  @ApiProperty({
+    description: "The platform's verification status of the social account",
+    type: String,
+    required: false,
+  })
   verified_type?: string;
 
+  @ApiProperty({
+    description: "The platform's display name of the social account",
+    type: String,
+    required: false,
+  })
   display_name?: string;
 }
 

--- a/api/src/social-provider-connections/dto/create-social-account.dto.ts
+++ b/api/src/social-provider-connections/dto/create-social-account.dto.ts
@@ -7,6 +7,10 @@ export class SocialAccountMetadata {
   has_platform_premium?: boolean;
 
   is_sandbox?: boolean;
+
+  verified_type?: string;
+
+  display_name?: string;
 }
 
 export class CreateSocialAccountDto {

--- a/dashboard/app/lib/.server/social-accounts/providers/x-oauth2.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/x-oauth2.social-account.ts
@@ -60,7 +60,7 @@ export async function getXOAuth2SocialProviderConnection({
       social_provider_user_id: user.id,
       social_provider_user_name: user.username,
       social_provider_photo_url: user.profile_image_url?.replace(
-        "_normal",
+        /_normal(?=\.\w+$)/,
         "",
       ),
       access_token_expires_at: new Date(Date.now() + expiresIn * 1000),

--- a/dashboard/app/lib/.server/social-accounts/providers/x-oauth2.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/x-oauth2.social-account.ts
@@ -59,12 +59,16 @@ export async function getXOAuth2SocialProviderConnection({
       refresh_token: refreshToken,
       social_provider_user_id: user.id,
       social_provider_user_name: user.username,
-      social_provider_photo_url: user.profile_image_url,
+      social_provider_photo_url: user.profile_image_url?.replace(
+        "_normal",
+        "",
+      ),
       access_token_expires_at: new Date(Date.now() + expiresIn * 1000),
       social_provider_metadata: {
         connection_type: "oauth2",
         has_platform_premium: isPremium,
         verified_type: user.verified_type ?? "none",
+        display_name: user.name,
       },
     },
   ];

--- a/dashboard/app/lib/.server/social-accounts/providers/x.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/x.social-account.ts
@@ -52,7 +52,7 @@ export async function getXSocialProviderConnection({
       social_provider_user_id: user.id,
       social_provider_user_name: user.username,
       social_provider_photo_url: user.profile_image_url?.replace(
-        "_normal",
+        /_normal(?=\.\w+$)/,
         "",
       ),
       access_token_expires_at: new Date(Date.now() + 180 * 24 * 60 * 60 * 1000),

--- a/dashboard/app/lib/.server/social-accounts/providers/x.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/x.social-account.ts
@@ -51,12 +51,16 @@ export async function getXSocialProviderConnection({
       refresh_token: accessSecret,
       social_provider_user_id: user.id,
       social_provider_user_name: user.username,
-      social_provider_photo_url: user.profile_image_url,
+      social_provider_photo_url: user.profile_image_url?.replace(
+        "_normal",
+        "",
+      ),
       access_token_expires_at: new Date(Date.now() + 180 * 24 * 60 * 60 * 1000),
       social_provider_metadata: {
         connection_type: "oauth1",
         has_platform_premium: isPremium,
         verified_type: user.verified_type ?? "none",
+        display_name: user.name,
       },
     },
   ];


### PR DESCRIPTION
## Summary

X's OAuth response already includes the account's display name and a downscaled profile photo, but the app was discarding the display name and storing the low-res thumbnail as-is. This surfaces that data so it doesn't need to be fetched from X's API again later.

## Changes

- `dashboard/app/lib/.server/social-accounts/providers/x-oauth2.social-account.ts` and `x.social-account.ts` — strip the `_normal` size suffix from `profile_image_url` to store the original, full-resolution photo, and capture `user.name` as `display_name` in `social_provider_metadata`.
- `api/src/social-provider-connections/dto/create-social-account.dto.ts` — added `verified_type` and `display_name` to the shared `SocialAccountMetadata` DTO so both fields are documented in Swagger and returned by the public API (verified_type was already being stored but wasn't declared on the DTO).
- No DB migration needed — `social_provider_metadata` is an existing generic `jsonb` column.

## Testing

- `cd dashboard && bun run typecheck && bun run lint` — pass.
- `cd api && bun run lint` on the changed file directly — pass (repo-wide `lint` currently fails on an unrelated pre-existing Supabase temp-file parsing error, unaffected by this change).
- Not yet exercised against a live X OAuth connect flow — recommend a manual test before merging: connect an X account and confirm `social_provider_photo_url` is full-res (no `_normal` in the URL) and `social_provider_metadata.display_name` is populated.

## Notes

Opened as a draft pending the live OAuth verification step above.

Closes PFM-958

🤖 Generated with AI