### PR TITLE
feat(api,trigger): support post chains (threads) on x, threads, and bluesky

### DIFF
--- a/api/src/social-post-results/dto/post-results.dto.ts
+++ b/api/src/social-post-results/dto/post-results.dto.ts
@@ -11,6 +11,14 @@ export class SocialPostResultDto {
   @ApiProperty({ description: 'The ID of the associated post' })
   post_id: string;
 
+  @ApiProperty({
+    description:
+      'The ID of the chain item this result belongs to, if the post was part of a reply chain/thread. Null indicates this result is for the root post.',
+    nullable: true,
+    type: String,
+  })
+  chain_item_id: string | null;
+
   @ApiProperty({ description: 'Indicates if the post was successful' })
   success: boolean;
 

--- a/api/src/social-post-results/social-post-results.service.ts
+++ b/api/src/social-post-results/social-post-results.service.ts
@@ -25,6 +25,7 @@ export class PostResultsService {
       id: string;
       details?: any;
       post_id: string;
+      chain_item_id: string | null;
       provider_connection_id: string;
       error_message?: string;
       media?: SocialPostResultDto['media'];
@@ -34,7 +35,7 @@ export class PostResultsService {
       await this.supabaseService.supabaseClient
         .from('social_post_results')
         .select(
-          'id, success, provider_post_id, provider_post_url, details, post_id, provider_connection_id, error_message, social_provider_connections(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
+          'id, success, provider_post_id, provider_post_url, details, post_id, chain_item_id, provider_connection_id, error_message, social_provider_connections(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
         )
         .eq('id', id)
         .eq('social_provider_connections.project_id', projectId)
@@ -52,6 +53,7 @@ export class PostResultsService {
         id: postResult?.id,
         details: postResult?.details,
         post_id: postResult?.post_id,
+        chain_item_id: postResult?.chain_item_id ?? null,
         provider_connection_id: postResult?.provider_connection_id,
         error_message: postResult?.error_message || undefined,
         media:
@@ -125,7 +127,7 @@ export class PostResultsService {
     const query = this.supabaseService.supabaseClient
       .from('social_post_results')
       .select(
-        'id, provider_connection_id, post_id, success, error_message, details, provider_post_id, provider_post_url, created_at, social_provider_connections!inner(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
+        'id, provider_connection_id, post_id, chain_item_id, success, error_message, details, provider_post_id, provider_post_url, created_at, social_provider_connections!inner(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
       )
       .eq('social_provider_connections.project_id', projectId)
       .in(
@@ -196,6 +198,7 @@ export class PostResultsService {
         id: raw.id,
         social_account_id: raw.provider_connection_id,
         post_id: raw.post_id,
+        chain_item_id: raw.chain_item_id,
         success: raw.success,
         error: raw.error_message,
         details: raw.details,
@@ -241,6 +244,7 @@ export class PostResultsService {
       id: postResults.data.id,
       social_account_id: postResults.data.provider_connection_id,
       post_id: postResults.data.post_id,
+      chain_item_id: postResults.data.chain_item_id,
       success: postResults.data.success,
       error: postResults.data.error_message || null,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/api/src/social-post-results/social-post-results.service.ts
+++ b/api/src/social-post-results/social-post-results.service.ts
@@ -35,7 +35,7 @@ export class PostResultsService {
       await this.supabaseService.supabaseClient
         .from('social_post_results')
         .select(
-          'id, success, provider_post_id, provider_post_url, details, post_id, chain_item_id, provider_connection_id, error_message, social_provider_connections(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
+          'id, success, provider_post_id, provider_post_url, details, post_id, chain_item_id, provider_connection_id, error_message, social_provider_connections(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing)), social_post_result_chain_item_media(social_post_chain_item_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
         )
         .eq('id', id)
         .eq('social_provider_connections.project_id', projectId)
@@ -56,15 +56,30 @@ export class PostResultsService {
         chain_item_id: postResult?.chain_item_id ?? null,
         provider_connection_id: postResult?.provider_connection_id,
         error_message: postResult?.error_message || undefined,
-        media:
-          postResult?.social_post_result_post_media?.map((resultMedia) => ({
+        media: [
+          ...(postResult?.social_post_result_post_media?.map((resultMedia) => ({
             url: resultMedia.social_post_media.url,
             thumbnail_url: resultMedia.social_post_media.thumbnail_url,
             thumbnail_timestamp_ms:
               resultMedia.social_post_media.thumbnail_timestamp_ms,
             tags: resultMedia.social_post_media.tags as any[] | null,
             skip_processing: resultMedia.social_post_media.skip_processing,
-          })) || [],
+          })) || []),
+          ...(postResult?.social_post_result_chain_item_media?.map(
+            (resultMedia) => ({
+              url: resultMedia.social_post_chain_item_media.url,
+              thumbnail_url:
+                resultMedia.social_post_chain_item_media.thumbnail_url,
+              thumbnail_timestamp_ms:
+                resultMedia.social_post_chain_item_media.thumbnail_timestamp_ms,
+              tags: resultMedia.social_post_chain_item_media.tags as
+                | any[]
+                | null,
+              skip_processing:
+                resultMedia.social_post_chain_item_media.skip_processing,
+            }),
+          ) || []),
+        ],
       },
     };
   }
@@ -127,7 +142,7 @@ export class PostResultsService {
     const query = this.supabaseService.supabaseClient
       .from('social_post_results')
       .select(
-        'id, provider_connection_id, post_id, chain_item_id, success, error_message, details, provider_post_id, provider_post_url, created_at, social_provider_connections!inner(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
+        'id, provider_connection_id, post_id, chain_item_id, success, error_message, details, provider_post_id, provider_post_url, created_at, social_provider_connections!inner(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing)), social_post_result_chain_item_media(social_post_chain_item_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
       )
       .eq('social_provider_connections.project_id', projectId)
       .in(
@@ -203,15 +218,26 @@ export class PostResultsService {
         error: raw.error_message,
         details: raw.details,
         platform_data,
-        media:
-          raw.social_post_result_post_media?.map((resultMedia) => ({
+        media: [
+          ...(raw.social_post_result_post_media?.map((resultMedia) => ({
             url: resultMedia.social_post_media.url,
             thumbnail_url: resultMedia.social_post_media.thumbnail_url,
             thumbnail_timestamp_ms:
               resultMedia.social_post_media.thumbnail_timestamp_ms,
             tags: resultMedia.social_post_media.tags as any[] | null,
             skip_processing: resultMedia.social_post_media.skip_processing,
-          })) || [],
+          })) || []),
+          ...(raw.social_post_result_chain_item_media?.map((resultMedia) => ({
+            url: resultMedia.social_post_chain_item_media.url,
+            thumbnail_url:
+              resultMedia.social_post_chain_item_media.thumbnail_url,
+            thumbnail_timestamp_ms:
+              resultMedia.social_post_chain_item_media.thumbnail_timestamp_ms,
+            tags: resultMedia.social_post_chain_item_media.tags as any[] | null,
+            skip_processing:
+              resultMedia.social_post_chain_item_media.skip_processing,
+          })) || []),
+        ],
       };
     });
 

--- a/api/src/social-posts/docs/posts-controller.md.ts
+++ b/api/src/social-posts/docs/posts-controller.md.ts
@@ -6,4 +6,6 @@ Posts represent content that can be published across multiple social media platf
 3. Account-specific content overrides
 
 The system will use the most specific content override available when publishing to each platform and account.
+
+Posts can optionally include a \`chain\`: an ordered list of follow-up posts published as sequential replies after the root post (item 1 replies to the root, item 2 replies to item 1, and so on), forming a thread. Chains are only supported on x, threads, and bluesky - other platforms in the same request publish only the root post and ignore the chain.
 `;

--- a/api/src/social-posts/dto/create-post.dto.ts
+++ b/api/src/social-posts/dto/create-post.dto.ts
@@ -5,6 +5,7 @@ import {
   AccountConfigurationDto,
   PlatformConfigurationsDto,
 } from './post-configurations.dto';
+import { SocialPostChainItemDto } from './post-chain.dto';
 
 export class CreateSocialPostDto {
   @ApiProperty({ description: 'Caption text for the post' })
@@ -49,6 +50,16 @@ export class CreateSocialPostDto {
 
   @ApiProperty({ description: 'Array of social account IDs for posting' })
   social_accounts: string[];
+
+  @ApiProperty({
+    description:
+      'Ordered list of follow-up posts published as a reply chain/thread after the root post (item 1 replies to the root, item 2 replies to item 1, and so on). Only applies to social_accounts on x, threads, and bluesky - other platforms post only the root post and ignore this field. All chain items post to the same social_accounts as the root; per-account/per-platform overrides are not supported for chain items.',
+    nullable: true,
+    required: false,
+    type: SocialPostChainItemDto,
+    isArray: true,
+  })
+  chain?: SocialPostChainItemDto[] | null;
 
   @ApiProperty({
     description: 'Array of social account IDs for posting',

--- a/api/src/social-posts/dto/post-chain.dto.ts
+++ b/api/src/social-posts/dto/post-chain.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SocialPostMediaDto } from './post-media.dto';
+
+export class SocialPostChainItemDto {
+  @ApiProperty({
+    description:
+      'Caption for this chain item. Posted as a reply to the previous chain item (or to the root post, for the first item).',
+  })
+  caption: string;
+
+  @ApiProperty({
+    description: 'Array of media associated with this chain item',
+    nullable: true,
+    required: false,
+    type: SocialPostMediaDto,
+    isArray: true,
+  })
+  media?: SocialPostMediaDto[] | null;
+}

--- a/api/src/social-posts/dto/post-chain.dto.ts
+++ b/api/src/social-posts/dto/post-chain.dto.ts
@@ -17,3 +17,14 @@ export class SocialPostChainItemDto {
   })
   media?: SocialPostMediaDto[] | null;
 }
+
+export class SocialPostChainItemResponseDto extends SocialPostChainItemDto {
+  @ApiProperty({ description: 'Unique identifier of the chain item' })
+  id: string;
+
+  @ApiProperty({
+    description:
+      'Position of this chain item in the reply chain, starting at 1',
+  })
+  sequence: number;
+}

--- a/api/src/social-posts/dto/post.dto.ts
+++ b/api/src/social-posts/dto/post.dto.ts
@@ -5,7 +5,7 @@ import {
   PlatformConfigurationsDto,
 } from './post-configurations.dto';
 import { SocialAccountDto } from '../../social-provider-connections/dto/social-accounts.dto';
-import { SocialPostChainItemDto } from './post-chain.dto';
+import { SocialPostChainItemResponseDto } from './post-chain.dto';
 
 export enum PostStatus {
   DRAFT = 'draft',
@@ -77,9 +77,9 @@ export class SocialPostDto {
       'Ordered list of follow-up posts published as a reply chain/thread after the root post',
     nullable: true,
     isArray: true,
-    type: SocialPostChainItemDto,
+    type: SocialPostChainItemResponseDto,
   })
-  chain: SocialPostChainItemDto[] | undefined | null;
+  chain: SocialPostChainItemResponseDto[] | undefined | null;
 
   @ApiProperty({ description: 'Timestamp when the post was created' })
   created_at: string;

--- a/api/src/social-posts/dto/post.dto.ts
+++ b/api/src/social-posts/dto/post.dto.ts
@@ -5,6 +5,7 @@ import {
   PlatformConfigurationsDto,
 } from './post-configurations.dto';
 import { SocialAccountDto } from '../../social-provider-connections/dto/social-accounts.dto';
+import { SocialPostChainItemDto } from './post-chain.dto';
 
 export enum PostStatus {
   DRAFT = 'draft',
@@ -70,6 +71,15 @@ export class SocialPostDto {
     type: SocialAccountDto,
   })
   social_accounts: SocialAccountDto[];
+
+  @ApiProperty({
+    description:
+      'Ordered list of follow-up posts published as a reply chain/thread after the root post',
+    nullable: true,
+    isArray: true,
+    type: SocialPostChainItemDto,
+  })
+  chain: SocialPostChainItemDto[] | undefined | null;
 
   @ApiProperty({ description: 'Timestamp when the post was created' })
   created_at: string;

--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -21,6 +21,23 @@ type ProviderTypeEnum = Database['public']['Enums']['social_provider'];
 
 type PostStatusEnum = Database['public']['Enums']['social_post_status'];
 
+const MAX_CHAIN_LENGTH = 25;
+
+const CHAIN_SELECT = `
+        social_post_chain_items (
+          id,
+          sequence,
+          caption,
+          social_post_chain_item_media (
+            id,
+            url,
+            thumbnail_url,
+            thumbnail_timestamp_ms,
+            tags,
+            skip_processing
+          )
+        )`;
+
 @Injectable()
 export class SocialPostsService {
   constructor(
@@ -127,6 +144,35 @@ export class SocialPostsService {
           }
         }
       }
+    }
+
+    // Validate chain items
+    if (Array.isArray(post.chain)) {
+      if (post.chain.length > MAX_CHAIN_LENGTH) {
+        errors.push(`chain cannot contain more than ${MAX_CHAIN_LENGTH} items`);
+      }
+
+      post.chain.forEach((item, index) => {
+        if (!item.caption) {
+          errors.push(`chain[${index}]: caption is required`);
+        }
+
+        if (item.media) {
+          for (const media of item.media) {
+            const urlValidation = this.validateMediaUrl(media.url);
+            errors.push(...urlValidation.map((e) => `chain[${index}]: ${e}`));
+
+            if (media.thumbnail_url) {
+              const thumbnailValidation = this.validateMediaUrl(
+                media.thumbnail_url,
+              );
+              errors.push(
+                ...thumbnailValidation.map((e) => `chain[${index}]: ${e}`),
+              );
+            }
+          }
+        }
+      });
     }
 
     // Validate account configuration media URLs
@@ -452,6 +498,54 @@ export class SocialPostsService {
       console.error(insertPostConfigurationsError);
     }
 
+    if (post.chain && post.chain.length > 0) {
+      const { data: insertedChainItems, error: insertChainItemsError } =
+        await this.supabaseService.supabaseClient
+          .from('social_post_chain_items')
+          .insert(
+            post.chain.map((item, index) => ({
+              post_id: data.id,
+              sequence: index + 1,
+              caption: item.caption,
+            })),
+          )
+          .select('id, sequence');
+
+      if (insertChainItemsError) {
+        console.error(insertChainItemsError);
+      } else if (insertedChainItems) {
+        const chainItemMedia = post.chain.flatMap((item, index) => {
+          const chainItem = insertedChainItems.find(
+            (c) => c.sequence === index + 1,
+          );
+
+          if (!chainItem || !item.media) {
+            return [];
+          }
+
+          return item.media.map((media) => ({
+            chain_item_id: chainItem.id,
+            url: media.url,
+            thumbnail_url: media.thumbnail_url,
+            thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+            tags: media.tags as any[],
+            skip_processing: media.skip_processing,
+          }));
+        });
+
+        if (chainItemMedia.length > 0) {
+          const { error: insertChainItemMediaError } =
+            await this.supabaseService.supabaseClient
+              .from('social_post_chain_item_media')
+              .insert(chainItemMedia);
+
+          if (insertChainItemMediaError) {
+            console.error(insertChainItemMediaError);
+          }
+        }
+      }
+    }
+
     if (data.status === 'processing') {
       await this.triggerPost(data.id);
     }
@@ -515,7 +609,8 @@ export class SocialPostsService {
          provider,
          provider_connection_id,
          provider_data
-        )
+        ),
+        ${CHAIN_SELECT}
         `,
       )
       .eq('id', postId)
@@ -581,7 +676,8 @@ export class SocialPostsService {
          provider,
          provider_connection_id,
          provider_data
-        )
+        ),
+        ${CHAIN_SELECT}
         `,
         { count: 'estimated', head: false },
       )
@@ -810,7 +906,8 @@ export class SocialPostsService {
               provider,
               provider_connection_id,
               provider_data
-            )
+            ),
+            ${CHAIN_SELECT}
         `,
         )
         .eq('id', postId)
@@ -869,6 +966,18 @@ export class SocialPostsService {
       provider_connection_id: string | null;
       provider_data: Json;
     }>;
+    social_post_chain_items?: Array<{
+      sequence: number;
+      caption: string;
+      social_post_chain_item_media: Array<{
+        id: string;
+        url: string;
+        thumbnail_url: string | null;
+        thumbnail_timestamp_ms: number | null;
+        tags: Json;
+        skip_processing: boolean | null;
+      }>;
+    }> | null;
   }): SocialPostDto {
     const postMedia = data.social_post_media
       .filter((media) => !media.provider && !media.provider_connection_id)
@@ -954,6 +1063,19 @@ export class SocialPostsService {
       }),
     );
 
+    const chain = [...(data.social_post_chain_items ?? [])]
+      .sort((a, b) => a.sequence - b.sequence)
+      .map((item) => ({
+        caption: item.caption,
+        media: item.social_post_chain_item_media.map((media) => ({
+          url: media.url,
+          thumbnail_url: media.thumbnail_url,
+          thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+          tags: media.tags as any[],
+          skip_processing: media.skip_processing,
+        })),
+      }));
+
     const postData: SocialPostDto = {
       id: data.id,
       external_id: data.external_id,
@@ -963,6 +1085,7 @@ export class SocialPostsService {
       platform_configurations: platformConfigurations,
       account_configurations: accountConfigurations,
       social_accounts: socialAccounts,
+      chain: chain.length > 0 ? chain : null,
       scheduled_at: data.post_at,
       created_at: data.created_at,
       updated_at: data.updated_at,

--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -512,7 +512,7 @@ export class SocialPostsService {
           .select('id, sequence');
 
       if (insertChainItemsError) {
-        console.error(insertChainItemsError);
+        throw new Error(insertChainItemsError.message);
       } else if (insertedChainItems) {
         const chainItemMedia = post.chain.flatMap((item, index) => {
           const chainItem = insertedChainItems.find(
@@ -540,7 +540,7 @@ export class SocialPostsService {
               .insert(chainItemMedia);
 
           if (insertChainItemMediaError) {
-            console.error(insertChainItemMediaError);
+            throw new Error(insertChainItemMediaError.message);
           }
         }
       }
@@ -967,6 +967,7 @@ export class SocialPostsService {
       provider_data: Json;
     }>;
     social_post_chain_items?: Array<{
+      id: string;
       sequence: number;
       caption: string;
       social_post_chain_item_media: Array<{
@@ -1066,6 +1067,8 @@ export class SocialPostsService {
     const chain = [...(data.social_post_chain_items ?? [])]
       .sort((a, b) => a.sequence - b.sequence)
       .map((item) => ({
+        id: item.id,
+        sequence: item.sequence,
         caption: item.caption,
         media: item.social_post_chain_item_media.map((media) => ({
           url: media.url,

--- a/api/supabase/migrations/20260804120000_social_post_chains.sql
+++ b/api/supabase/migrations/20260804120000_social_post_chains.sql
@@ -1,0 +1,110 @@
+--
+-- Social Post Chain Items
+-- Ordered follow-up items in a reply chain (thread), hanging off a single social_posts row.
+-- The root post's content stays in social_posts/social_post_media/social_post_configurations;
+-- this table holds only items 1..N of the chain (the replies). A post "is a chain" iff it has
+-- rows here.
+CREATE TABLE public.social_post_chain_items(
+    id text PRIMARY KEY DEFAULT nanoid('spci'),
+    post_id text NOT NULL REFERENCES social_posts(id) ON DELETE CASCADE,
+    sequence smallint NOT NULL CHECK (sequence >= 1),
+    caption text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (post_id, sequence)
+);
+
+--
+-- Indexes
+CREATE INDEX social_post_chain_items_post_id_idx ON public.social_post_chain_items(post_id);
+
+--
+-- RLS
+ALTER TABLE public.social_post_chain_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own social post chain items" ON public.social_post_chain_items
+    FOR SELECT
+        USING (user_has_post_access(post_id));
+
+CREATE POLICY "Users can insert their own social post chain items" ON public.social_post_chain_items
+    FOR INSERT
+        WITH CHECK (user_has_post_access(post_id));
+
+CREATE POLICY "Users can update their own social post chain items" ON public.social_post_chain_items
+    FOR UPDATE
+        USING (user_has_post_access(post_id))
+        WITH CHECK (user_has_post_access(post_id));
+
+CREATE POLICY "Users can delete their own social post chain items" ON public.social_post_chain_items
+    FOR DELETE
+        USING (user_has_post_access(post_id));
+
+--
+-- Social Post Chain Item Media
+CREATE TABLE public.social_post_chain_item_media(
+    id text PRIMARY KEY DEFAULT nanoid('spcim'),
+    chain_item_id text NOT NULL REFERENCES social_post_chain_items(id) ON DELETE CASCADE,
+    url text NOT NULL,
+    thumbnail_url text NULL,
+    thumbnail_timestamp_ms int NULL,
+    tags jsonb NULL,
+    skip_processing boolean NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+--
+-- Indexes
+CREATE INDEX social_post_chain_item_media_chain_item_id_idx ON public.social_post_chain_item_media(chain_item_id);
+
+--
+-- Function to check if current user has access to a chain item
+CREATE OR REPLACE FUNCTION user_has_chain_item_access(chain_item_id text)
+    RETURNS boolean
+    LANGUAGE sql
+    SECURITY DEFINER STABLE
+    AS $$
+    SELECT
+        EXISTS(
+            SELECT
+                1
+            FROM
+                social_post_chain_items sci
+                JOIN social_posts sp ON sp.id = sci.post_id
+                JOIN projects p ON p.id = sp.project_id
+                JOIN team_users tm ON p.team_id = tm.team_id
+            WHERE
+                sci.id = chain_item_id
+                AND tm.user_id = auth.uid());
+$$;
+
+--
+-- RLS
+ALTER TABLE public.social_post_chain_item_media ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own social post chain item media" ON public.social_post_chain_item_media
+    FOR SELECT
+        USING (user_has_chain_item_access(chain_item_id));
+
+CREATE POLICY "Users can insert their own social post chain item media" ON public.social_post_chain_item_media
+    FOR INSERT
+        WITH CHECK (user_has_chain_item_access(chain_item_id));
+
+CREATE POLICY "Users can update their own social post chain item media" ON public.social_post_chain_item_media
+    FOR UPDATE
+        USING (user_has_chain_item_access(chain_item_id))
+        WITH CHECK (user_has_chain_item_access(chain_item_id));
+
+CREATE POLICY "Users can delete their own social post chain item media" ON public.social_post_chain_item_media
+    FOR DELETE
+        USING (user_has_chain_item_access(chain_item_id));
+
+--
+-- Link social post results to the chain item they belong to. NULL means the result is for the
+-- root post; existing rows are unaffected since the column defaults to NULL.
+ALTER TABLE public.social_post_results
+    ADD COLUMN chain_item_id text NULL REFERENCES social_post_chain_items(id) ON DELETE CASCADE;
+
+CREATE INDEX social_post_results_chain_item_id_idx ON public.social_post_results(chain_item_id)
+WHERE
+    chain_item_id IS NOT NULL;

--- a/api/supabase/migrations/20260805000000_social_post_result_chain_item_media.sql
+++ b/api/supabase/migrations/20260805000000_social_post_result_chain_item_media.sql
@@ -1,0 +1,29 @@
+CREATE TABLE public.social_post_result_chain_item_media(
+    id text PRIMARY KEY DEFAULT nanoid('sprcim'),
+    social_post_result_id text NOT NULL REFERENCES social_post_results(id),
+    social_post_chain_item_media_id text NOT NULL REFERENCES social_post_chain_item_media(id)
+);
+
+CREATE INDEX social_post_result_chain_item_media_result_id_idx ON public.social_post_result_chain_item_media(social_post_result_id);
+
+CREATE INDEX social_post_result_chain_item_media_media_id_idx ON public.social_post_result_chain_item_media(social_post_chain_item_media_id);
+
+
+ALTER TABLE public.social_post_result_chain_item_media ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own social post result chain item media" ON public.social_post_result_chain_item_media
+    FOR SELECT
+        USING (user_has_post_result_access(social_post_result_id));
+
+CREATE POLICY "Users can insert their own social post result chain item media" ON public.social_post_result_chain_item_media
+    FOR INSERT
+        WITH CHECK (user_has_post_result_access(social_post_result_id));
+
+CREATE POLICY "Users can update their own social post result chain item media" ON public.social_post_result_chain_item_media
+    FOR UPDATE
+        USING (user_has_post_result_access(social_post_result_id))
+        WITH CHECK (user_has_post_result_access(social_post_result_id));
+
+CREATE POLICY "Users can delete their own social post result chain item media" ON public.social_post_result_chain_item_media
+    FOR DELETE
+        USING (user_has_post_result_access(social_post_result_id));

--- a/api/supabase/supabase.types.ts
+++ b/api/supabase/supabase.types.ts
@@ -338,6 +338,85 @@ export type Database = {
           },
         ]
       }
+      social_post_chain_item_media: {
+        Row: {
+          chain_item_id: string
+          created_at: string
+          id: string
+          skip_processing: boolean | null
+          tags: Json | null
+          thumbnail_timestamp_ms: number | null
+          thumbnail_url: string | null
+          updated_at: string
+          url: string
+        }
+        Insert: {
+          chain_item_id: string
+          created_at?: string
+          id?: string
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url: string
+        }
+        Update: {
+          chain_item_id?: string
+          created_at?: string
+          id?: string
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_post_chain_item_media_chain_item_id_fkey"
+            columns: ["chain_item_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_chain_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      social_post_chain_items: {
+        Row: {
+          caption: string
+          created_at: string
+          id: string
+          post_id: string
+          sequence: number
+          updated_at: string
+        }
+        Insert: {
+          caption: string
+          created_at?: string
+          id?: string
+          post_id: string
+          sequence: number
+          updated_at?: string
+        }
+        Update: {
+          caption?: string
+          created_at?: string
+          id?: string
+          post_id?: string
+          sequence?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_post_chain_items_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       social_post_configurations: {
         Row: {
           caption: string | null
@@ -517,6 +596,7 @@ export type Database = {
       }
       social_post_results: {
         Row: {
+          chain_item_id: string | null
           created_at: string
           details: Json | null
           error_message: string | null
@@ -529,6 +609,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          chain_item_id?: string | null
           created_at?: string
           details?: Json | null
           error_message?: string | null
@@ -541,6 +622,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          chain_item_id?: string | null
           created_at?: string
           details?: Json | null
           error_message?: string | null
@@ -553,6 +635,13 @@ export type Database = {
           updated_at?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "social_post_results_chain_item_id_fkey"
+            columns: ["chain_item_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_chain_items"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "social_post_results_post_id_fkey"
             columns: ["post_id"]
@@ -1279,6 +1368,10 @@ export type Database = {
       nanoid: {
         Args: { alphabet?: string; prefix: string; size?: number }
         Returns: string
+      }
+      user_has_chain_item_access: {
+        Args: { chain_item_id: string }
+        Returns: boolean
       }
       user_has_post_access: { Args: { post_id: string }; Returns: boolean }
       user_has_post_result_access: {

--- a/api/supabase/supabase.types.ts
+++ b/api/supabase/supabase.types.ts
@@ -561,6 +561,39 @@ export type Database = {
           },
         ]
       }
+      social_post_result_chain_item_media: {
+        Row: {
+          id: string
+          social_post_chain_item_media_id: string
+          social_post_result_id: string
+        }
+        Insert: {
+          id?: string
+          social_post_chain_item_media_id: string
+          social_post_result_id: string
+        }
+        Update: {
+          id?: string
+          social_post_chain_item_media_id?: string
+          social_post_result_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_post_result_chain_item_media_social_post_result_id_fkey"
+            columns: ["social_post_result_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_results"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "social_post_result_chain_item_social_post_chain_item_media_fkey"
+            columns: ["social_post_chain_item_media_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_chain_item_media"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       social_post_result_post_media: {
         Row: {
           id: string

--- a/trigger/post-to-platform.ts
+++ b/trigger/post-to-platform.ts
@@ -308,23 +308,40 @@ export const postToPlatform = task({
         },
       });
 
-      // Chain item media is localized from social_post_chain_item_media, not
-      // social_post_media, so it can't be linked via this join table (its FK
-      // only references social_post_media).
-      if (!chainItemId && media.length > 0) {
-        const { error: postResultMediaError } = await supabaseClient
-          .from("social_post_result_post_media")
-          .insert(
-            media.map((m) => ({
-              social_post_result_id: insertedPostResult.id,
-              social_post_media_id: m.id,
-            })),
-          );
+      // Root-post media lives in social_post_media, chain-item media lives in
+      // social_post_chain_item_media — each links to the result through its
+      // own join table since the FKs point at different source tables.
+      if (media.length > 0) {
+        if (chainItemId) {
+          const { error: postResultChainItemMediaError } = await supabaseClient
+            .from("social_post_result_chain_item_media")
+            .insert(
+              media.map((m) => ({
+                social_post_result_id: insertedPostResult.id,
+                social_post_chain_item_media_id: m.id,
+              })),
+            );
 
-        if (postResultMediaError) {
-          logger.error("Failed to insert post result media", {
-            postResultMediaError,
-          });
+          if (postResultChainItemMediaError) {
+            logger.error("Failed to insert post result chain item media", {
+              postResultChainItemMediaError,
+            });
+          }
+        } else {
+          const { error: postResultMediaError } = await supabaseClient
+            .from("social_post_result_post_media")
+            .insert(
+              media.map((m) => ({
+                social_post_result_id: insertedPostResult.id,
+                social_post_media_id: m.id,
+              })),
+            );
+
+          if (postResultMediaError) {
+            logger.error("Failed to insert post result media", {
+              postResultMediaError,
+            });
+          }
         }
       }
     }

--- a/trigger/post-to-platform.ts
+++ b/trigger/post-to-platform.ts
@@ -154,6 +154,7 @@ export const postToPlatform = task({
       teamId,
       appCredentials,
       projectId,
+      chainItemId,
     } = payload;
     let postResult: PostResult | null = null;
     try {
@@ -246,6 +247,8 @@ export const postToPlatform = task({
       }
     }
 
+    postResult.chain_item_id = chainItemId ?? null;
+
     await tags.add(`result_${postResult.success ? "success" : "error"}`);
 
     logger.info("Saving Post Result", { postResult });
@@ -299,24 +302,30 @@ export const postToPlatform = task({
             url: insertedPostResult.provider_post_url,
           },
           post_id: insertedPostResult.post_id,
+          chain_item_id: insertedPostResult.chain_item_id,
           social_account_id: insertedPostResult.provider_connection_id,
           success: insertedPostResult.success,
         },
       });
 
-      const { error: postResultMediaError } = await supabaseClient
-        .from("social_post_result_post_media")
-        .insert(
-          media.map((m) => ({
-            social_post_result_id: insertedPostResult.id,
-            social_post_media_id: m.id,
-          })),
-        );
+      // Chain item media is localized from social_post_chain_item_media, not
+      // social_post_media, so it can't be linked via this join table (its FK
+      // only references social_post_media).
+      if (!chainItemId && media.length > 0) {
+        const { error: postResultMediaError } = await supabaseClient
+          .from("social_post_result_post_media")
+          .insert(
+            media.map((m) => ({
+              social_post_result_id: insertedPostResult.id,
+              social_post_media_id: m.id,
+            })),
+          );
 
-      if (postResultMediaError) {
-        logger.error("Failed to insert post result media", {
-          postResultMediaError,
-        });
+        if (postResultMediaError) {
+          logger.error("Failed to insert post result media", {
+            postResultMediaError,
+          });
+        }
       }
     }
 

--- a/trigger/posting/chain-select.ts
+++ b/trigger/posting/chain-select.ts
@@ -1,0 +1,14 @@
+export const CHAIN_SELECT = `
+        social_post_chain_items (
+          id,
+          sequence,
+          caption,
+          social_post_chain_item_media (
+            id,
+            url,
+            thumbnail_url,
+            thumbnail_timestamp_ms,
+            tags,
+            skip_processing
+          )
+        )`;

--- a/trigger/posting/platforms/bluesky-post-client.ts
+++ b/trigger/posting/platforms/bluesky-post-client.ts
@@ -5,6 +5,7 @@ import { JSDOM } from "jsdom";
 import fetch from "node-fetch";
 import { SupabaseClient } from "@supabase/supabase-js";
 import {
+  BlueskyConfiguration,
   PlatformAppCredentials,
   PostMedia,
   PostResult,
@@ -81,11 +82,13 @@ export class BlueskyPostClient extends PostClient {
     account,
     caption,
     media,
+    platformConfig,
   }: {
     postId: string;
     account: SocialAccount;
     caption: string;
     media: PostMedia[];
+    platformConfig?: BlueskyConfiguration;
   }): Promise<PostResult> {
     try {
       const trimmedCaption = caption.slice(0, this.#charLimit);
@@ -151,6 +154,10 @@ export class BlueskyPostClient extends PostClient {
       const postPayload: {
         text: string;
         facets: Main[] | undefined;
+        reply?: {
+          root: { uri: string; cid: string };
+          parent: { uri: string; cid: string };
+        };
         embed?:
           | {
               $type: string;
@@ -189,6 +196,10 @@ export class BlueskyPostClient extends PostClient {
         postPayload.embed = embed;
       }
 
+      if (platformConfig?.reply) {
+        postPayload.reply = platformConfig.reply;
+      }
+
       this.#requests.push({ postRequest: postPayload });
 
       const response = await this.#agent.post(postPayload);
@@ -204,6 +215,7 @@ export class BlueskyPostClient extends PostClient {
         }/post/${response.uri.split("/").pop()}`,
         details: {
           trimmed: caption.length > trimmedCaption.length,
+          cid: response.cid,
           requests: this.#requests,
           responses: this.#responses,
         },

--- a/trigger/posting/platforms/threads-post-client.ts
+++ b/trigger/posting/platforms/threads-post-client.ts
@@ -85,7 +85,11 @@ export class ThreadsPostClient extends PostClient {
 
       switch (true) {
         case media.length == 0: {
-          containerId = await this.#processText(account, allowedCaption);
+          containerId = await this.#processText(
+            account,
+            allowedCaption,
+            platformConfig?.reply_to_id,
+          );
           break;
         }
         case media.length == 1: {
@@ -94,6 +98,7 @@ export class ThreadsPostClient extends PostClient {
             media,
             platformConfig?.location,
             allowedCaption,
+            platformConfig?.reply_to_id,
           );
           break;
         }
@@ -102,6 +107,7 @@ export class ThreadsPostClient extends PostClient {
             account,
             media,
             allowedCaption,
+            platformConfig?.reply_to_id,
           );
           break;
         }
@@ -211,30 +217,30 @@ export class ThreadsPostClient extends PostClient {
   async #processText(
     account: SocialAccount,
     caption: string,
+    replyToId?: string,
   ): Promise<string | null> {
+    const body: Record<string, unknown> = {
+      media_type: "TEXT",
+      text: caption,
+    };
+
+    if (replyToId) {
+      body.reply_to_id = replyToId;
+    }
+
     this.#requests.push({
       createContainerRequest: {
         url: this.#containerUrl,
-        params: {
-          media_type: "TEXT",
-          text: caption,
-        },
+        params: body,
       },
     });
 
     const createContainerResponse: AxiosResponse<{ id: string }> =
-      await axios.post(
-        this.#containerUrl,
-        {
-          media_type: "TEXT",
-          text: caption,
+      await axios.post(this.#containerUrl, body, {
+        headers: {
+          Authorization: `Bearer ${account.access_token}`,
         },
-        {
-          headers: {
-            Authorization: `Bearer ${account.access_token}`,
-          },
-        },
-      );
+      });
 
     this.#responses.push({
       createContainerResponse: createContainerResponse.data,
@@ -253,46 +259,36 @@ export class ThreadsPostClient extends PostClient {
     media: PostMedia[],
     location?: string,
     caption?: string,
+    replyToId?: string,
   ): Promise<string | null> {
     const medium = media[0];
     const signedUrl = await this.getSignedUrlForFile(medium);
     const isVideo = medium.type === "video";
 
+    const body: Record<string, unknown> = {
+      media_type:
+        isVideo && location == "reels" ? "REELS" : isVideo ? "VIDEO" : "IMAGE",
+      [isVideo ? "video_url" : "image_url"]: signedUrl,
+      text: caption,
+    };
+
+    if (replyToId) {
+      body.reply_to_id = replyToId;
+    }
+
     this.#requests.push({
       createContainerRequest: {
         url: this.#containerUrl,
-        params: {
-          media_type:
-            isVideo && location == "reels"
-              ? "REELS"
-              : isVideo
-                ? "VIDEO"
-                : "IMAGE",
-          [isVideo ? "video_url" : "image_url"]: signedUrl,
-          text: caption,
-        },
+        params: body,
       },
     });
 
     const createContainerResponse: AxiosResponse<{ id: string }> =
-      await axios.post(
-        this.#containerUrl,
-        {
-          media_type:
-            isVideo && location == "reels"
-              ? "REELS"
-              : isVideo
-                ? "VIDEO"
-                : "IMAGE",
-          [isVideo ? "video_url" : "image_url"]: signedUrl,
-          text: caption,
+      await axios.post(this.#containerUrl, body, {
+        headers: {
+          Authorization: `Bearer ${account.access_token}`,
         },
-        {
-          headers: {
-            Authorization: `Bearer ${account.access_token}`,
-          },
-        },
-      );
+      });
 
     this.#responses.push({
       createContainerResponse: createContainerResponse.data,
@@ -368,6 +364,7 @@ export class ThreadsPostClient extends PostClient {
     account: SocialAccount,
     media: PostMedia[],
     caption: string,
+    replyToId?: string,
   ): Promise<string | null> {
     const containerIds: string[] = [];
     const allowedMedia = media.slice(0, this.#maxItems);
@@ -413,25 +410,27 @@ export class ThreadsPostClient extends PostClient {
       await wait.for({ seconds: 2 });
     }
 
+    const carouselBody: Record<string, unknown> = {
+      media_type: "CAROUSEL",
+      children: containerIds.join(","),
+      text: caption,
+    };
+
+    if (replyToId) {
+      carouselBody.reply_to_id = replyToId;
+    }
+
     this.#requests.push({
       createCarouselRequest: {
         url: this.#containerUrl,
-        params: {
-          media_type: "CAROUSEL",
-          children: containerIds.join(","),
-          text: caption,
-        },
+        params: carouselBody,
       },
     });
 
     // Step 2: Create carousel container
     const carouselResponse: AxiosResponse<{ id: string }> = await axios.post(
       this.#containerUrl,
-      {
-        media_type: "CAROUSEL",
-        children: containerIds.join(","),
-        text: caption,
-      },
+      carouselBody,
       {
         headers: {
           Authorization: `Bearer ${account.access_token}`,

--- a/trigger/posting/platforms/twitter-post-client.ts
+++ b/trigger/posting/platforms/twitter-post-client.ts
@@ -142,6 +142,12 @@ export class TwitterPostClient extends PostClient {
         postPayload.quote_tweet_id = platformConfig.quote_tweet_id;
       }
 
+      if (platformConfig?.in_reply_to_tweet_id) {
+        postPayload.reply = {
+          in_reply_to_tweet_id: platformConfig.in_reply_to_tweet_id,
+        };
+      }
+
       this.#requests.push({
         postRequest: postPayload,
       });

--- a/trigger/posting/post.types.ts
+++ b/trigger/posting/post.types.ts
@@ -3,6 +3,7 @@ export interface PostResult {
   success: boolean;
   error_message?: string;
   post_id: string;
+  chain_item_id?: string | null;
   provider_post_url?: string;
   provider_post_id?: string;
   details?: any;
@@ -67,6 +68,19 @@ export interface Post {
     provider: Provider | null;
     provider_connection_id: string | null;
     provider_data: PlatformConfiguration;
+  }[];
+  social_post_chain_items?: {
+    id: string;
+    sequence: number;
+    caption: string;
+    social_post_chain_item_media: {
+      id: string;
+      url: string;
+      thumbnail_url: string | null;
+      thumbnail_timestamp_ms: number | null;
+      tags: UserTag[] | null;
+      skip_processing: boolean | null;
+    }[];
   }[];
 }
 
@@ -154,6 +168,8 @@ export interface TwitterConfiguration {
   community_id?: string;
   quote_tweet_id?: string;
   reply_settings?: string;
+  /** Internal-only: injected by process-post.ts when posting a chain item, never set by API callers. */
+  in_reply_to_tweet_id?: string;
 }
 
 export interface YoutubeLocalization {
@@ -198,15 +214,27 @@ export interface LinkedinConfiguration {
   reshare_post_id?: string;
 }
 
+export interface BlueskyReplyRef {
+  uri: string;
+  cid: string;
+}
+
 export interface BlueskyConfiguration {
   caption?: string;
   media?: PostMedia[];
+  /** Internal-only: injected by process-post.ts when posting a chain item, never set by API callers. */
+  reply?: {
+    root: BlueskyReplyRef;
+    parent: BlueskyReplyRef;
+  };
 }
 
 export interface ThreadsConfiguration {
   caption?: string;
   location?: "reels" | "timeline";
   media?: PostMedia[];
+  /** Internal-only: injected by process-post.ts when posting a chain item, never set by API callers. */
+  reply_to_id?: string;
 }
 
 export interface TempMedia {
@@ -241,4 +269,5 @@ export interface IndividualPostData {
   projectId: string;
   platformConfig: PlatformConfiguration;
   appCredentials: PlatformAppCredentials;
+  chainItemId?: string | null;
 }

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -58,6 +58,17 @@ const transformPostData = (data: {
     provider_connection_id: string | null;
     provider_data: any;
   }[];
+  social_post_chain_items?: {
+    sequence: number;
+    caption: string;
+    social_post_chain_item_media: {
+      url: string;
+      thumbnail_url: string | null;
+      thumbnail_timestamp_ms: number | null;
+      tags: Json;
+      skip_processing: boolean | null;
+    }[];
+  }[];
 }) => {
   const postMedia = data.social_post_media
     .filter((media) => !media.provider && !media.provider_connection_id)
@@ -128,6 +139,19 @@ const transformPostData = (data: {
     }),
   );
 
+  const chain = [...(data.social_post_chain_items ?? [])]
+    .sort((a, b) => a.sequence - b.sequence)
+    .map((item) => ({
+      caption: item.caption,
+      media: item.social_post_chain_item_media.map((media) => ({
+        url: media.url,
+        thumbnail_url: media.thumbnail_url,
+        thumbnail_timestamp_ms: media.thumbnail_timestamp_ms,
+        tags: media.tags as any[],
+        skip_processing: media.skip_processing,
+      })),
+    }));
+
   return {
     id: data.id,
     external_id: data.external_id,
@@ -137,6 +161,7 @@ const transformPostData = (data: {
     platform_configurations: platformConfigurations,
     account_configurations: accountConfigurations,
     social_accounts: socialAccounts,
+    chain: chain.length > 0 ? chain : null,
     scheduled_at: data.post_at,
     created_at: data.created_at,
     updated_at: data.updated_at,
@@ -624,6 +649,35 @@ export const processPost = task({
           chainLength: chainItems.length,
         });
 
+        // Localize every chain item's media once up front (it doesn't vary
+        // by account, unlike root-post media), instead of re-localizing it
+        // once per chain-capable account.
+        const localizedChainMedia = await localizeMedia(
+          chainItems.flatMap((item) => item.social_post_chain_item_media),
+        );
+        const localizedChainMediaById = new Map(
+          localizedChainMedia.map((medium) => [medium.id, medium]),
+        );
+        const itemMediaById = new Map(
+          chainItems.map((item) => [
+            item.id,
+            item.social_post_chain_item_media
+              .map((medium) => localizedChainMediaById.get(medium.id))
+              .filter(
+                (medium): medium is LocalizedMedia => medium !== undefined,
+              ),
+          ]),
+        );
+        const failedMediaItemIds = new Set(
+          chainItems
+            .filter(
+              (item) =>
+                item.social_post_chain_item_media.length > 0 &&
+                (itemMediaById.get(item.id)?.length ?? 0) === 0,
+            )
+            .map((item) => item.id),
+        );
+
         for (const { account, appCredentials } of chainAccounts) {
           const rootResult = rootResultsByAccountId.get(account.id);
 
@@ -660,57 +714,114 @@ export const processPost = task({
               continue;
             }
 
-            const itemMedia = await localizeMedia(
-              item.social_post_chain_item_media,
-            );
-
-            const platformConfig = buildReplyPlatformConfig(
-              account.provider,
-              previousResult,
-              rootRef,
-            );
-
-            logger.info("Posting Chain Item", {
-              provider: account.provider,
-              provider_connection_id: account.id,
-              sequence: item.sequence,
-            });
-
-            const result = await tasks.triggerAndWait("post-to-platform", {
-              stripeCustomerId: postData.stripe_customer_id,
-              teamId: project.team_id,
-              platform: account.provider,
-              postId: postData.id,
-              account,
-              media: itemMedia,
-              caption: item.caption,
-              platformConfig,
-              appCredentials,
-              projectId: post.project_id,
-              chainItemId: item.id,
-            });
-
-            logger.info("Posting Chain Item Complete", {
-              provider: account.provider,
-              provider_connection_id: account.id,
-              sequence: item.sequence,
-              success: result.ok && result.output.success,
-            });
-
-            if (result.ok && result.output.success) {
-              previousResult = result.output;
-            } else {
-              chainBroken = true;
-              if (!result.ok) {
+            try {
+              if (failedMediaItemIds.has(item.id)) {
+                logger.error("All Chain Item Media Failed", {
+                  provider_connection_id: account.id,
+                  chain_item_id: item.id,
+                });
                 errorResults.push({
                   success: false,
                   provider_connection_id: account.id,
                   post_id: postData.id,
                   chain_item_id: item.id,
-                  error_message:
-                    "post-to-platform run failed unexpectedly for chain item",
+                  error_message: `All media failed to process for chain item, please check media URLS`,
                 });
+                chainBroken = true;
+                continue;
               }
+
+              // Re-fetch the account on every chain item: an earlier item
+              // (or the root post) may have refreshed and persisted a new
+              // access/refresh token, and platforms like X rotate the OAuth2
+              // refresh_token on every use, so a stale in-memory `account`
+              // would fail to refresh again.
+              const { data: freshAccountRow, error: freshAccountError } =
+                await supabaseClient
+                  .from("social_provider_connections")
+                  .select("*")
+                  .eq("id", account.id)
+                  .single();
+
+              if (freshAccountError || !freshAccountRow) {
+                logger.warn(
+                  "Failed to refresh account before chain item, reusing last known token",
+                  {
+                    provider_connection_id: account.id,
+                    error: freshAccountError,
+                  },
+                );
+              }
+
+              const currentAccount: SocialAccount = freshAccountRow
+                ? (freshAccountRow as unknown as SocialAccount)
+                : account;
+
+              const itemMedia = itemMediaById.get(item.id) ?? [];
+
+              const platformConfig = buildReplyPlatformConfig(
+                account.provider,
+                previousResult,
+                rootRef,
+              );
+
+              logger.info("Posting Chain Item", {
+                provider: account.provider,
+                provider_connection_id: account.id,
+                sequence: item.sequence,
+              });
+
+              const result = await tasks.triggerAndWait("post-to-platform", {
+                stripeCustomerId: postData.stripe_customer_id,
+                teamId: project.team_id,
+                platform: account.provider,
+                postId: postData.id,
+                account: currentAccount,
+                media: itemMedia,
+                caption: item.caption,
+                platformConfig,
+                appCredentials,
+                projectId: post.project_id,
+                chainItemId: item.id,
+              });
+
+              logger.info("Posting Chain Item Complete", {
+                provider: account.provider,
+                provider_connection_id: account.id,
+                sequence: item.sequence,
+                success: result.ok && result.output.success,
+              });
+
+              if (result.ok && result.output.success) {
+                previousResult = result.output;
+              } else {
+                chainBroken = true;
+                if (!result.ok) {
+                  errorResults.push({
+                    success: false,
+                    provider_connection_id: account.id,
+                    post_id: postData.id,
+                    chain_item_id: item.id,
+                    error_message:
+                      "post-to-platform run failed unexpectedly for chain item",
+                  });
+                }
+              }
+            } catch (error: any) {
+              logger.error("Failed Posting Chain Item", {
+                account,
+                item,
+                error,
+              });
+              errorResults.push({
+                success: false,
+                provider_connection_id: account.id,
+                post_id: postData.id,
+                chain_item_id: item.id,
+                error_message: error?.message || "Unknown error",
+                details: { error },
+              });
+              chainBroken = true;
             }
           }
         }
@@ -780,6 +891,19 @@ export const processPost = task({
          provider,
          provider_connection_id,
          provider_data
+        ),
+        social_post_chain_items (
+          id,
+          sequence,
+          caption,
+          social_post_chain_item_media (
+            id,
+            url,
+            thumbnail_url,
+            thumbnail_timestamp_ms,
+            tags,
+            skip_processing
+          )
         )
         `,
         )

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -11,6 +11,7 @@ import type {
   SocialAccount,
   UserTag,
 } from "./posting/post.types";
+import { CHAIN_SELECT } from "./posting/chain-select";
 import { Unkey } from "@unkey/api";
 
 const CHAIN_CAPABLE_PROVIDERS: Provider[] = ["x", "threads", "bluesky"];
@@ -644,7 +645,7 @@ export const processPost = task({
       }
 
       if (chainAccounts.length > 0) {
-        logger.info("Posting Chain Items Sequentially", {
+        logger.info("Posting Chain Items Per Account In Parallel", {
           totalChainAccounts: chainAccounts.length,
           chainLength: chainItems.length,
         });
@@ -678,153 +679,155 @@ export const processPost = task({
             .map((item) => item.id),
         );
 
-        for (const { account, appCredentials } of chainAccounts) {
-          const rootResult = rootResultsByAccountId.get(account.id);
+        await Promise.allSettled(
+          chainAccounts.map(async ({ account, appCredentials }) => {
+            const rootResult = rootResultsByAccountId.get(account.id);
 
-          if (!rootResult?.success) {
-            logger.warn("Skipping chain: root post did not succeed", {
-              provider: account.provider,
-              provider_connection_id: account.id,
-            });
-            errorResults.push(
-              ...chainItems.map((item) => ({
-                success: false,
+            if (!rootResult?.success) {
+              logger.warn("Skipping chain: root post did not succeed", {
+                provider: account.provider,
                 provider_connection_id: account.id,
-                post_id: postData.id,
-                chain_item_id: item.id,
-                error_message: `Skipped chain item: root post did not succeed for ${account.provider}`,
-              })),
-            );
-            continue;
-          }
-
-          let previousResult: PostResult = rootResult;
-          const rootRef: PostResult = rootResult;
-          let chainBroken = false;
-
-          for (const item of chainItems) {
-            if (chainBroken) {
-              errorResults.push({
-                success: false,
-                provider_connection_id: account.id,
-                post_id: postData.id,
-                chain_item_id: item.id,
-                error_message: `Skipped chain item: an earlier item in the chain failed for ${account.provider}`,
               });
-              continue;
+              errorResults.push(
+                ...chainItems.map((item) => ({
+                  success: false,
+                  provider_connection_id: account.id,
+                  post_id: postData.id,
+                  chain_item_id: item.id,
+                  error_message: `Skipped chain item: root post did not succeed for ${account.provider}`,
+                })),
+              );
+              return;
             }
 
-            try {
-              if (failedMediaItemIds.has(item.id)) {
-                logger.error("All Chain Item Media Failed", {
+            let previousResult: PostResult = rootResult;
+            const rootRef: PostResult = rootResult;
+            let chainBroken = false;
+
+            for (const item of chainItems) {
+              if (chainBroken) {
+                errorResults.push({
+                  success: false,
                   provider_connection_id: account.id,
+                  post_id: postData.id,
                   chain_item_id: item.id,
+                  error_message: `Skipped chain item: an earlier item in the chain failed for ${account.provider}`,
+                });
+                continue;
+              }
+
+              try {
+                if (failedMediaItemIds.has(item.id)) {
+                  logger.error("All Chain Item Media Failed", {
+                    provider_connection_id: account.id,
+                    chain_item_id: item.id,
+                  });
+                  errorResults.push({
+                    success: false,
+                    provider_connection_id: account.id,
+                    post_id: postData.id,
+                    chain_item_id: item.id,
+                    error_message: `All media failed to process for chain item, please check media URLS`,
+                  });
+                  chainBroken = true;
+                  continue;
+                }
+
+                // Re-fetch the account on every chain item: an earlier item
+                // (or the root post) may have refreshed and persisted a new
+                // access/refresh token, and platforms like X rotate the OAuth2
+                // refresh_token on every use, so a stale in-memory `account`
+                // would fail to refresh again.
+                const { data: freshAccountRow, error: freshAccountError } =
+                  await supabaseClient
+                    .from("social_provider_connections")
+                    .select("*")
+                    .eq("id", account.id)
+                    .single();
+
+                if (freshAccountError || !freshAccountRow) {
+                  logger.warn(
+                    "Failed to refresh account before chain item, reusing last known token",
+                    {
+                      provider_connection_id: account.id,
+                      error: freshAccountError,
+                    },
+                  );
+                }
+
+                const currentAccount: SocialAccount = freshAccountRow
+                  ? (freshAccountRow as unknown as SocialAccount)
+                  : account;
+
+                const itemMedia = itemMediaById.get(item.id) ?? [];
+
+                const platformConfig = buildReplyPlatformConfig(
+                  account.provider,
+                  previousResult,
+                  rootRef,
+                );
+
+                logger.info("Posting Chain Item", {
+                  provider: account.provider,
+                  provider_connection_id: account.id,
+                  sequence: item.sequence,
+                });
+
+                const result = await tasks.triggerAndWait("post-to-platform", {
+                  stripeCustomerId: postData.stripe_customer_id,
+                  teamId: project.team_id,
+                  platform: account.provider,
+                  postId: postData.id,
+                  account: currentAccount,
+                  media: itemMedia,
+                  caption: item.caption,
+                  platformConfig,
+                  appCredentials,
+                  projectId: post.project_id,
+                  chainItemId: item.id,
+                });
+
+                logger.info("Posting Chain Item Complete", {
+                  provider: account.provider,
+                  provider_connection_id: account.id,
+                  sequence: item.sequence,
+                  success: result.ok && result.output.success,
+                });
+
+                if (result.ok && result.output.success) {
+                  previousResult = result.output;
+                } else {
+                  chainBroken = true;
+                  if (!result.ok) {
+                    errorResults.push({
+                      success: false,
+                      provider_connection_id: account.id,
+                      post_id: postData.id,
+                      chain_item_id: item.id,
+                      error_message:
+                        "post-to-platform run failed unexpectedly for chain item",
+                    });
+                  }
+                }
+              } catch (error: any) {
+                logger.error("Failed Posting Chain Item", {
+                  account,
+                  item,
+                  error,
                 });
                 errorResults.push({
                   success: false,
                   provider_connection_id: account.id,
                   post_id: postData.id,
                   chain_item_id: item.id,
-                  error_message: `All media failed to process for chain item, please check media URLS`,
+                  error_message: error?.message || "Unknown error",
+                  details: { error },
                 });
                 chainBroken = true;
-                continue;
               }
-
-              // Re-fetch the account on every chain item: an earlier item
-              // (or the root post) may have refreshed and persisted a new
-              // access/refresh token, and platforms like X rotate the OAuth2
-              // refresh_token on every use, so a stale in-memory `account`
-              // would fail to refresh again.
-              const { data: freshAccountRow, error: freshAccountError } =
-                await supabaseClient
-                  .from("social_provider_connections")
-                  .select("*")
-                  .eq("id", account.id)
-                  .single();
-
-              if (freshAccountError || !freshAccountRow) {
-                logger.warn(
-                  "Failed to refresh account before chain item, reusing last known token",
-                  {
-                    provider_connection_id: account.id,
-                    error: freshAccountError,
-                  },
-                );
-              }
-
-              const currentAccount: SocialAccount = freshAccountRow
-                ? (freshAccountRow as unknown as SocialAccount)
-                : account;
-
-              const itemMedia = itemMediaById.get(item.id) ?? [];
-
-              const platformConfig = buildReplyPlatformConfig(
-                account.provider,
-                previousResult,
-                rootRef,
-              );
-
-              logger.info("Posting Chain Item", {
-                provider: account.provider,
-                provider_connection_id: account.id,
-                sequence: item.sequence,
-              });
-
-              const result = await tasks.triggerAndWait("post-to-platform", {
-                stripeCustomerId: postData.stripe_customer_id,
-                teamId: project.team_id,
-                platform: account.provider,
-                postId: postData.id,
-                account: currentAccount,
-                media: itemMedia,
-                caption: item.caption,
-                platformConfig,
-                appCredentials,
-                projectId: post.project_id,
-                chainItemId: item.id,
-              });
-
-              logger.info("Posting Chain Item Complete", {
-                provider: account.provider,
-                provider_connection_id: account.id,
-                sequence: item.sequence,
-                success: result.ok && result.output.success,
-              });
-
-              if (result.ok && result.output.success) {
-                previousResult = result.output;
-              } else {
-                chainBroken = true;
-                if (!result.ok) {
-                  errorResults.push({
-                    success: false,
-                    provider_connection_id: account.id,
-                    post_id: postData.id,
-                    chain_item_id: item.id,
-                    error_message:
-                      "post-to-platform run failed unexpectedly for chain item",
-                  });
-                }
-              }
-            } catch (error: any) {
-              logger.error("Failed Posting Chain Item", {
-                account,
-                item,
-                error,
-              });
-              errorResults.push({
-                success: false,
-                provider_connection_id: account.id,
-                post_id: postData.id,
-                chain_item_id: item.id,
-                error_message: error?.message || "Unknown error",
-                details: { error },
-              });
-              chainBroken = true;
             }
-          }
-        }
+          }),
+        );
       }
     } catch (error) {
       logger.error("Unexpected Error", { error });
@@ -892,19 +895,7 @@ export const processPost = task({
          provider_connection_id,
          provider_data
         ),
-        social_post_chain_items (
-          id,
-          sequence,
-          caption,
-          social_post_chain_item_media (
-            id,
-            url,
-            thumbnail_url,
-            thumbnail_timestamp_ms,
-            tags,
-            skip_processing
-          )
-        )
+        ${CHAIN_SELECT}
         `,
         )
         .single();

--- a/trigger/process-post.ts
+++ b/trigger/process-post.ts
@@ -5,10 +5,15 @@ import type {
   PlatformAppCredentials,
   PlatformConfiguration,
   Post,
+  PostMedia,
   PostResult,
+  Provider,
+  SocialAccount,
   UserTag,
 } from "./posting/post.types";
 import { Unkey } from "@unkey/api";
+
+const CHAIN_CAPABLE_PROVIDERS: Provider[] = ["x", "threads", "bluesky"];
 
 import { Database, Json } from "./supabase.types";
 
@@ -138,6 +143,122 @@ const transformPostData = (data: {
   };
 };
 
+interface LocalizedMedia extends PostMedia {
+  provider?: string | null;
+  provider_connection_id?: string | null;
+}
+
+const localizeMedia = async (
+  media: {
+    id: string;
+    provider?: string | null;
+    provider_connection_id?: string | null;
+    url: string;
+    thumbnail_url: string | null;
+    thumbnail_timestamp_ms: number | null;
+    tags?: UserTag[] | null;
+    skip_processing?: boolean | null;
+  }[],
+): Promise<LocalizedMedia[]> => {
+  const postMedia: LocalizedMedia[] = [];
+
+  if (!media || media.length === 0) {
+    return postMedia;
+  }
+
+  logger.info("Localizing Media", { media });
+
+  const localizedMedia = await tasks.batchTriggerAndWait(
+    "process-post-medium",
+    media.map((medium) => ({
+      payload: {
+        medium: {
+          id: medium.id,
+          provider: medium.provider,
+          provider_connection_id: medium.provider_connection_id,
+          url: medium.url,
+          thumbnail_url: medium.thumbnail_url,
+          thumbnail_timestamp_ms: medium.thumbnail_timestamp_ms,
+          tags: medium.tags,
+          skip_processing: medium.skip_processing,
+        },
+      },
+    })),
+  );
+
+  logger.info("Localizing Media Complete", { localizedMedia });
+
+  const succesfulMedia = localizedMedia.runs
+    .filter((run) => run.ok)
+    .map((run) => run.output);
+
+  const postImages = succesfulMedia.filter(
+    (medium) => medium.type !== "video",
+  );
+  const postVideos = succesfulMedia.filter(
+    (medium) => medium.type === "video",
+  );
+
+  postMedia.push(...postImages);
+  postMedia.push(...postVideos.filter((m) => m.skip_processing));
+
+  const videosToProcess = postVideos.filter((m) => !m.skip_processing);
+
+  if (videosToProcess.length > 0) {
+    logger.info("Processing Videos");
+    const processVideosResult = await tasks.batchTriggerAndWait(
+      "ffmpeg-process-video",
+      videosToProcess.map((video) => ({
+        payload: {
+          medium: video,
+        },
+      })),
+    );
+
+    logger.info("Processing Videos Complete", { processVideosResult });
+
+    postMedia.push(
+      ...processVideosResult.runs
+        .filter((run) => run.ok)
+        .map((run) => run.output),
+    );
+
+    logger.info("Updated post media with processed video URLs", {
+      postMedia,
+    });
+  }
+
+  return postMedia;
+};
+
+const buildReplyPlatformConfig = (
+  provider: string,
+  previousResult: PostResult,
+  rootResult: PostResult,
+): PlatformConfiguration => {
+  switch (provider) {
+    case "x":
+      return { in_reply_to_tweet_id: previousResult.provider_post_id };
+    case "threads":
+      return { reply_to_id: previousResult.provider_post_id };
+    case "bluesky":
+      return {
+        reply: {
+          root: {
+            uri: rootResult.provider_post_id!,
+            cid: rootResult.details?.cid,
+          },
+          parent: {
+            uri: previousResult.provider_post_id!,
+            cid: previousResult.details?.cid,
+          },
+        },
+      };
+    default:
+      return {};
+  }
+};
+
 const unkey = new Unkey({ rootKey: process.env.UNKEY_ROOT_KEY! });
 
 const UNKEY_MAX_RETRIES = 3;
@@ -241,92 +362,23 @@ export const processPost = task({
       }
 
       await tags.add(`${project.team_id}`);
-      const postMedia: {
-        id: string;
-        provider?: string | null;
-        provider_connection_id?: string | null;
-        url: string;
-        thumbnail_url: string;
-        thumbnail_timestamp_ms?: number | null;
-        type: string;
-        tags?: UserTag[] | null;
-        skip_processing?: boolean | null;
-      }[] = [];
-      if (post.social_post_media && post.social_post_media.length > 0) {
-        logger.info("Localizing Media", { media: post.social_post_media });
+      const postMedia = await localizeMedia(post.social_post_media ?? []);
 
-        const localizedMedia = await tasks.batchTriggerAndWait(
-          "process-post-medium",
-          post.social_post_media.map((medium) => ({
-            payload: {
-              medium: {
-                id: medium.id,
-                provider: medium.provider,
-                provider_connection_id: medium.provider_connection_id,
-                url: medium.url,
-                thumbnail_url: medium.thumbnail_url,
-                thumbnail_timestamp_ms: medium.thumbnail_timestamp_ms,
-                tags: medium.tags,
-                skip_processing: medium.skip_processing,
-              },
-            },
+      if (
+        post.social_post_media &&
+        post.social_post_media.length > 0 &&
+        postMedia.length === 0
+      ) {
+        logger.error("All Media Failed");
+        errorResults.push(
+          ...accounts.map((connection) => ({
+            success: false,
+            provider_connection_id: connection.id,
+            post_id: post.id,
+            error_message: `All media failed to process, please check media URLS`,
           })),
         );
-
-        logger.info("Localizing Media Complete", { localizedMedia });
-
-        const succesfulMedia = localizedMedia.runs
-          .filter((run) => run.ok)
-          .map((run) => run.output);
-
-        const postImages = succesfulMedia.filter(
-          (medium) => medium.type !== "video",
-        );
-        const postVideos = succesfulMedia.filter(
-          (medium) => medium.type === "video",
-        );
-
-        postMedia.push(...postImages);
-        postMedia.push(...postVideos.filter((m) => m.skip_processing));
-
-        const videosToProcess = postVideos.filter((m) => !m.skip_processing);
-
-        if (videosToProcess.length > 0) {
-          logger.info("Processing Videos");
-          const processVideosResult = await tasks.batchTriggerAndWait(
-            "ffmpeg-process-video",
-            videosToProcess.map((video) => ({
-              payload: {
-                medium: video,
-              },
-            })),
-          );
-
-          logger.info("Processing Videos Complete", { processVideosResult });
-
-          postMedia.push(
-            ...processVideosResult.runs
-              .filter((run) => run.ok)
-              .map((run) => run.output),
-          );
-
-          logger.info("Updated post media with processed video URLs", {
-            postMedia,
-          });
-        }
-
-        if (postMedia.length == 0) {
-          logger.error("All Media Failed");
-          errorResults.push(
-            ...accounts.map((connection) => ({
-              success: false,
-              provider_connection_id: connection.id,
-              post_id: post.id,
-              error_message: `All media failed to process, please check media URLS`,
-            })),
-          );
-          throw new Error("All media failed to process");
-        }
+        throw new Error("All media failed to process");
       }
 
       logger.info("Constructing Post Data");
@@ -343,8 +395,16 @@ export const processPost = task({
 
       logger.info("Constructed Post Data", { postData });
 
+      const chainItems = [...(post.social_post_chain_items ?? [])].sort(
+        (a, b) => a.sequence - b.sequence,
+      );
+
       const bulkPostData: IndividualPostData[] = [];
       const storyBulkPostData: IndividualPostData[] = [];
+      const chainAccounts: {
+        account: SocialAccount;
+        appCredentials: PlatformAppCredentials;
+      }[] = [];
       for (const account of postData.accounts) {
         try {
           logger.info("Getting App Credentials");
@@ -411,6 +471,13 @@ export const processPost = task({
           }
 
           logger.info("Got App Credentials");
+
+          if (
+            chainItems.length > 0 &&
+            CHAIN_CAPABLE_PROVIDERS.includes(account.provider)
+          ) {
+            chainAccounts.push({ account, appCredentials });
+          }
 
           logger.info("Creating Individual Post Configuration");
           const platformConfig = postData.configurations.filter(
@@ -504,6 +571,8 @@ export const processPost = task({
         }
       }
 
+      const rootResultsByAccountId = new Map<string, PostResult>();
+
       if (bulkPostData.length > 0) {
         logger.info("Posting To Accounts", { bulkPostData });
         const batchPostResult = await tasks.batchTriggerAndWait(
@@ -512,6 +581,13 @@ export const processPost = task({
         );
 
         logger.info("Posting To Accounts Complete", { batchPostResult });
+
+        bulkPostData.forEach((data, index) => {
+          const run = batchPostResult.runs[index];
+          if (run?.ok) {
+            rootResultsByAccountId.set(data.account.id, run.output);
+          }
+        });
       }
 
       if (storyBulkPostData.length > 0) {
@@ -541,6 +617,104 @@ export const processPost = task({
           });
         }
       }
+
+      if (chainAccounts.length > 0) {
+        logger.info("Posting Chain Items Sequentially", {
+          totalChainAccounts: chainAccounts.length,
+          chainLength: chainItems.length,
+        });
+
+        for (const { account, appCredentials } of chainAccounts) {
+          const rootResult = rootResultsByAccountId.get(account.id);
+
+          if (!rootResult?.success) {
+            logger.warn("Skipping chain: root post did not succeed", {
+              provider: account.provider,
+              provider_connection_id: account.id,
+            });
+            errorResults.push(
+              ...chainItems.map((item) => ({
+                success: false,
+                provider_connection_id: account.id,
+                post_id: postData.id,
+                chain_item_id: item.id,
+                error_message: `Skipped chain item: root post did not succeed for ${account.provider}`,
+              })),
+            );
+            continue;
+          }
+
+          let previousResult: PostResult = rootResult;
+          const rootRef: PostResult = rootResult;
+          let chainBroken = false;
+
+          for (const item of chainItems) {
+            if (chainBroken) {
+              errorResults.push({
+                success: false,
+                provider_connection_id: account.id,
+                post_id: postData.id,
+                chain_item_id: item.id,
+                error_message: `Skipped chain item: an earlier item in the chain failed for ${account.provider}`,
+              });
+              continue;
+            }
+
+            const itemMedia = await localizeMedia(
+              item.social_post_chain_item_media,
+            );
+
+            const platformConfig = buildReplyPlatformConfig(
+              account.provider,
+              previousResult,
+              rootRef,
+            );
+
+            logger.info("Posting Chain Item", {
+              provider: account.provider,
+              provider_connection_id: account.id,
+              sequence: item.sequence,
+            });
+
+            const result = await tasks.triggerAndWait("post-to-platform", {
+              stripeCustomerId: postData.stripe_customer_id,
+              teamId: project.team_id,
+              platform: account.provider,
+              postId: postData.id,
+              account,
+              media: itemMedia,
+              caption: item.caption,
+              platformConfig,
+              appCredentials,
+              projectId: post.project_id,
+              chainItemId: item.id,
+            });
+
+            logger.info("Posting Chain Item Complete", {
+              provider: account.provider,
+              provider_connection_id: account.id,
+              sequence: item.sequence,
+              success: result.ok && result.output.success,
+            });
+
+            if (result.ok && result.output.success) {
+              previousResult = result.output;
+            } else {
+              chainBroken = true;
+              if (!result.ok) {
+                errorResults.push({
+                  success: false,
+                  provider_connection_id: account.id,
+                  post_id: postData.id,
+                  chain_item_id: item.id,
+                  error_message:
+                    "post-to-platform run failed unexpectedly for chain item",
+                });
+              }
+            }
+          }
+        }
+      }
     } catch (error) {
       logger.error("Unexpected Error", { error });
     } finally {
@@ -568,6 +742,7 @@ export const processPost = task({
                   url: r.provider_post_url,
                 },
                 post_id: r.post_id,
+                chain_item_id: r.chain_item_id,
                 social_account_id: r.provider_connection_id,
                 success: r.success,
               },

--- a/trigger/process-scheduled-posts.ts
+++ b/trigger/process-scheduled-posts.ts
@@ -1,6 +1,7 @@
 import { logger, schedules, tasks } from "@trigger.dev/sdk";
 import { createClient } from "@supabase/supabase-js";
 import { Post } from "./posting/post.types";
+import { CHAIN_SELECT } from "./posting/chain-select";
 
 import { Database } from "./supabase.types";
 
@@ -49,19 +50,7 @@ export const processScheduledPosts = schedules.task({
               provider_connection_id,
               provider_data
             ),
-            social_post_chain_items (
-              id,
-              sequence,
-              caption,
-              social_post_chain_item_media (
-                id,
-                url,
-                thumbnail_url,
-                thumbnail_timestamp_ms,
-                tags,
-                skip_processing
-              )
-            )
+            ${CHAIN_SELECT}
             `,
         )
         .eq("status", "scheduled")

--- a/trigger/process-scheduled-posts.ts
+++ b/trigger/process-scheduled-posts.ts
@@ -48,6 +48,19 @@ export const processScheduledPosts = schedules.task({
               provider,
               provider_connection_id,
               provider_data
+            ),
+            social_post_chain_items (
+              id,
+              sequence,
+              caption,
+              social_post_chain_item_media (
+                id,
+                url,
+                thumbnail_url,
+                thumbnail_timestamp_ms,
+                tags,
+                skip_processing
+              )
             )
             `,
         )

--- a/trigger/supabase-media-cleanup.ts
+++ b/trigger/supabase-media-cleanup.ts
@@ -102,6 +102,41 @@ export const supabaseMediaCleanup = schedules.task({
       if (scheduledPostUrls.length < scheduledPostLimit) break;
     }
 
+    // social_post_chain_item_media has no direct post_id — it links via
+    // chain_item_id -> social_post_chain_items.id -> post_id, so it needs
+    // its own two-hop query rather than fitting in the loop above.
+    let scheduledChainMediaOffset = 0;
+
+    for (;;) {
+      const { data: scheduledChainMediaUrls, error: scheduledChainMediaError } =
+        await supabaseClient
+          .from("social_post_chain_item_media")
+          .select("url, social_post_chain_items!inner(social_posts!inner(status))")
+          .eq("social_post_chain_items.social_posts.status", "scheduled")
+          .like("url", `%${storageUrl}%`)
+          .range(
+            scheduledChainMediaOffset,
+            scheduledChainMediaOffset + scheduledPostLimit - 1,
+          );
+
+      if (scheduledChainMediaError) {
+        logger.error("Error fetching scheduled chain item media", {
+          error: scheduledChainMediaError,
+        });
+        return;
+      }
+
+      if (!scheduledChainMediaUrls || scheduledChainMediaUrls.length === 0)
+        break;
+
+      allScheduledPostUrls.push(
+        ...scheduledChainMediaUrls.map((media) => media.url),
+      );
+      scheduledChainMediaOffset += scheduledPostLimit;
+
+      if (scheduledChainMediaUrls.length < scheduledPostLimit) break;
+    }
+
     logger.info("Completed fetching scheduled post urls", {
       scheduledPostUrls: allScheduledPostUrls.length,
     });

--- a/trigger/supabase.types.ts
+++ b/trigger/supabase.types.ts
@@ -318,6 +318,39 @@ export type Database = {
           },
         ]
       }
+      social_post_result_chain_item_media: {
+        Row: {
+          id: string
+          social_post_chain_item_media_id: string
+          social_post_result_id: string
+        }
+        Insert: {
+          id?: string
+          social_post_chain_item_media_id: string
+          social_post_result_id: string
+        }
+        Update: {
+          id?: string
+          social_post_chain_item_media_id?: string
+          social_post_result_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_post_result_chain_item_media_social_post_result_id_fkey"
+            columns: ["social_post_result_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_results"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "social_post_result_chain_item_social_post_chain_item_media_fkey"
+            columns: ["social_post_chain_item_media_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_chain_item_media"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       social_post_result_post_media: {
         Row: {
           id: string

--- a/trigger/supabase.types.ts
+++ b/trigger/supabase.types.ts
@@ -95,6 +95,85 @@ export type Database = {
           },
         ]
       }
+      social_post_chain_item_media: {
+        Row: {
+          chain_item_id: string
+          created_at: string
+          id: string
+          skip_processing: boolean | null
+          tags: Json | null
+          thumbnail_timestamp_ms: number | null
+          thumbnail_url: string | null
+          updated_at: string
+          url: string
+        }
+        Insert: {
+          chain_item_id: string
+          created_at?: string
+          id?: string
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url: string
+        }
+        Update: {
+          chain_item_id?: string
+          created_at?: string
+          id?: string
+          skip_processing?: boolean | null
+          tags?: Json | null
+          thumbnail_timestamp_ms?: number | null
+          thumbnail_url?: string | null
+          updated_at?: string
+          url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_post_chain_item_media_chain_item_id_fkey"
+            columns: ["chain_item_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_chain_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      social_post_chain_items: {
+        Row: {
+          caption: string
+          created_at: string
+          id: string
+          post_id: string
+          sequence: number
+          updated_at: string
+        }
+        Insert: {
+          caption: string
+          created_at?: string
+          id?: string
+          post_id: string
+          sequence: number
+          updated_at?: string
+        }
+        Update: {
+          caption?: string
+          created_at?: string
+          id?: string
+          post_id?: string
+          sequence?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_post_chain_items_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       social_post_configurations: {
         Row: {
           caption: string | null
@@ -274,6 +353,7 @@ export type Database = {
       }
       social_post_results: {
         Row: {
+          chain_item_id: string | null
           created_at: string
           details: Json | null
           error_message: string | null
@@ -286,6 +366,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          chain_item_id?: string | null
           created_at?: string
           details?: Json | null
           error_message?: string | null
@@ -298,6 +379,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          chain_item_id?: string | null
           created_at?: string
           details?: Json | null
           error_message?: string | null
@@ -310,6 +392,13 @@ export type Database = {
           updated_at?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "social_post_results_chain_item_id_fkey"
+            columns: ["chain_item_id"]
+            isOneToOne: false
+            referencedRelation: "social_post_chain_items"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "social_post_results_post_id_fkey"
             columns: ["post_id"]
@@ -1036,6 +1125,10 @@ export type Database = {
       nanoid: {
         Args: { alphabet?: string; prefix: string; size?: number }
         Returns: string
+      }
+      user_has_chain_item_access: {
+        Args: { chain_item_id: string }
+        Returns: boolean
       }
       user_has_post_access: { Args: { post_id: string }; Returns: boolean }
       user_has_post_result_access: {


### PR DESCRIPTION
## Summary

Implements PFM-966: support for publishing "post chains" (threads) — a root
post plus an ordered sequence of follow-up posts, each published as a reply
to the previous one. Requested because competitors (Ayrshare, PostEverywhere,
SocialRails) support this via an array of posts in a single request, and it's
central to at least one customer's use case. Chaining is only supported on
x, threads, and bluesky — other platforms in the same request post only the
root and silently ignore the `chain` field.

## Changes

- **DB migration** (`api/supabase/migrations/20260804120000_social_post_chains.sql`):
  new `social_post_chain_items` and `social_post_chain_item_media` tables,
  plus a nullable `chain_item_id` FK on `social_post_results` (null = root
  post result). No columns added to `social_posts` itself — fully additive,
  zero behavior change for existing posts.
- **API** (`api/src/social-posts/`, `api/src/social-post-results/`): new
  optional `chain` array on `CreateSocialPostDto`/`SocialPostDto` (caption +
  media per item, capped at 25 items), validation, insert/select/echo-back
  logic, and `chain_item_id` surfaced on post results.
- **Trigger orchestration** (`trigger/process-post.ts`, `post-to-platform.ts`,
  `process-scheduled-posts.ts`): root posts still fan out in parallel exactly
  as before. Chain items post sequentially per account via `triggerAndWait`
  (mirroring the existing `storyBulkPostData` pattern), injecting the
  previous item's platform post ID into the next item's config. A failed
  root or mid-chain item stops the rest of that account's chain and records
  synthetic failure rows rather than silently dropping them.
- **Platform clients**: X now sets `reply.in_reply_to_tweet_id`; Threads sets
  `reply_to_id` on container creation; Bluesky now captures the `cid` it was
  previously discarding (needed for AT Protocol's `reply.{root,parent}`
  structure) and sets it when replying.
- **Docs**: Swagger `@ApiProperty` descriptions on the new fields and an
  updated Social Posts tag description.

## Review follow-ups (round 1)

A code review of the chain implementation surfaced 7 issues, all addressed
in that commit:

- **Stale OAuth token across chain items**: the account/token object used
  for each chain item's `post-to-platform` call was captured once before the
  root post ran, so a token refresh done for the root post (or an earlier
  chain item) never reached later items — a real problem for X, which
  rotates its OAuth2 `refresh_token` on every use. Now re-fetched fresh from
  `social_provider_connections` before every chain-item post.
- **Duplicate media localization**: chain-item media was being
  downloaded/processed once per chain-capable account instead of once per
  item. Now localized once up front and reused across accounts, same as
  root-post media.
- **Missing "all media failed" guard for chain items**: the root post
  already fails loudly if all its media fails to process; chain items now
  get the same guard instead of silently posting a bare caption.
- **No per-item error isolation**: an exception anywhere in the chain-item
  loop (e.g. from media localization) aborted the entire run for every
  remaining account and item with no error rows recorded. Each chain item
  now posts inside its own try/catch, so a failure only stops the rest of
  that one account's chain.
- **Chain-item media never linked to post results**: `social_post_results`
  → media was only wired for root-post media
  (`social_post_result_post_media`); chain-item results always reported
  empty `media`. Added `social_post_result_chain_item_media` (new
  migration) and wired it through the insert path and both
  `social-post-results.service.ts` read paths.
- **Storage cleanup deleting scheduled chain media**: the hourly
  `supabase-media-cleanup` job only checked `social_post_media` for URLs to
  preserve, so media attached to chain items on not-yet-published scheduled
  posts could be deleted before the post ran. It now also queries
  `social_post_chain_item_media` (via the `chain_item -> post` two-hop
  join).
- **`social.post.updated` webhook missing chain data**: the API's
  `SocialPostDto` already included `chain`, but the trigger-side webhook
  payload (built by a separate, hand-duplicated `transformPostData`) did
  not. Now includes `chain` in the same shape.

## Review follow-ups (round 2)

A second `/code-review 316` pass surfaced 4 more issues, all addressed in
the latest commit:

- **Chain item `id` missing from API responses**: `SocialPostChainItemDto`
  was reused for both the create-post request and the `GET /posts`
  response, but only carried `caption`/`media` — never the DB-generated
  `id`. Callers had no way to match a `chain_item_id` on
  `social_post_results` (or the `social.post.result.created` webhook) back
  to a specific chain entry. Split into a request-only DTO and a new
  `SocialPostChainItemResponseDto` (adds `id`/`sequence`), wired into
  `post.dto.ts` and `social-posts.service.ts`'s `transformPostData`.
- **Chain insert failures silently swallowed**: a failed
  `social_post_chain_items` or `social_post_chain_item_media` insert was
  only `console.error`'d, then `createPost` fell through to trigger/return
  a 200 as if the thread had been created. Now throws, consistent with how
  the root `social_posts` insert failure is already handled, so the caller
  gets a 500 instead of a post silently missing its chain.
- **Sequential per-account chain posting**: `process-post.ts` posted each
  chain-capable account's (x/threads/bluesky) reply chain one full account
  at a time via a sequential `for` loop, multiplying wall-clock time and
  risking the task's `maxDuration: 3600` on posts with several
  chain-capable accounts and long chains. Verified each account's chain
  state (`previousResult`/`rootRef`/`chainBroken`) is fully independent —
  switched the outer loop to `Promise.allSettled` so all accounts post
  concurrently while each account's own reply sequence stays ordered.
- **Duplicated select fragment**: the `social_post_chain_items(...)`
  Supabase select fragment was hand-duplicated in `process-post.ts` and
  `process-scheduled-posts.ts`. Extracted to a new
  `trigger/posting/chain-select.ts` (mirroring the `CHAIN_SELECT` constant
  `api/` already has), imported into both.

## Testing

- `bun run typecheck` and `bun run lint` pass clean in both `api/` and
  `trigger/` (re-verified after the round 2 fixes above).
- Ran the migrations against a local Supabase instance (`supabase db
  reset`) and regenerated types in both `api/` and `trigger/`.
- Verified schema correctness directly via `psql`: unique `(post_id,
  sequence)` constraint holds; cascade deletes are correct (deleting a chain
  item cascades its media and its linked result while the root result and
  post survive; deleting the post cascades everything).
- **Not tested**: full HTTP-level flow and live posting to X/Threads/Bluesky
  — this sandbox has no Unkey API key or real platform credentials, so the
  create → trigger → post-to-platform path hasn't been exercised end-to-end
  against real accounts. Recommend a manual pass against real test accounts
  before merging.

## Notes

- Chain items don't support per-account/per-platform caption overrides in
  this version (the root post keeps its existing override system unchanged)
  — a deliberate scope cut, cheap to add later if needed.
- Follow-ups flagged but not done here (out of scope — marketing/CMS
  surface, not API/trigger): a CMS guide on post chains, noting thread
  support in `marketing/app/lib/.server/data/integrations.*.ts`, and adding
  a `chain` example to `marketing/app/components/code-samples.tsx`.
- No dashboard UI for composing/viewing chains in this pass (API + trigger
  only, per scope agreed with @dennis).

Closes PFM-966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
