### PR TITLE
fix(api,dashboard): force Facebook asset picker on re-link

### DIFF
--- a/api/src/social-provider-connections/docs/create-auth-url.md.ts
+++ b/api/src/social-provider-connections/docs/create-auth-url.md.ts
@@ -2,4 +2,6 @@ export const createAuthUrlDescription = `
 Generates a URL that initiates the authentication flow for a user's social media account. When visited, the user is redirected to the selected social platform's login/authorization page. Upon successful authentication, they are redirected back to your application.
 
 For Quickstart projects using Post for Me system credentials, \`redirect_url_override\` is not accepted. Configure the project redirect URL in the dashboard instead.
+
+Use the top-level \`force_reauth\` boolean to control whether the OAuth flow forces the account picker / consent screen to be shown again during re-authorization, rather than silently reusing previously granted access. This only applies to \`facebook\`, \`instagram\` (both \`connection_type\` values), \`tiktok\`, \`tiktok_business\`, \`youtube\`, and \`x\` (with \`connection_type\` set to \`oauth1\`) — it is ignored for all other platforms. There is no single global default: \`facebook\`, \`instagram\` (facebook connection type), \`tiktok\`, \`tiktok_business\`, and \`youtube\` default to forcing re-auth; \`instagram\` (instagram connection type) and \`x\` (oauth1) default to not forcing re-auth. Set \`force_reauth\` explicitly to \`true\` or \`false\` to override a given platform's default.
 `;

--- a/api/src/social-provider-connections/dto/create-provider-auth-url.dto.ts
+++ b/api/src/social-provider-connections/dto/create-provider-auth-url.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsIn, IsOptional } from 'class-validator';
+import { IsBoolean, IsIn, IsOptional } from 'class-validator';
 
 export class BlueskyAuthUrlProviderData {
   @ApiProperty({ description: 'The handle of the account', type: String })
@@ -229,4 +229,13 @@ export class CreateSocialAccountProviderAuthUrlDto {
   @IsIn(['posts', 'feeds'], { each: true })
   @IsOptional()
   permissions?: string[];
+
+  @ApiProperty({
+    description:
+      "Forces the OAuth flow to show the account picker / consent screen again during re-authorization, rather than silently reusing previously granted access. Only applies to facebook, instagram (both connection_types), tiktok, tiktok_business, youtube, and x (oauth1 connection_type) — ignored for all other platforms. There is no single default: facebook, instagram (facebook connection_type), tiktok, tiktok_business, and youtube default to forcing re-auth (true); instagram (instagram connection_type) and x (oauth1) default to NOT forcing re-auth (false). Set explicitly to override a given platform's default.",
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  force_reauth?: boolean;
 }

--- a/api/src/social-provider-connections/helper/auth-url.helper.spec.ts
+++ b/api/src/social-provider-connections/helper/auth-url.helper.spec.ts
@@ -1,6 +1,7 @@
 import type { ConfigService } from '@nestjs/config';
 import type { SupabaseService } from '../../supabase/supabase.service';
 import type { SocialProviderAppCredentialsDto } from '../../social-provider-app-credentials/dto/social-provider-app-credentials.dto';
+import { TwitterApi } from 'twitter-api-v2';
 import { generateAuthUrl } from './auth-url.helper';
 
 describe('generateAuthUrl', () => {
@@ -25,6 +26,7 @@ describe('generateAuthUrl', () => {
     externalId: undefined,
     redirectUrlOverride: undefined,
     permissions: [],
+    forceReauth: undefined,
   };
 
   const appCredentials = (
@@ -36,7 +38,7 @@ describe('generateAuthUrl', () => {
     appSecret: 'app-secret',
   });
 
-  it('includes auth_type=rerequest for facebook', async () => {
+  it('includes auth_type=rerequest for facebook by default', async () => {
     const authUrl = await generateAuthUrl({
       ...baseArgs,
       appCredentials: appCredentials('facebook'),
@@ -46,7 +48,18 @@ describe('generateAuthUrl', () => {
     expect(params.get('auth_type')).toBe('rerequest');
   });
 
-  it('includes auth_type=rerequest for instagram_w_facebook', async () => {
+  it('omits auth_type for facebook when force_reauth is false', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('facebook'),
+      forceReauth: false,
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('auth_type')).toBeNull();
+  });
+
+  it('includes auth_type=rerequest for instagram_w_facebook by default', async () => {
     const authUrl = await generateAuthUrl({
       ...baseArgs,
       appCredentials: appCredentials('instagram_w_facebook'),
@@ -56,7 +69,18 @@ describe('generateAuthUrl', () => {
     expect(params.get('auth_type')).toBe('rerequest');
   });
 
-  it('does not add auth_type for native instagram, and leaves force_reauth untouched', async () => {
+  it('omits auth_type for instagram_w_facebook when force_reauth is false', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('instagram_w_facebook'),
+      forceReauth: false,
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('auth_type')).toBeNull();
+  });
+
+  it('does not add auth_type for native instagram, and defaults force_reauth to false', async () => {
     const authUrl = await generateAuthUrl({
       ...baseArgs,
       appCredentials: appCredentials('instagram'),
@@ -65,6 +89,126 @@ describe('generateAuthUrl', () => {
     const params = new URL(authUrl!).searchParams;
     expect(params.get('auth_type')).toBeNull();
     expect(params.get('force_reauth')).toBe('false');
+  });
+
+  it('sets force_reauth=true for native instagram when forceReauth is explicitly true', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('instagram'),
+      forceReauth: true,
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('force_reauth')).toBe('true');
+  });
+
+  it('includes disable_auto_auth=1 for tiktok by default', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('tiktok'),
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('disable_auto_auth')).toBe('1');
+  });
+
+  it('omits disable_auto_auth for tiktok when force_reauth is false', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('tiktok'),
+      forceReauth: false,
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('disable_auto_auth')).toBeNull();
+  });
+
+  it('includes disable_auto_auth=1 for tiktok_business by default', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('tiktok_business'),
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('disable_auto_auth')).toBe('1');
+  });
+
+  it('omits disable_auto_auth for tiktok_business when force_reauth is false', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('tiktok_business'),
+      forceReauth: false,
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('disable_auto_auth')).toBeNull();
+  });
+
+  it('includes prompt=consent for youtube by default', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('youtube'),
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('prompt')).toBe('consent');
+  });
+
+  it('omits prompt entirely for youtube when force_reauth is false', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('youtube'),
+      forceReauth: false,
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.has('prompt')).toBe(false);
+  });
+
+  describe('x (oauth1)', () => {
+    let generateAuthLinkSpy: jest.SpiedFunction<
+      typeof TwitterApi.prototype.generateAuthLink
+    >;
+
+    beforeEach(() => {
+      generateAuthLinkSpy = jest
+        .spyOn(TwitterApi.prototype, 'generateAuthLink')
+        .mockResolvedValue({
+          url: 'https://api.twitter.com/oauth/authorize?oauth_token=token',
+          oauth_token: 'token',
+          oauth_token_secret: 'secret',
+          oauth_callback_confirmed: 'true',
+        });
+    });
+
+    afterEach(() => {
+      generateAuthLinkSpy.mockRestore();
+    });
+
+    it('does not pass forceLogin for x (oauth1) by default', async () => {
+      await generateAuthUrl({
+        ...baseArgs,
+        appCredentials: appCredentials('x'),
+      });
+
+      expect(generateAuthLinkSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ forceLogin: undefined }),
+      );
+    });
+
+    it('passes forceLogin=true for x (oauth1) when forceReauth is explicitly true', async () => {
+      await generateAuthUrl({
+        ...baseArgs,
+        appCredentials: appCredentials('x'),
+        forceReauth: true,
+      });
+
+      expect(generateAuthLinkSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ forceLogin: true }),
+      );
+    });
   });
 
   it.each(['pinterest', 'linkedin', 'threads', 'tiktok'] as const)(

--- a/api/src/social-provider-connections/helper/auth-url.helper.spec.ts
+++ b/api/src/social-provider-connections/helper/auth-url.helper.spec.ts
@@ -1,0 +1,82 @@
+import type { ConfigService } from '@nestjs/config';
+import type { SupabaseService } from '../../supabase/supabase.service';
+import type { SocialProviderAppCredentialsDto } from '../../social-provider-app-credentials/dto/social-provider-app-credentials.dto';
+import { generateAuthUrl } from './auth-url.helper';
+
+describe('generateAuthUrl', () => {
+  const configService = {
+    get: jest.fn().mockReturnValue(undefined),
+  } as unknown as ConfigService;
+
+  const supabaseService = {
+    supabaseClient: {
+      from: jest.fn().mockReturnValue({
+        upsert: jest.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    },
+  } as unknown as SupabaseService;
+
+  const baseArgs = {
+    projectId: 'project-1',
+    isSystem: false,
+    configService,
+    supabaseService,
+    providerData: null,
+    externalId: undefined,
+    redirectUrlOverride: undefined,
+    permissions: [],
+  };
+
+  const appCredentials = (
+    provider: SocialProviderAppCredentialsDto['provider'],
+  ): SocialProviderAppCredentialsDto => ({
+    provider,
+    projectId: 'project-1',
+    appId: 'app-id',
+    appSecret: 'app-secret',
+  });
+
+  it('includes auth_type=rerequest for facebook', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('facebook'),
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('auth_type')).toBe('rerequest');
+  });
+
+  it('includes auth_type=rerequest for instagram_w_facebook', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('instagram_w_facebook'),
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('auth_type')).toBe('rerequest');
+  });
+
+  it('does not add auth_type for native instagram, and leaves force_reauth untouched', async () => {
+    const authUrl = await generateAuthUrl({
+      ...baseArgs,
+      appCredentials: appCredentials('instagram'),
+    });
+
+    const params = new URL(authUrl!).searchParams;
+    expect(params.get('auth_type')).toBeNull();
+    expect(params.get('force_reauth')).toBe('false');
+  });
+
+  it.each(['pinterest', 'linkedin', 'threads', 'tiktok'] as const)(
+    'does not add auth_type for %s',
+    async (provider) => {
+      const authUrl = await generateAuthUrl({
+        ...baseArgs,
+        appCredentials: appCredentials(provider),
+      });
+
+      const params = new URL(authUrl!).searchParams;
+      expect(params.get('auth_type')).toBeNull();
+    },
+  );
+});

--- a/api/src/social-provider-connections/helper/auth-url.helper.ts
+++ b/api/src/social-provider-connections/helper/auth-url.helper.ts
@@ -121,6 +121,7 @@ export async function generateAuthUrl({
         ['scope', scopes.join(',')],
         ['response_type', 'code'],
         ['state', authState],
+        ['auth_type', 'rerequest'],
       ]);
 
       authUrl = `https://www.facebook.com/${facebookVersion}/dialog/oauth?${authParams.toString()}`;
@@ -169,6 +170,7 @@ export async function generateAuthUrl({
         ['scope', scopes.join(',')],
         ['response_type', 'code'],
         ['state', authState],
+        ['auth_type', 'rerequest'],
       ]);
 
       authUrl = `https://www.facebook.com/${facebookVersion}/dialog/oauth?${authParams.toString()}`;

--- a/api/src/social-provider-connections/helper/auth-url.helper.ts
+++ b/api/src/social-provider-connections/helper/auth-url.helper.ts
@@ -19,6 +19,7 @@ export async function generateAuthUrl({
   externalId,
   redirectUrlOverride,
   permissions,
+  forceReauth,
 }: {
   projectId: string;
   isSystem: boolean;
@@ -29,6 +30,7 @@ export async function generateAuthUrl({
   externalId: string | undefined;
   redirectUrlOverride: string | undefined | null;
   permissions: string[];
+  forceReauth: boolean | undefined;
 }): Promise<string | undefined> {
   const { appId, appSecret } = appCredentials;
 
@@ -121,8 +123,11 @@ export async function generateAuthUrl({
         ['scope', scopes.join(',')],
         ['response_type', 'code'],
         ['state', authState],
-        ['auth_type', 'rerequest'],
       ]);
+
+      if (forceReauth !== false) {
+        authParams.append('auth_type', 'rerequest');
+      }
 
       authUrl = `https://www.facebook.com/${facebookVersion}/dialog/oauth?${authParams.toString()}`;
 
@@ -170,8 +175,11 @@ export async function generateAuthUrl({
         ['scope', scopes.join(',')],
         ['response_type', 'code'],
         ['state', authState],
-        ['auth_type', 'rerequest'],
       ]);
+
+      if (forceReauth !== false) {
+        authParams.append('auth_type', 'rerequest');
+      }
 
       authUrl = `https://www.facebook.com/${facebookVersion}/dialog/oauth?${authParams.toString()}`;
       break;
@@ -200,7 +208,7 @@ export async function generateAuthUrl({
         ['scope', scopes.join(',')],
         ['response_type', 'code'],
         ['state', authState],
-        ['force_reauth', 'false'],
+        ['force_reauth', forceReauth === true ? 'true' : 'false'],
       ]);
 
       authUrl = `https://www.instagram.com/oauth/authorize?${authParams.toString()}`;
@@ -215,6 +223,7 @@ export async function generateAuthUrl({
 
       const authLink = await client.generateAuthLink(callbackUrl, {
         linkMode: 'authorize',
+        forceLogin: forceReauth === true ? true : undefined,
       });
 
       authUrl = authLink.url;
@@ -316,8 +325,11 @@ export async function generateAuthUrl({
         ['scope', scopes.join(',')],
         ['response_type', 'code'],
         ['state', authState],
-        ['disable_auto_auth', '1'],
       ]);
+
+      if (forceReauth !== false) {
+        authParams.append('disable_auto_auth', '1');
+      }
 
       const tikTokVersion =
         configService.get<string>('TIKTOK_API_VERSION') || 'v2';
@@ -360,9 +372,12 @@ export async function generateAuthUrl({
         ['redirect_uri', callbackUrl],
         ['scope', scopes.join(',')],
         ['response_type', 'code'],
-        ['disable_auto_auth', '1'],
         ['state', authState],
       ]);
+
+      if (forceReauth !== false) {
+        authParams.append('disable_auto_auth', '1');
+      }
 
       const tikTokVersion =
         configService.get<string>('TIKTOK_API_VERSION') || 'v2';
@@ -402,8 +417,8 @@ export async function generateAuthUrl({
         access_type: 'offline',
         scope: scopes,
         include_granted_scopes: true,
-        prompt: 'consent',
         state: authState,
+        ...(forceReauth !== false ? { prompt: 'consent' } : {}),
       });
 
       break;

--- a/api/src/social-provider-connections/social-provider-connections.controller.ts
+++ b/api/src/social-provider-connections/social-provider-connections.controller.ts
@@ -283,6 +283,7 @@ export class SocialAccountsController {
       externalId: createAuthUrlInput.external_id,
       redirectUrlOverride: createAuthUrlInput.redirect_url_override || null,
       permissions: createAuthUrlInput.permissions || ['posts'],
+      forceReauth: createAuthUrlInput.force_reauth,
       isSystem,
     });
 

--- a/api/src/social-provider-connections/social-provider-connections.service.ts
+++ b/api/src/social-provider-connections/social-provider-connections.service.ts
@@ -226,6 +226,7 @@ export class SocialAccountsService {
     externalId,
     redirectUrlOverride,
     permissions,
+    forceReauth,
     isSystem,
   }: {
     projectId: string;
@@ -234,6 +235,7 @@ export class SocialAccountsService {
     externalId: string | undefined;
     redirectUrlOverride: string | undefined | null;
     permissions: string[];
+    forceReauth: boolean | undefined;
     isSystem: boolean;
   }): Promise<string | undefined> {
     const authUrl = await generateAuthUrl({
@@ -246,6 +248,7 @@ export class SocialAccountsService {
       externalId,
       redirectUrlOverride,
       permissions,
+      forceReauth,
     });
 
     return authUrl;

--- a/dashboard/app/lib/.server/social-accounts/providers/facebook.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/facebook.social-account.ts
@@ -51,6 +51,19 @@ export async function getFacebookSocialProviderConnection({
 
   const accessToken = longLivedData.access_token;
 
+  // Identifies which Facebook login this grant came from, so re-auth
+  // reconciliation only ever touches Pages granted by the same login.
+  let facebookUserId: string | undefined;
+  try {
+    const meResponse = await fetch(
+      `https://graph.facebook.com/v23.0/me?fields=id&access_token=${accessToken}`,
+    );
+    const meData = await meResponse.json();
+    facebookUserId = meData?.id;
+  } catch (error) {
+    console.error("Error fetching Facebook user id:", error);
+  }
+
   let accountsUrl = `https://graph.facebook.com/v23.0/me/accounts?fields=name,access_token,picture&limit=100&access_token=${accessToken}`;
 
   const accounts: SocialProviderConnection[] = [];
@@ -74,6 +87,7 @@ export async function getFacebookSocialProviderConnection({
             social_provider_photo_url: profilePhotoUrl,
             access_token: page.access_token,
             access_token_expires_at: new Date(Date.now() + 5184000 * 1000),
+            social_provider_metadata: { facebook_user_id: facebookUserId },
           });
         }
       }

--- a/dashboard/app/lib/.server/social-accounts/providers/instagram-w-facebook.social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/providers/instagram-w-facebook.social-account.ts
@@ -43,6 +43,19 @@ export async function getInstagramWFacebookSocialProviderConnection({
 
   const accessToken = longLivedData.access_token;
 
+  // Identifies which Facebook login this grant came from, so re-auth
+  // reconciliation only ever touches accounts granted by the same login.
+  let facebookUserId: string | undefined;
+  try {
+    const meResponse = await fetch(
+      `https://graph.facebook.com/v23.0/me?fields=id&access_token=${accessToken}`,
+    );
+    const meData = await meResponse.json();
+    facebookUserId = meData?.id;
+  } catch (error) {
+    console.error("Error fetching Facebook user id:", error);
+  }
+
   const allPages: {
     instagram_business_account: {
       id: string;
@@ -87,6 +100,7 @@ export async function getInstagramWFacebookSocialProviderConnection({
           page.instagram_business_account.profile_picture_url,
         social_provider_metadata: {
           connection_type: "facebook",
+          facebook_user_id: facebookUserId,
         },
       });
     }

--- a/dashboard/app/lib/.server/social-accounts/social-account.test.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SocialProviderConnection } from "./social-account.types";
+
+const batchTriggerMock = vi.fn();
+vi.mock("@trigger.dev/sdk", () => ({
+  tasks: {
+    batchTrigger: (...args: unknown[]) => batchTriggerMock(...args),
+  },
+}));
+
+const getFacebookSocialProviderConnectionMock = vi.fn();
+vi.mock("./providers/facebook.social-account", () => ({
+  getFacebookSocialProviderConnection: (...args: unknown[]) =>
+    getFacebookSocialProviderConnectionMock(...args),
+}));
+
+const getTikTokSocialProviderConnectionMock = vi.fn();
+vi.mock("./providers/tiktok.social-account", () => ({
+  getTikTokSocialProviderConnection: (...args: unknown[]) =>
+    getTikTokSocialProviderConnectionMock(...args),
+}));
+
+import { addSocialAccountConnections } from "./social-account";
+
+function connection(
+  overrides: Partial<SocialProviderConnection>
+): SocialProviderConnection {
+  return {
+    access_token: "new-token",
+    refresh_token: "new-refresh",
+    access_token_expires_at: new Date("2026-01-01"),
+    refresh_token_expires_at: undefined,
+    social_provider_user_id: "page-a",
+    social_provider_user_name: "Page A",
+    social_provider_photo_url: undefined,
+    social_provider_metadata: undefined,
+    ...overrides,
+  };
+}
+
+function createSupabaseServiceRoleMock({
+  staleConnections = [] as Record<string, unknown>[],
+  insertedConnections = [] as Record<string, unknown>[],
+}: {
+  staleConnections?: Record<string, unknown>[];
+  insertedConnections?: Record<string, unknown>[];
+}) {
+  const updateMock = vi.fn();
+  const fromMock = vi.fn(() => {
+    let mode: "select" | "update" | "upsert" | null = null;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chain: any = {
+      select: vi.fn(() => {
+        if (mode !== "upsert") {
+          mode = "select";
+        }
+        return chain;
+      }),
+      eq: vi.fn(() => chain),
+      not: vi.fn(() => chain),
+      update: vi.fn((payload: unknown) => {
+        mode = "update";
+        updateMock(payload);
+        return chain;
+      }),
+      upsert: vi.fn(() => {
+        mode = "upsert";
+        return chain;
+      }),
+      in: vi.fn(() => chain),
+      then: (
+        resolve: (value: { data: unknown; error: unknown }) => unknown,
+        reject: (reason: unknown) => unknown
+      ) => {
+        const result =
+          mode === "select"
+            ? { data: staleConnections, error: null }
+            : mode === "update"
+              ? { data: null, error: null }
+              : { data: insertedConnections, error: null };
+        return Promise.resolve(result).then(resolve, reject);
+      },
+    };
+
+    return chain;
+  });
+
+  return { from: fromMock, updateMock } as unknown as Parameters<
+    typeof addSocialAccountConnections
+  >[0]["supabaseServiceRole"] & { updateMock: typeof updateMock };
+}
+
+describe("addSocialAccountConnections stale asset reconciliation", () => {
+  beforeEach(() => {
+    batchTriggerMock.mockReset();
+    getFacebookSocialProviderConnectionMock.mockReset();
+    getTikTokSocialProviderConnectionMock.mockReset();
+  });
+
+  it("disconnects a previously-granted Facebook Page missing from the new grant", async () => {
+    getFacebookSocialProviderConnectionMock.mockResolvedValue([
+      connection({ social_provider_user_id: "page-a" }),
+    ]);
+
+    const staleConnection = {
+      id: "conn-page-b",
+      provider: "facebook",
+      social_provider_user_name: "Page B",
+      social_provider_user_id: "page-b",
+      social_provider_profile_photo_url: null,
+      external_id: null,
+      access_token_expires_at: null,
+      refresh_token_expires_at: null,
+      social_provider_metadata: null,
+    };
+
+    const supabaseServiceRole = createSupabaseServiceRoleMock({
+      staleConnections: [staleConnection],
+      insertedConnections: [{ id: "conn-page-a" }],
+    });
+
+    const result = await addSocialAccountConnections({
+      projectId: "project-1",
+      provider: "facebook",
+      request: new Request("https://example.com/callback?code=abc"),
+      supabaseServiceRole,
+      isSystem: false,
+      appCredentials: { appId: "app-id", appSecret: "app-secret" },
+      externalId: undefined,
+      redirectUrlOverride: undefined,
+    });
+
+    expect(result.successConnections).toEqual(["conn-page-a"]);
+    expect(supabaseServiceRole.updateMock).toHaveBeenCalledWith({
+      access_token: null,
+      refresh_token: null,
+    });
+
+    expect(batchTriggerMock).toHaveBeenCalledWith(
+      "process-webhooks",
+      expect.arrayContaining([
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            eventType: "social.account.updated",
+            eventData: expect.objectContaining({
+              id: "conn-page-b",
+              status: "disconnected",
+              access_token: "",
+              refresh_token: "",
+            }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("does not reconcile single-asset providers like tiktok", async () => {
+    getTikTokSocialProviderConnectionMock.mockResolvedValue([
+      connection({ social_provider_user_id: "tiktok-user" }),
+    ]);
+
+    const supabaseServiceRole = createSupabaseServiceRoleMock({
+      insertedConnections: [{ id: "conn-tiktok" }],
+    });
+
+    await addSocialAccountConnections({
+      projectId: "project-1",
+      provider: "tiktok",
+      request: new Request("https://example.com/callback?code=abc"),
+      supabaseServiceRole,
+      isSystem: false,
+      appCredentials: { appId: "app-id", appSecret: "app-secret" },
+      externalId: undefined,
+      redirectUrlOverride: undefined,
+    });
+
+    expect(supabaseServiceRole.updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/lib/.server/social-accounts/social-account.test.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.test.ts
@@ -46,6 +46,12 @@ function createSupabaseServiceRoleMock({
   insertedConnections?: Record<string, unknown>[];
 }) {
   const updateMock = vi.fn();
+  // Only the reconciliation "select stale connections" query uses .eq()/.is()
+  // filters in the current implementation (the update/upsert chains don't),
+  // so it's safe to capture these globally across every from() call.
+  const eqCalls: { column: string; value: unknown }[] = [];
+  const isCalls: { column: string; value: unknown }[] = [];
+
   const fromMock = vi.fn(() => {
     let mode: "select" | "update" | "upsert" | null = null;
 
@@ -57,8 +63,16 @@ function createSupabaseServiceRoleMock({
         }
         return chain;
       }),
-      eq: vi.fn(() => chain),
+      eq: vi.fn((column: string, value: unknown) => {
+        eqCalls.push({ column, value });
+        return chain;
+      }),
+      is: vi.fn((column: string, value: unknown) => {
+        isCalls.push({ column, value });
+        return chain;
+      }),
       not: vi.fn(() => chain),
+      neq: vi.fn(() => chain),
       update: vi.fn((payload: unknown) => {
         mode = "update";
         updateMock(payload);
@@ -86,9 +100,13 @@ function createSupabaseServiceRoleMock({
     return chain;
   });
 
-  return { from: fromMock, updateMock } as unknown as Parameters<
+  return { from: fromMock, updateMock, eqCalls, isCalls } as unknown as Parameters<
     typeof addSocialAccountConnections
-  >[0]["supabaseServiceRole"] & { updateMock: typeof updateMock };
+  >[0]["supabaseServiceRole"] & {
+    updateMock: typeof updateMock;
+    eqCalls: typeof eqCalls;
+    isCalls: typeof isCalls;
+  };
 }
 
 describe("addSocialAccountConnections stale asset reconciliation", () => {
@@ -98,9 +116,12 @@ describe("addSocialAccountConnections stale asset reconciliation", () => {
     getTikTokSocialProviderConnectionMock.mockReset();
   });
 
-  it("disconnects a previously-granted Facebook Page missing from the new grant", async () => {
+  it("disconnects a previously-granted Facebook Page missing from the new grant, scoped to the same Facebook login", async () => {
     getFacebookSocialProviderConnectionMock.mockResolvedValue([
-      connection({ social_provider_user_id: "page-a" }),
+      connection({
+        social_provider_user_id: "page-a",
+        social_provider_metadata: { facebook_user_id: "fb-user-1" },
+      }),
     ]);
 
     const staleConnection = {
@@ -112,7 +133,7 @@ describe("addSocialAccountConnections stale asset reconciliation", () => {
       external_id: null,
       access_token_expires_at: null,
       refresh_token_expires_at: null,
-      social_provider_metadata: null,
+      social_provider_metadata: { facebook_user_id: "fb-user-1" },
     };
 
     const supabaseServiceRole = createSupabaseServiceRoleMock({
@@ -137,6 +158,17 @@ describe("addSocialAccountConnections stale asset reconciliation", () => {
       refresh_token: null,
     });
 
+    // Reconciliation must be scoped to the Facebook login that produced this
+    // grant, and to "no external_id" since none was provided on this flow.
+    expect(supabaseServiceRole.eqCalls).toContainEqual({
+      column: "social_provider_metadata->>facebook_user_id",
+      value: "fb-user-1",
+    });
+    expect(supabaseServiceRole.isCalls).toContainEqual({
+      column: "external_id",
+      value: null,
+    });
+
     expect(batchTriggerMock).toHaveBeenCalledWith(
       "process-webhooks",
       expect.arrayContaining([
@@ -153,6 +185,63 @@ describe("addSocialAccountConnections stale asset reconciliation", () => {
         }),
       ])
     );
+  });
+
+  it("scopes reconciliation to the current external_id instead of every sub-account in the project", async () => {
+    getFacebookSocialProviderConnectionMock.mockResolvedValue([
+      connection({
+        social_provider_user_id: "page-a",
+        social_provider_metadata: { facebook_user_id: "fb-user-1" },
+      }),
+    ]);
+
+    const supabaseServiceRole = createSupabaseServiceRoleMock({
+      staleConnections: [],
+      insertedConnections: [{ id: "conn-page-a" }],
+    });
+
+    await addSocialAccountConnections({
+      projectId: "project-1",
+      provider: "facebook",
+      request: new Request("https://example.com/callback?code=abc"),
+      supabaseServiceRole,
+      isSystem: false,
+      appCredentials: { appId: "app-id", appSecret: "app-secret" },
+      externalId: "customer-a",
+      redirectUrlOverride: undefined,
+    });
+
+    expect(supabaseServiceRole.eqCalls).toContainEqual({
+      column: "external_id",
+      value: "customer-a",
+    });
+    expect(supabaseServiceRole.isCalls).not.toContainEqual({
+      column: "external_id",
+      value: null,
+    });
+  });
+
+  it("skips reconciliation when the new grant has no facebook_user_id (safe default)", async () => {
+    getFacebookSocialProviderConnectionMock.mockResolvedValue([
+      connection({ social_provider_user_id: "page-a" }),
+    ]);
+
+    const supabaseServiceRole = createSupabaseServiceRoleMock({
+      insertedConnections: [{ id: "conn-page-a" }],
+    });
+
+    await addSocialAccountConnections({
+      projectId: "project-1",
+      provider: "facebook",
+      request: new Request("https://example.com/callback?code=abc"),
+      supabaseServiceRole,
+      isSystem: false,
+      appCredentials: { appId: "app-id", appSecret: "app-secret" },
+      externalId: undefined,
+      redirectUrlOverride: undefined,
+    });
+
+    expect(supabaseServiceRole.updateMock).not.toHaveBeenCalled();
   });
 
   it("does not reconcile single-asset providers like tiktok", async () => {

--- a/dashboard/app/lib/.server/social-accounts/social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.ts
@@ -140,6 +140,66 @@ export async function addSocialAccountConnections({
     }
   }
 
+  const multiAssetProviders = new Set(["facebook", "instagram_w_facebook"]);
+
+  if (multiAssetProviders.has(provider) && connectionsToInsert.length > 0) {
+    const newSocialProviderUserIds = connectionsToInsert.map(
+      (c) => c.social_provider_user_id,
+    );
+
+    const { data: staleConnections, error: staleLookupError } =
+      await supabaseServiceRole
+        .from("social_provider_connections")
+        .select("*")
+        .eq("project_id", projectId)
+        .eq("provider", normalizedProvider as Provider)
+        .not("access_token", "is", null)
+        .not(
+          "social_provider_user_id",
+          "in",
+          `(${newSocialProviderUserIds.map((id) => `"${id}"`).join(",")})`,
+        );
+
+    if (staleLookupError) {
+      console.error(staleLookupError);
+    } else if (staleConnections && staleConnections.length > 0) {
+      const { error: reconcileError } = await supabaseServiceRole
+        .from("social_provider_connections")
+        .update({ access_token: null, refresh_token: null })
+        .in(
+          "id",
+          staleConnections.map((c) => c.id),
+        );
+
+      if (reconcileError) {
+        console.error(reconcileError);
+      } else {
+        const disconnectEvents = staleConnections.map((c) => ({
+          payload: {
+            projectId,
+            eventType: "social.account.updated",
+            eventData: {
+              id: c.id,
+              platform: c.provider || "",
+              username: c.social_provider_user_name || "",
+              user_id: c.social_provider_user_id || "",
+              profile_photo_url: c.social_provider_profile_photo_url,
+              status: "disconnected",
+              external_id: c.external_id,
+              access_token: "",
+              refresh_token: "",
+              access_token_expires_at:
+                c.access_token_expires_at || new Date().toISOString(),
+              refresh_token_expires_at: c.refresh_token_expires_at,
+              metadata: c.social_provider_metadata,
+            },
+          },
+        }));
+        await tasks.batchTrigger("process-webhooks", disconnectEvents);
+      }
+    }
+  }
+
   const { data: insertedConnections, error: connectionsError } =
     await supabaseServiceRole
       .from("social_provider_connections")

--- a/dashboard/app/lib/.server/social-accounts/social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.ts
@@ -140,6 +140,43 @@ export async function addSocialAccountConnections({
     }
   }
 
+  const { data: insertedConnections, error: connectionsError } =
+    await supabaseServiceRole
+      .from("social_provider_connections")
+      .upsert(connectionsToInsert, {
+        onConflict: "provider,project_id,social_provider_user_id",
+      })
+      .select();
+
+  if (insertedConnections && insertedConnections.length > 0) {
+    const events = insertedConnections.map((c) => ({
+      payload: {
+        projectId,
+        eventType: "social.account.created",
+        eventData: {
+          id: c.id,
+          platform: c.provider || "",
+          username: c.social_provider_user_name || "",
+          user_id: c.social_provider_user_id || "",
+          profile_photo_url: c.social_provider_profile_photo_url,
+          status: c.access_token ? "connected" : "disconnected",
+          external_id: c.external_id,
+          access_token: c.access_token || "",
+          refresh_token: c.refresh_token || "",
+          access_token_expires_at:
+            c.access_token_expires_at || new Date().toISOString(),
+          refresh_token_expires_at: c.refresh_token_expires_at,
+          metadata: c.social_provider_metadata,
+        },
+      },
+    }));
+    await tasks.batchTrigger("process-webhooks", events);
+  }
+
+  if (connectionsError) {
+    console.error(connectionsError);
+  }
+
   const multiAssetProviders = new Set(["facebook", "instagram_w_facebook"]);
 
   // The Facebook login that produced this grant. Reconciliation is scoped to
@@ -149,9 +186,13 @@ export async function addSocialAccountConnections({
   const facebookUserId = connectionsToInsert[0]?.social_provider_metadata
     ?.facebook_user_id as string | undefined;
 
+  // Only reconcile once the new grant is confirmed persisted — otherwise a
+  // failed upsert above would leave the user with the old Pages disconnected
+  // and none of the newly-granted ones saved.
   if (
     multiAssetProviders.has(provider) &&
-    connectionsToInsert.length > 0 &&
+    insertedConnections &&
+    insertedConnections.length > 0 &&
     facebookUserId
   ) {
     const newSocialProviderUserIds = connectionsToInsert.map(
@@ -218,42 +259,6 @@ export async function addSocialAccountConnections({
     }
   }
 
-  const { data: insertedConnections, error: connectionsError } =
-    await supabaseServiceRole
-      .from("social_provider_connections")
-      .upsert(connectionsToInsert, {
-        onConflict: "provider,project_id,social_provider_user_id",
-      })
-      .select();
-
-  if (insertedConnections && insertedConnections.length > 0) {
-    const events = insertedConnections.map((c) => ({
-      payload: {
-        projectId,
-        eventType: "social.account.created",
-        eventData: {
-          id: c.id,
-          platform: c.provider || "",
-          username: c.social_provider_user_name || "",
-          user_id: c.social_provider_user_id || "",
-          profile_photo_url: c.social_provider_profile_photo_url,
-          status: c.access_token ? "connected" : "disconnected",
-          external_id: c.external_id,
-          access_token: c.access_token || "",
-          refresh_token: c.refresh_token || "",
-          access_token_expires_at:
-            c.access_token_expires_at || new Date().toISOString(),
-          refresh_token_expires_at: c.refresh_token_expires_at,
-          metadata: c.social_provider_metadata,
-        },
-      },
-    }));
-    await tasks.batchTrigger("process-webhooks", events);
-  }
-
-  if (connectionsError) {
-    console.error(connectionsError);
-  }
   return {
     successConnections: insertedConnections?.map((i) => i.id) || [],
     failedConnections,

--- a/dashboard/app/lib/.server/social-accounts/social-account.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.ts
@@ -142,23 +142,41 @@ export async function addSocialAccountConnections({
 
   const multiAssetProviders = new Set(["facebook", "instagram_w_facebook"]);
 
-  if (multiAssetProviders.has(provider) && connectionsToInsert.length > 0) {
+  // The Facebook login that produced this grant. Reconciliation is scoped to
+  // it so re-linking one Facebook/Instagram login never touches Pages or IG
+  // accounts that belong to a different login (or a different external_id
+  // sub-account) connected to the same project.
+  const facebookUserId = connectionsToInsert[0]?.social_provider_metadata
+    ?.facebook_user_id as string | undefined;
+
+  if (
+    multiAssetProviders.has(provider) &&
+    connectionsToInsert.length > 0 &&
+    facebookUserId
+  ) {
     const newSocialProviderUserIds = connectionsToInsert.map(
       (c) => c.social_provider_user_id,
     );
 
+    let staleConnectionsQuery = supabaseServiceRole
+      .from("social_provider_connections")
+      .select("*")
+      .eq("project_id", projectId)
+      .eq("provider", normalizedProvider as Provider)
+      .eq("social_provider_metadata->>facebook_user_id", facebookUserId)
+      .not("access_token", "is", null)
+      .not(
+        "social_provider_user_id",
+        "in",
+        `(${newSocialProviderUserIds.map((id) => `"${id}"`).join(",")})`,
+      );
+
+    staleConnectionsQuery = externalId
+      ? staleConnectionsQuery.eq("external_id", externalId)
+      : staleConnectionsQuery.is("external_id", null);
+
     const { data: staleConnections, error: staleLookupError } =
-      await supabaseServiceRole
-        .from("social_provider_connections")
-        .select("*")
-        .eq("project_id", projectId)
-        .eq("provider", normalizedProvider as Provider)
-        .not("access_token", "is", null)
-        .not(
-          "social_provider_user_id",
-          "in",
-          `(${newSocialProviderUserIds.map((id) => `"${id}"`).join(",")})`,
-        );
+      await staleConnectionsQuery;
 
     if (staleLookupError) {
       console.error(staleLookupError);

--- a/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.test.ts
+++ b/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/lib/.server/supabase", () => ({
+  withSupabase: (handler: unknown) => handler,
+}));
+
+const addSocialAccountConnectionsMock = vi.fn();
+vi.mock("~/lib/.server/social-accounts/social-account", () => ({
+  addSocialAccountConnections: (...args: unknown[]) =>
+    addSocialAccountConnectionsMock(...args),
+}));
+
+import { loader } from "./route.loader";
+
+function buildRequest(query: string) {
+  return new Request(
+    `https://example.com/callback/project-1/facebook/account${query}`
+  );
+}
+
+const supabase = {
+  auth: {
+    getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+  },
+};
+
+const supabaseServiceRole = {
+  from: vi.fn(() => {
+    throw new Error("supabaseServiceRole should not be queried");
+  }),
+};
+
+describe("callback.$projectId.$provider.account loader", () => {
+  beforeEach(() => {
+    addSocialAccountConnectionsMock.mockReset();
+  });
+
+  it("surfaces the Facebook denial reason without exchanging a code", async () => {
+    const request = buildRequest(
+      "?error=access_denied&error_reason=user_denied&error_description=User%20denied%20the%20request&state=abc"
+    );
+
+    const result = (await loader({
+      request,
+      params: { projectId: "project-1", provider: "facebook" },
+      supabase,
+      supabaseServiceRole,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)) as any;
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.provider).toBe("facebook");
+    expect(result.projectId).toBe("project-1");
+    expect(result.error).toContain("User denied the request");
+    expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to error_reason when no description is present", async () => {
+    const request = buildRequest(
+      "?error=access_denied&error_reason=user_denied&state=abc"
+    );
+
+    const result = (await loader({
+      request,
+      params: { projectId: "project-1", provider: "facebook" },
+      supabase,
+      supabaseServiceRole,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)) as any;
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.error).toContain("user_denied");
+    expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.test.ts
+++ b/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.test.ts
@@ -24,10 +24,32 @@ const supabase = {
   },
 };
 
-const supabaseServiceRole = {
-  from: vi.fn(() => {
-    throw new Error("supabaseServiceRole should not be queried");
-  }),
+function createSupabaseServiceRoleMock({
+  project,
+}: {
+  project: Record<string, unknown> | null;
+}) {
+  const from = vi.fn((table: string) => {
+    if (table === "projects") {
+      const chain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        single: vi.fn().mockResolvedValue({ data: project, error: null }),
+      };
+      return chain;
+    }
+
+    throw new Error(`Unexpected table queried: ${table}`);
+  });
+
+  return { from };
+}
+
+const baseProject = {
+  auth_callback_url: null,
+  team_id: "team-1",
+  is_system: false,
+  social_provider_app_credentials: [],
 };
 
 describe("callback.$projectId.$provider.account loader", () => {
@@ -44,13 +66,16 @@ describe("callback.$projectId.$provider.account loader", () => {
       request,
       params: { projectId: "project-1", provider: "facebook" },
       supabase,
-      supabaseServiceRole,
+      supabaseServiceRole: createSupabaseServiceRoleMock({
+        project: baseProject,
+      }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)) as any;
 
     expect(result.isSuccess).toBe(false);
     expect(result.provider).toBe("facebook");
     expect(result.projectId).toBe("project-1");
+    expect(result.teamId).toBe("team-1");
     expect(result.error).toContain("User denied the request");
     expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
   });
@@ -64,12 +89,41 @@ describe("callback.$projectId.$provider.account loader", () => {
       request,
       params: { projectId: "project-1", provider: "facebook" },
       supabase,
-      supabaseServiceRole,
+      supabaseServiceRole: createSupabaseServiceRoleMock({
+        project: baseProject,
+      }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)) as any;
 
     expect(result.isSuccess).toBe(false);
     expect(result.error).toContain("user_denied");
+    expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the project's callback URL with the denial reason when one is configured", async () => {
+    const request = buildRequest(
+      "?error=access_denied&error_reason=user_denied&error_description=User%20denied%20the%20request&state=abc"
+    );
+
+    const result = await loader({
+      request,
+      params: { projectId: "project-1", provider: "facebook" },
+      supabase,
+      supabaseServiceRole: createSupabaseServiceRoleMock({
+        project: {
+          ...baseProject,
+          auth_callback_url: "https://customer.example.com/callback",
+        },
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    // react-router's redirect() returns a Response
+    expect(result).toBeInstanceOf(Response);
+    const location = (result as Response).headers.get("Location");
+    expect(location).toContain("https://customer.example.com/callback");
+    expect(location).toContain("isSuccess=false");
+    expect(location).toContain("User+denied+the+request");
     expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
@@ -26,6 +26,22 @@ export const loader = withSupabase(async function ({
     });
   }
 
+  const oauthError = url.searchParams.get("error");
+
+  if (oauthError) {
+    return createResponse({
+      isSuccess: false,
+      errors: [
+        url.searchParams.get("error_description") ||
+          url.searchParams.get("error_reason") ||
+          `Authorization was denied (${oauthError})`,
+      ],
+      projectId,
+      provider,
+      isLoggedIn,
+    });
+  }
+
   const key =
     (url.searchParams.get("oauth_token") as string) ||
     (url.searchParams.get("state") as string);

--- a/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
@@ -26,34 +26,6 @@ export const loader = withSupabase(async function ({
     });
   }
 
-  const oauthError = url.searchParams.get("error");
-
-  if (oauthError) {
-    return createResponse({
-      isSuccess: false,
-      errors: [
-        url.searchParams.get("error_description") ||
-          url.searchParams.get("error_reason") ||
-          `Authorization was denied (${oauthError})`,
-      ],
-      projectId,
-      provider,
-      isLoggedIn,
-    });
-  }
-
-  const key =
-    (url.searchParams.get("oauth_token") as string) ||
-    (url.searchParams.get("state") as string);
-
-  if (!key) {
-    return createResponse({
-      isSuccess: false,
-      errors: ["Auth state not set"],
-      isLoggedIn,
-    });
-  }
-
   const { data: project, error: projectError } = await supabaseServiceRole
     .from("projects")
     .select(
@@ -78,6 +50,36 @@ export const loader = withSupabase(async function ({
       errors: ["Project not found"],
       projectId,
       provider,
+      isLoggedIn,
+    });
+  }
+
+  const oauthError = url.searchParams.get("error");
+
+  if (oauthError) {
+    return createResponse({
+      isSuccess: false,
+      errors: [
+        url.searchParams.get("error_description") ||
+          url.searchParams.get("error_reason") ||
+          `Authorization was denied (${oauthError})`,
+      ],
+      projectId,
+      provider,
+      teamId: project.team_id,
+      callbackUrl: project.auth_callback_url,
+      isLoggedIn,
+    });
+  }
+
+  const key =
+    (url.searchParams.get("oauth_token") as string) ||
+    (url.searchParams.get("state") as string);
+
+  if (!key) {
+    return createResponse({
+      isSuccess: false,
+      errors: ["Auth state not set"],
       isLoggedIn,
     });
   }

--- a/dashboard/app/routes/callback.$provider.account/route.loader.test.ts
+++ b/dashboard/app/routes/callback.$provider.account/route.loader.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/lib/.server/supabase", () => ({
+  withSupabase: (handler: unknown) => handler,
+}));
+
+const addSocialAccountConnectionsMock = vi.fn();
+vi.mock("~/lib/.server/social-accounts/social-account", () => ({
+  addSocialAccountConnections: (...args: unknown[]) =>
+    addSocialAccountConnectionsMock(...args),
+}));
+
+import { loader } from "./route.loader";
+
+function buildRequest(query: string) {
+  return new Request(`https://example.com/callback/facebook/account${query}`);
+}
+
+const supabase = {
+  auth: {
+    getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+  },
+};
+
+const supabaseServiceRole = {
+  from: vi.fn(() => {
+    throw new Error("supabaseServiceRole should not be queried");
+  }),
+};
+
+describe("callback.$provider.account loader (system project)", () => {
+  beforeEach(() => {
+    addSocialAccountConnectionsMock.mockReset();
+  });
+
+  it("surfaces the Facebook denial reason before looking up oauth state", async () => {
+    const request = buildRequest(
+      "?error=access_denied&error_reason=user_denied&error_description=User%20denied%20the%20request&state=abc"
+    );
+
+    const result = (await loader({
+      request,
+      params: { provider: "facebook" },
+      supabase,
+      supabaseServiceRole,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)) as any;
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.provider).toBe("facebook");
+    expect(result.error).toContain("User denied the request");
+    expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/routes/callback.$provider.account/route.loader.test.ts
+++ b/dashboard/app/routes/callback.$provider.account/route.loader.test.ts
@@ -22,10 +22,52 @@ const supabase = {
   },
 };
 
-const supabaseServiceRole = {
-  from: vi.fn(() => {
-    throw new Error("supabaseServiceRole should not be queried");
-  }),
+function createSupabaseServiceRoleMock({
+  oauthData,
+  project,
+}: {
+  oauthData: Record<string, unknown>[];
+  project: Record<string, unknown> | null;
+}) {
+  const from = vi.fn((table: string) => {
+    if (table === "social_provider_connection_oauth_data") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chain: any = {
+        select: vi.fn(() => chain),
+        in: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        then: (
+          resolve: (value: { data: unknown; error: unknown }) => unknown,
+          reject: (reason: unknown) => unknown
+        ) =>
+          Promise.resolve({ data: oauthData, error: null }).then(
+            resolve,
+            reject
+          ),
+      };
+      return chain;
+    }
+
+    if (table === "projects") {
+      const chain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        single: vi.fn().mockResolvedValue({ data: project, error: null }),
+      };
+      return chain;
+    }
+
+    throw new Error(`Unexpected table queried: ${table}`);
+  });
+
+  return { from };
+}
+
+const baseProject = {
+  auth_callback_url: null,
+  team_id: "team-1",
+  is_system: true,
+  social_provider_app_credentials: [],
 };
 
 describe("callback.$provider.account loader (system project)", () => {
@@ -33,10 +75,70 @@ describe("callback.$provider.account loader (system project)", () => {
     addSocialAccountConnectionsMock.mockReset();
   });
 
-  it("surfaces the Facebook denial reason before looking up oauth state", async () => {
+  it("surfaces the Facebook denial reason once the oauth state resolves the project", async () => {
     const request = buildRequest(
       "?error=access_denied&error_reason=user_denied&error_description=User%20denied%20the%20request&state=abc"
     );
+
+    const result = (await loader({
+      request,
+      params: { provider: "facebook" },
+      supabase,
+      supabaseServiceRole: createSupabaseServiceRoleMock({
+        oauthData: [
+          { key: "project", project_id: "project-1", value: null },
+        ],
+        project: baseProject,
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)) as any;
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.provider).toBe("facebook");
+    expect(result.projectId).toBe("project-1");
+    expect(result.teamId).toBe("team-1");
+    expect(result.error).toContain("User denied the request");
+    expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the project's callback URL with the denial reason when one is configured", async () => {
+    const request = buildRequest(
+      "?error=access_denied&error_reason=user_denied&error_description=User%20denied%20the%20request&state=abc"
+    );
+
+    const result = await loader({
+      request,
+      params: { provider: "facebook" },
+      supabase,
+      supabaseServiceRole: createSupabaseServiceRoleMock({
+        oauthData: [
+          { key: "project", project_id: "project-1", value: null },
+        ],
+        project: {
+          ...baseProject,
+          auth_callback_url: "https://customer.example.com/callback",
+        },
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    expect(result).toBeInstanceOf(Response);
+    const location = (result as Response).headers.get("Location");
+    expect(location).toContain("https://customer.example.com/callback");
+    expect(location).toContain("isSuccess=false");
+    expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
+  });
+
+  it("still returns 'Auth state not set' when no state is present, without querying the database", async () => {
+    const request = buildRequest(
+      "?error=access_denied&error_reason=user_denied"
+    );
+
+    const supabaseServiceRole = {
+      from: vi.fn(() => {
+        throw new Error("supabaseServiceRole should not be queried");
+      }),
+    };
 
     const result = (await loader({
       request,
@@ -47,8 +149,7 @@ describe("callback.$provider.account loader (system project)", () => {
     } as any)) as any;
 
     expect(result.isSuccess).toBe(false);
-    expect(result.provider).toBe("facebook");
-    expect(result.error).toContain("User denied the request");
+    expect(result.error).toBe("Auth state not set");
     expect(addSocialAccountConnectionsMock).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/app/routes/callback.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$provider.account/route.loader.ts
@@ -17,6 +17,21 @@ export const loader = withSupabase(async function ({
 
   let { provider } = params;
 
+  const oauthError = url.searchParams.get("error");
+
+  if (oauthError) {
+    return createResponse({
+      isSuccess: false,
+      errors: [
+        url.searchParams.get("error_description") ||
+          url.searchParams.get("error_reason") ||
+          `Authorization was denied (${oauthError})`,
+      ],
+      provider,
+      isLoggedIn,
+    });
+  }
+
   const key =
     (url.searchParams.get("oauth_token") as string) ||
     (url.searchParams.get("state") as string);

--- a/dashboard/app/routes/callback.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$provider.account/route.loader.ts
@@ -17,21 +17,6 @@ export const loader = withSupabase(async function ({
 
   let { provider } = params;
 
-  const oauthError = url.searchParams.get("error");
-
-  if (oauthError) {
-    return createResponse({
-      isSuccess: false,
-      errors: [
-        url.searchParams.get("error_description") ||
-          url.searchParams.get("error_reason") ||
-          `Authorization was denied (${oauthError})`,
-      ],
-      provider,
-      isLoggedIn,
-    });
-  }
-
   const key =
     (url.searchParams.get("oauth_token") as string) ||
     (url.searchParams.get("state") as string);
@@ -117,6 +102,24 @@ export const loader = withSupabase(async function ({
       errors: ["Project not found"],
       projectId,
       provider: normalizedProvider,
+      isLoggedIn,
+    });
+  }
+
+  const oauthError = url.searchParams.get("error");
+
+  if (oauthError) {
+    return createResponse({
+      isSuccess: false,
+      errors: [
+        url.searchParams.get("error_description") ||
+          url.searchParams.get("error_reason") ||
+          `Authorization was denied (${oauthError})`,
+      ],
+      projectId,
+      provider: normalizedProvider,
+      teamId: project.team_id,
+      callbackUrl: project.auth_callback_url,
       isLoggedIn,
     });
   }


### PR DESCRIPTION
## Summary

When a user re-links a previously-connected Facebook (or Instagram-via-Facebook) account, Meta shows a "Continue as X" shortcut dialog that re-authorizes only the assets granted last time, so a newly added Page never gets offered — the flow "succeeds" silently and users have to know to dig into "Edit settings" manually. This adds `auth_type=rerequest` to the Facebook OAuth URL to force the full asset picker to show, plus fixes two adjacent gaps in the same re-link path that become more visible once users actually see that picker.

It also promotes this "force reauthorization" behavior into a single top-level `force_reauth` parameter on the create-auth-url endpoint, since several other providers turned out to have the same kind of mechanism already hardcoded on or off (TikTok, YouTube) or available but unused (native Instagram, X oauth1) — rather than a one-off `platform_data.facebook.force_reauth` toggle, callers get one consistent switch across every provider that supports it.

## Changes

- **`api/src/social-provider-connections/helper/auth-url.helper.ts`** — add `auth_type=rerequest` to the Facebook OAuth authorize URL for both the `facebook` and `instagram_w_facebook` cases (both hit the same `facebook.com/.../dialog/oauth` endpoint). Native `instagram` login and all other providers are untouched.
- **`dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts`** and **`dashboard/app/routes/callback.$provider.account/route.loader.ts`** — read `error`/`error_reason`/`error_description` from the OAuth redirect and short-circuit with a clear denial message, instead of falling through to a generic "No code provided" / "Internal Error" when a user declines the Facebook dialog. The denial check runs *after* the project (and, on the system callback route, the oauth state) resolves, so the response still carries `teamId`/`callbackUrl`/`projectId` — needed both for the dashboard's own "View Accounts" link and for redirecting embedded integrations back to their configured `auth_callback_url` on denial.
- **`dashboard/app/lib/.server/social-accounts/social-account.ts`** — on a Facebook/Instagram-via-Facebook re-auth, Pages/IG accounts that were previously connected but are missing from the new grant get soft-disconnected (tokens nulled, row preserved — mirrors the existing `disconnectSocialAccount` pattern) and fire a `social.account.updated` webhook. Scoped to `facebook`/`instagram_w_facebook` only, since they're the only providers where one OAuth flow can yield multiple asset connections. Reconciliation runs *after* the new grant is confirmed persisted (not before), so a failed upsert can't leave a user's previously-connected Pages disconnected with nothing new saved in their place.
- **`api/src/social-provider-connections/dto/create-provider-auth-url.dto.ts`**, **`.../helper/auth-url.helper.ts`**, **`.../social-provider-connections.controller.ts`**, **`.../social-provider-connections.service.ts`** — add a top-level `force_reauth?: boolean` request parameter, threaded from the controller through to `generateAuthUrl`. Wired into every provider case with a real "force reauth" mechanism:
  - `facebook` / `instagram_w_facebook` — `auth_type=rerequest` (default **on**, matches the behavior above).
  - `instagram` (native) — `force_reauth=<bool>` query param (default **off**, matches current shipped behavior).
  - `tiktok` / `tiktok_business` — `disable_auto_auth=1` (default **on**, matches current shipped behavior — previously hardcoded, now optional).
  - `youtube` — Google's `prompt=consent` (default **on**, matches current shipped behavior — previously hardcoded, now optional). Uses a conditional spread rather than `prompt: undefined`, since `google-auth-library` serializes options with `querystring.stringify`, which turns an explicit `undefined` value into a literal `prompt=` rather than omitting the key.
  - `x` (oauth1) — `forceLogin` option on `twitter-api-v2`'s `generateAuthLink` (default **off**, previously unused).
  - `x_oauth2`, `pinterest`, `linkedin`, `threads`, `bluesky` have no equivalent mechanism and silently ignore the parameter.
  - Each provider keeps its own current default when `force_reauth` is omitted, so no existing integration's behavior changes unless it explicitly passes the parameter.

No new dependencies, env vars, or migrations.

## Testing

- `bun run typecheck` and `bun run lint` pass in both `api/` and `dashboard/`.
- Unit tests:
  - `api/src/social-provider-connections/helper/auth-url.helper.spec.ts` (Jest, 18 tests) — default + explicit-override coverage for every provider that honors `force_reauth` (`facebook`, `instagram_w_facebook`, native `instagram`, `tiktok`, `tiktok_business`, `youtube`, `x` oauth1 via a `TwitterApi.prototype.generateAuthLink` spy), plus a regression guard that unsupported providers don't add `auth_type`.
  - `dashboard/app/routes/callback.$projectId.$provider.account/route.loader.test.ts` and the `callback.$provider.account` sibling (Vitest, 3 tests each) — a Facebook denial short-circuits with the real message and never reaches `addSocialAccountConnections`; the denial response redirects to the project's `callbackUrl` when one is configured; a missing `state` still short-circuits without touching the database.
  - `dashboard/app/lib/.server/social-accounts/social-account.test.ts` (Vitest, 4 tests) — a Page missing from a re-auth gets soft-disconnected and fires a webhook; single-asset providers (e.g. TikTok) never trigger reconciliation; reconciliation is scoped to `external_id`; a grant with no `facebook_user_id` skips reconciliation.
- `bun run test` passes in both siblings (18 in `api/`, 10 in `dashboard/`).
- Not yet manually verified end-to-end against a live Facebook test app (triggering the actual "Continue as X" shortcut requires a pre-connected test user) — recommend doing that pass before merge.

## Notes

- If a user deselects every asset during re-auth (ends up with zero granted Pages), reconciliation is skipped rather than disconnecting everything — the loader already treats zero successful connections as a full failure. Flagged as a known limitation, not blocking.
- The TikTok `disable_auto_auth` and native-Instagram `force_reauth` mechanisms are exercised via the existing hardcoded values already live in production; there's no public Meta/TikTok documentation confirming their exact semantics, so this is based on the working code, not an official spec.
- Investigated PFM-979 findings and full implementation plan: https://linear.app/day-moon/issue/PFM-979

Closes PFM-979

🤖 Generated with [Claude Code](https://claude.com/claude-code)