### PR TITLE
feat(dashboard): upgrade data tables to ReUI Data Grid on TanStack Table v9 (PFM-978)

### DIFF
--- a/dashboard/app/routes/_protected.$teamId.$projectId.accounts.$accountId._index/_columns.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.accounts.$accountId._index/_columns.tsx
@@ -1,16 +1,8 @@
-import { ArrowUpDown } from "lucide-react";
-import { Button } from "~/ui/button";
 import { Badge } from "~/ui/badge";
+import { DataGridColumnHeader, type DataGridColumnDef } from "~/ui/data-grid";
+
 import type { PlatformPost } from "./_types";
 import type { PostMetrics } from "./_types";
-import type { ColumnDef } from "@tanstack/react-table";
-
-export type CustomColumnDef<TData, TValue = unknown> = ColumnDef<
-  TData,
-  TValue
-> & {
-  label?: string;
-};
 
 const providerColors = {
   facebook: "bg-blue-500",
@@ -63,26 +55,18 @@ function getEngagement(metrics: PostMetrics | undefined): number {
   );
 }
 
-export const columns: CustomColumnDef<PlatformPost>[] = [
+export const columns: DataGridColumnDef<PlatformPost>[] = [
   {
-    label: "Posted At",
+    meta: { headerTitle: "Posted At" },
     id: "posted_at",
     accessorFn: (row) => {
       if (!row.posted_at) return 0;
       const d = new Date(row.posted_at);
       return Number.isNaN(d.getTime()) ? 0 : d.getTime();
     },
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Posted At
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Posted At" />
+    ),
     cell: ({ row }) => {
       const date = row.original.posted_at;
       if (!date) return <div className="text-muted-foreground">N/A</div>;
@@ -90,7 +74,7 @@ export const columns: CustomColumnDef<PlatformPost>[] = [
     },
   },
   {
-    label: "Caption",
+    meta: { headerTitle: "Caption" },
     accessorKey: "caption",
     header: "Caption",
     cell: ({ row }) => {
@@ -107,7 +91,7 @@ export const columns: CustomColumnDef<PlatformPost>[] = [
     },
   },
   {
-    label: "Platform",
+    meta: { headerTitle: "Platform" },
     accessorKey: "platform",
     header: "Platform",
     cell: ({ row }) => {
@@ -120,120 +104,72 @@ export const columns: CustomColumnDef<PlatformPost>[] = [
     },
   },
   {
-    label: "Likes",
+    meta: { headerTitle: "Likes" },
     id: "likes",
     accessorFn: (row) => row.metrics?.likes ?? 0,
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Likes
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Likes" />
+    ),
     cell: ({ row }) => {
       const likes = row.getValue("likes") as number;
       return <div className="font-medium">{formatNumber(likes)}</div>;
     },
   },
   {
-    label: "Comments",
+    meta: { headerTitle: "Comments" },
     id: "comments",
     accessorFn: (row) => row.metrics?.comments ?? 0,
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Comments
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Comments" />
+    ),
     cell: ({ row }) => {
       const comments = row.getValue("comments") as number;
       return <div className="font-medium">{formatNumber(comments)}</div>;
     },
   },
   {
-    label: "Shares",
+    meta: { headerTitle: "Shares" },
     id: "shares",
     accessorFn: (row) => row.metrics?.shares ?? 0,
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Shares
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Shares" />
+    ),
     cell: ({ row }) => {
       const shares = row.getValue("shares") as number;
       return <div className="font-medium">{formatNumber(shares)}</div>;
     },
   },
   {
-    label: "Views",
+    meta: { headerTitle: "Views" },
     id: "views",
     accessorFn: (row) => getViews(row.metrics),
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Views
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Views" />
+    ),
     cell: ({ row }) => {
       const views = row.getValue("views") as number;
       return <div className="font-medium">{formatNumber(views)}</div>;
     },
   },
   {
-    label: "Reach",
+    meta: { headerTitle: "Reach" },
     id: "reach",
     accessorFn: (row) => row.metrics?.reach ?? 0,
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Reach
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Reach" />
+    ),
     cell: ({ row }) => {
       const reach = row.getValue("reach") as number;
       return <div className="font-medium">{formatNumber(reach)}</div>;
     },
   },
   {
-    label: "Watch Time",
+    meta: { headerTitle: "Watch Time" },
     id: "watch_time",
     accessorFn: (row) => row.metrics?.total_time_watched ?? 0,
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Watch Time
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Watch Time" />
+    ),
     cell: ({ row }) => {
       const watchTime = row.getValue("watch_time") as number;
       return (
@@ -244,27 +180,19 @@ export const columns: CustomColumnDef<PlatformPost>[] = [
     },
   },
   {
-    label: "Engagement",
+    meta: { headerTitle: "Engagement" },
     id: "engagement",
     accessorFn: (row) => getEngagement(row.metrics),
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Engagement
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Engagement" />
+    ),
     cell: ({ row }) => {
       const engagement = row.getValue("engagement") as number;
       return <div className="font-medium">{formatNumber(engagement)}</div>;
     },
   },
   {
-    label: "Platform URL",
+    meta: { headerTitle: "Platform URL" },
     accessorKey: "platform_url",
     header: "Link",
     cell: ({ row }) => {

--- a/dashboard/app/routes/_protected.$teamId.$projectId.accounts.$accountId._index/_data-table.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.accounts.$accountId._index/_data-table.tsx
@@ -1,51 +1,30 @@
 import * as React from "react";
-import {
-  flexRender,
-  getCoreRowModel,
-  getFilteredRowModel,
-  getSortedRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
-import { ChevronDown } from "lucide-react";
+import { useTable } from "@tanstack/react-table";
 import { useLoaderData } from "react-router";
 
 import { Button } from "~/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "~/ui/dropdown-menu";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "~/ui/table";
+  DataGridColumnVisibility,
+  DataGridTable,
+  dataGridFeatures,
+} from "~/ui/data-grid";
 
-import { columns, type CustomColumnDef } from "./_columns";
-import type { PlatformPost } from "./_types";
+import { columns } from "./_columns";
+
 import type {
-  ColumnFiltersState,
+  ColumnVisibilityState,
   SortingState,
-  VisibilityState,
 } from "@tanstack/react-table";
 
 export function AccountFeedDataTable() {
   const data = useLoaderData();
   const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    [],
-  );
   const [columnVisibility, setColumnVisibility] =
-    React.useState<VisibilityState>({
+    React.useState<ColumnVisibilityState>({
       engagement: false,
       reach: false,
       watch_time: false,
     });
-  const [rowSelection, setRowSelection] = React.useState({});
 
   const isYouTube = data.accountInfo?.provider === "youtube";
 
@@ -61,22 +40,13 @@ export function AccountFeedDataTable() {
 
   const posts = React.useMemo(() => data.posts || [], [data.posts]);
 
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data: posts,
-    columns: tableColumns as CustomColumnDef<PlatformPost>[],
+    columns: tableColumns,
+    state: { sorting, columnVisibility },
     onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
-    onRowSelectionChange: setRowSelection,
-    state: {
-      sorting,
-      columnFilters,
-      columnVisibility,
-      rowSelection,
-    },
   });
 
   if (!data.success) {
@@ -92,85 +62,14 @@ export function AccountFeedDataTable() {
   return (
     <div className="w-full space-y-4">
       <div className="flex items-center justify-end">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="ml-auto bg-card">
-              Columns <ChevronDown className="ml-2 h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {table
-              .getAllColumns()
-              .filter((column) => column.getCanHide())
-              .map((column) => {
-                return (
-                  <DropdownMenuCheckboxItem
-                    key={column.id}
-                    className="capitalize"
-                    checked={column.getIsVisible()}
-                    onCheckedChange={(value) =>
-                      column.toggleVisibility(!!value)
-                    }
-                  >
-                    {(column.columnDef as CustomColumnDef<PlatformPost>)
-                      .label ?? column.id}
-                  </DropdownMenuCheckboxItem>
-                );
-              })}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <DataGridColumnVisibility table={table} />
       </div>
 
-      <div className="bg-card rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() ? "selected" : null}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={tableColumns.length}
-                  className="h-24 text-center"
-                >
-                  No posts found for this account.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <DataGridTable
+        table={table}
+        columnCount={tableColumns.length}
+        emptyMessage="No posts found for this account."
+      />
 
       {data.meta.has_more ? (
         <div className="flex justify-center">

--- a/dashboard/app/routes/_protected.$teamId.$projectId.accounts._index/_columns.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.accounts._index/_columns.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpDown, MoreHorizontal, User } from "lucide-react";
+import { MoreHorizontal, User } from "lucide-react";
 import { useFetcher, useNavigate, useParams } from "react-router";
 
 import { Button } from "~/ui/button";
@@ -13,16 +13,9 @@ import {
   DropdownMenuTrigger,
 } from "~/ui/dropdown-menu";
 import { Switch } from "~/ui/switch";
+import { DataGridColumnHeader, type DataGridColumnDef } from "~/ui/data-grid";
 
 import type { SocialConnection } from "./_types";
-import type { ColumnDef } from "@tanstack/react-table";
-
-export type CustomColumnDef<TData, TValue = unknown> = ColumnDef<
-  TData,
-  TValue
-> & {
-  label?: string;
-};
 
 const providerColors = {
   facebook: "bg-blue-500",
@@ -36,11 +29,12 @@ const providerColors = {
   threads: "bg-purple-500",
 } as const;
 
-export const columns: CustomColumnDef<SocialConnection>[] = [
+export const columns: DataGridColumnDef<SocialConnection>[] = [
   {
-    label: "Social Provider Profile Photo Url",
+    meta: { headerTitle: "Social Provider Profile Photo Url" },
     accessorKey: "social_provider_profile_photo_url",
     header: "",
+    enableSorting: false,
     cell: ({ row }) => {
       const connection = row.original;
       return (
@@ -57,19 +51,11 @@ export const columns: CustomColumnDef<SocialConnection>[] = [
     },
   },
   {
-    label: "Provider",
+    meta: { headerTitle: "Provider" },
     accessorKey: "provider",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Provider
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Provider" />
+    ),
     cell: ({ row }) => {
       const provider = row.getValue("provider") as keyof typeof providerColors;
       return (
@@ -80,26 +66,18 @@ export const columns: CustomColumnDef<SocialConnection>[] = [
     },
   },
   {
-    label: "Social Provider User Name",
+    meta: { headerTitle: "Social Provider User Name" },
     accessorKey: "social_provider_user_name",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Username
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Username" />
+    ),
     cell: ({ row }) => {
       const username = row.getValue("social_provider_user_name") as string;
       return <div className="font-medium">{username || "N/A"}</div>;
     },
   },
   {
-    label: "User Id",
+    meta: { headerTitle: "User Id" },
     accessorKey: "social_provider_user_id",
     header: "User ID",
     cell: ({ row }) => {
@@ -110,7 +88,7 @@ export const columns: CustomColumnDef<SocialConnection>[] = [
     },
   },
   {
-    label: "External Id",
+    meta: { headerTitle: "External Id" },
     accessorKey: "external_id",
     header: "External ID",
     cell: ({ row }) => {
@@ -123,7 +101,7 @@ export const columns: CustomColumnDef<SocialConnection>[] = [
     },
   },
   {
-    label: "Status",
+    meta: { headerTitle: "Status" },
     accessorKey: "status",
     header: "Status",
     cell: ({ row }) => {
@@ -134,19 +112,11 @@ export const columns: CustomColumnDef<SocialConnection>[] = [
     },
   },
   {
-    label: "Created At",
+    meta: { headerTitle: "Created At" },
     accessorKey: "created_at",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Connected
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Connected" />
+    ),
     cell: ({ row }) => {
       const date = new Date(row.getValue("created_at"));
       return <div>{date.toLocaleDateString()}</div>;

--- a/dashboard/app/routes/_protected.$teamId.$projectId.accounts._index/_data-table.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.accounts._index/_data-table.tsx
@@ -1,40 +1,18 @@
 import * as React from "react";
-import {
-  flexRender,
-  getCoreRowModel,
-  getFilteredRowModel,
-  getSortedRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
-import { ChevronDown } from "lucide-react";
+import { useTable } from "@tanstack/react-table";
 
-import { Button } from "~/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "~/ui/dropdown-menu";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "~/ui/table";
-import { Copyable } from "~/components/copyable";
+  DataGridColumnVisibility,
+  DataGridTable,
+  dataGridFeatures,
+} from "~/ui/data-grid";
 
-import { columns, type CustomColumnDef } from "./_columns";
+import { columns } from "./_columns";
 import { TableFilters } from "./_table-filters";
 import { TablePagination } from "./_table-pagination";
 
-import type { LoaderData, SocialConnection } from "./_types";
-import type {
-  ColumnFiltersState,
-  SortingState,
-  VisibilityState,
-} from "@tanstack/react-table";
+import type { LoaderData } from "./_types";
+import type { SortingState } from "@tanstack/react-table";
 
 interface DataTableProps {
   data: LoaderData;
@@ -42,34 +20,20 @@ interface DataTableProps {
 
 export function SocialConnectionsDataTable({ data }: DataTableProps) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    [],
-  );
-  const [columnVisibility, setColumnVisibility] =
-    React.useState<VisibilityState>({});
-  const [rowSelection, setRowSelection] = React.useState({});
+  const [columnVisibility, setColumnVisibility] = React.useState({});
 
   const connections = React.useMemo(
     () => data.connections || [],
     [data.connections],
   );
 
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data: connections,
-    columns: columns as CustomColumnDef<SocialConnection>[],
+    columns,
+    state: { sorting, columnVisibility },
     onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
-    onRowSelectionChange: setRowSelection,
-    state: {
-      sorting,
-      columnFilters,
-      columnVisibility,
-      rowSelection,
-    },
   });
 
   if (!data.success) {
@@ -86,96 +50,14 @@ export function SocialConnectionsDataTable({ data }: DataTableProps) {
     <div className="w-full space-y-4">
       <div className="flex items-center justify-between">
         <TableFilters />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="ml-auto bg-card">
-              Columns <ChevronDown className="ml-2 h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {table
-              .getAllColumns()
-              .filter((column) => column.getCanHide())
-              .map((column) => {
-                return (
-                  <DropdownMenuCheckboxItem
-                    key={column.id}
-                    className="capitalize"
-                    checked={column.getIsVisible()}
-                    onCheckedChange={(value) =>
-                      column.toggleVisibility(!!value)
-                    }
-                  >
-                    {(column.columnDef as CustomColumnDef<SocialConnection>)
-                      .label ?? column.id}
-                  </DropdownMenuCheckboxItem>
-                );
-              })}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <DataGridColumnVisibility table={table} />
       </div>
 
-      <div className="bg-card rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() ? "selected" : null}
-                  className="cursor-pointer hover:bg-muted/50"
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {cell.column.id === "username" ||
-                      cell.column.id === "userId" ? (
-                        <Copyable value={String(cell.getValue())}>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext(),
-                          )}
-                        </Copyable>
-                      ) : (
-                        flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
-                >
-                  No social connections found.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <DataGridTable
+        table={table}
+        columnCount={columns.length}
+        emptyMessage="No social connections found."
+      />
 
       <TablePagination data={data} />
     </div>

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_columns.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_columns.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useRevalidator } from "react-router";
-import { ArrowUpDownIcon, MoreHorizontalIcon } from "lucide-react";
+import { MoreHorizontalIcon } from "lucide-react";
 
 import {
   CalendarClock4Icon,
@@ -33,8 +33,8 @@ import {
 } from "~/ui/dialog";
 
 import { useForm as useFormFetcher } from "~/hooks/use-form";
+import { DataGridColumnHeader, type DataGridColumnDef } from "~/ui/data-grid";
 
-import type { ColumnDef } from "@tanstack/react-table";
 import type { PostWithConnections } from "./_types";
 import { format } from "date-fns";
 
@@ -76,22 +76,13 @@ const providerColors = {
   threads: "bg-purple-500",
 } as const;
 
-export const columns: ColumnDef<PostWithConnections>[] = [
+export const columns: DataGridColumnDef<PostWithConnections>[] = [
   {
     accessorKey: "status",
-    header: ({ column }) => {
-      return (
-        <div className="flex justify-center">
-          <Button
-            variant="ghost"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          >
-            Status
-            <ArrowUpDownIcon className="ml-2 h-4 w-4" />
-          </Button>
-        </div>
-      );
-    },
+    meta: { headerTitle: "Status" },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Status" align="center" />
+    ),
     cell: ({ row }) => {
       const status = row.getValue("status") as string;
       const Icon = statusIcons[status];
@@ -107,17 +98,10 @@ export const columns: ColumnDef<PostWithConnections>[] = [
   },
   {
     accessorKey: "id",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Post ID
-          <ArrowUpDownIcon className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    meta: { headerTitle: "Post ID" },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Post ID" />
+    ),
     cell: ({ row }) => {
       const postId = row.getValue("id") as string;
       return (
@@ -129,17 +113,10 @@ export const columns: ColumnDef<PostWithConnections>[] = [
   },
   {
     accessorKey: "external_id",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          External ID
-          <ArrowUpDownIcon className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    meta: { headerTitle: "External ID" },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="External ID" />
+    ),
     cell: ({ row }) => {
       return row.getValue("external_id") as string;
     },
@@ -242,17 +219,10 @@ export const columns: ColumnDef<PostWithConnections>[] = [
   },
   {
     accessorKey: "scheduled_at",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Post At
-          <ArrowUpDownIcon className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
+    meta: { headerTitle: "Post At" },
+    header: ({ column }) => (
+      <DataGridColumnHeader column={column} title="Post At" />
+    ),
     cell: ({ row }) => {
       const date = new Date(row.getValue("scheduled_at"));
       return <div className="text-sm">{format(date, "MM/dd/yyyy HH:mm")}</div>;

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_data-table.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_data-table.tsx
@@ -1,40 +1,19 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
-import {
-  flexRender,
-  getCoreRowModel,
-  getFilteredRowModel,
-  getSortedRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
-import { ChevronDownIcon } from "lucide-react";
+import { useTable } from "@tanstack/react-table";
 
-import { Button } from "~/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "~/ui/dropdown-menu";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "~/ui/table";
+  DataGridColumnVisibility,
+  DataGridTable,
+  dataGridFeatures,
+} from "~/ui/data-grid";
 
 import { columns } from "./_columns";
 import { TableFilters } from "./_table-filters";
 import { TablePagination } from "./_table-pagination";
 
 import type { LoaderData } from "./_types";
-import type {
-  ColumnFiltersState,
-  SortingState,
-  VisibilityState,
-} from "@tanstack/react-table";
+import type { SortingState } from "@tanstack/react-table";
 
 interface DataTableProps {
   data: LoaderData;
@@ -43,28 +22,17 @@ interface DataTableProps {
 export function PostsDataTable({ data }: DataTableProps) {
   const navigate = useNavigate();
   const [sorting, setSorting] = useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
-  const [rowSelection, setRowSelection] = useState({});
+  const [columnVisibility, setColumnVisibility] = useState({});
 
   const posts = useMemo(() => data.posts || [], [data.posts]);
 
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data: posts,
     columns,
+    state: { sorting, columnVisibility },
     onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
-    onRowSelectionChange: setRowSelection,
-    state: {
-      sorting,
-      columnFilters,
-      columnVisibility,
-      rowSelection,
-    },
   });
 
   if (!data.success) {
@@ -81,112 +49,15 @@ export function PostsDataTable({ data }: DataTableProps) {
     <div className="w-full space-y-4">
       <div className="flex items-center justify-between">
         <TableFilters />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="ml-auto bg-card">
-              Columns <ChevronDownIcon className="ml-2 h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {table
-              .getAllColumns()
-              .filter((column) => column.getCanHide())
-              .map((column) => {
-                return (
-                  <DropdownMenuCheckboxItem
-                    key={column.id}
-                    className="capitalize"
-                    checked={column.getIsVisible()}
-                    onCheckedChange={(value) =>
-                      column.toggleVisibility(!!value)
-                    }
-                  >
-                    {column.id}
-                  </DropdownMenuCheckboxItem>
-                );
-              })}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <DataGridColumnVisibility table={table} />
       </div>
 
-      <div className="bg-card rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => {
-                const post = row.original;
-
-                return (
-                  <TableRow
-                    key={row.id}
-                    tabIndex={0}
-                    className="cursor-pointer"
-                    data-state={row.getIsSelected() ? "selected" : undefined}
-                    onClick={(e) => {
-                      const target = e.target as HTMLElement | null;
-
-                      if (!target) return;
-                      if (e.defaultPrevented) return;
-
-                      // Avoid row navigation when interacting with controls/links inside the row.
-                      if (
-                        target.closest(
-                          'a,button,input,textarea,select,[role="button"],[role="menuitem"],[data-row-click="ignore"]',
-                        )
-                      ) {
-                        return;
-                      }
-
-                      navigate(`${post.id}`);
-                    }}
-                    onKeyDown={(e) => {
-                      // Only navigate when the row itself has focus.
-                      if (e.target !== e.currentTarget) return;
-                      if (e.key === "Enter" || e.key === " ") navigate(`${post.id}`);
-                    }}
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                );
-              })
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
-                >
-                  No posts found.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <DataGridTable
+        table={table}
+        columnCount={columns.length}
+        onRowClick={(post) => navigate(`${post.id}`)}
+        emptyMessage="No posts found."
+      />
 
       <TablePagination data={data} />
     </div>

--- a/dashboard/app/ui/data-grid.tsx
+++ b/dashboard/app/ui/data-grid.tsx
@@ -1,0 +1,384 @@
+/**
+ * Trimmed, vendored ReUI Data Grid — rebuilt on TanStack Table v9.
+ *
+ * This is intentionally NOT a 1:1 copy of the upstream ReUI Data Grid
+ * (https://reui.io/docs/components/base/data-grid). Our tables have diverged
+ * from the vendored copy in both style and organization on purpose, so this
+ * file ports only the pieces we actually use:
+ *
+ *   - the v9 `useTable` / `tableFeatures` architecture (replacing v8's
+ *     `useReactTable` + `getXxxRowModel()` options),
+ *   - a reusable sortable column header (`DataGridColumnHeader`),
+ *   - a reusable column-visibility toggle (`DataGridColumnVisibility`),
+ *   - a single table renderer (`DataGridTable`) that owns our shared markup
+ *     (the `bg-card rounded-md border` shell, row-click navigation, empty and
+ *     loading states) so the per-route data tables stop re-implementing it.
+ *
+ * Deliberately dropped from upstream: virtualization, drag-and-drop, row/column
+ * pinning, tree rows, aggregate footers and client-side pagination — none of
+ * which our server-driven tables need. Our styling is built on this app's own
+ * `~/ui/table` primitives and Radix-based dropdown, not upstream's Base UI ones.
+ */
+import * as React from "react";
+import {
+  columnVisibilityFeature,
+  createSortedRowModel,
+  flexRender,
+  metaHelper,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_alphanumericCaseSensitive,
+  sortFn_basic,
+  sortFn_datetime,
+  sortFn_text,
+  sortFn_textCaseSensitive,
+  tableFeatures,
+} from "@tanstack/react-table";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ChevronDownIcon,
+  ChevronsUpDownIcon,
+} from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { Button } from "~/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "~/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/ui/table";
+import { Skeleton } from "~/ui/skeleton";
+
+import type {
+  Column,
+  ColumnDef,
+  RowData,
+  Table as TableInstance,
+} from "@tanstack/react-table";
+import type { ReactNode } from "react";
+
+/**
+ * Per-column extras the grid reads off `columnDef.meta`.
+ *
+ * v9 resolves this through the `columnMeta` slot on the feature bundle below
+ * instead of a global `declare module` augmentation, so consuming the data grid
+ * no longer widens `ColumnMeta` for every other table in the app.
+ */
+export interface DataGridColumnMeta {
+  /** Label used by the column header and the visibility toggle. */
+  headerTitle?: string;
+  /** Extra classes applied to this column's `<th>`. */
+  headerClassName?: string;
+  /** Extra classes applied to this column's `<td>`. */
+  cellClassName?: string;
+}
+
+/**
+ * The trimmed feature bundle every data table in this app builds on. v9
+ * requires each table to declare its features up front:
+ *   - `columnVisibilityFeature` gates `row.getVisibleCells()` /
+ *     `column.getIsVisible()` — needed even by tables that never hide a column.
+ *   - `rowSortingFeature` + `sortedRowModel` power client-side sorting.
+ *   - the `sortFns` map lets `sortFn: "auto"` resolve to a built-in.
+ */
+export const dataGridFeatures = tableFeatures({
+  columnVisibilityFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns: {
+    alphanumeric: sortFn_alphanumeric,
+    alphanumericCaseSensitive: sortFn_alphanumericCaseSensitive,
+    basic: sortFn_basic,
+    datetime: sortFn_datetime,
+    text: sortFn_text,
+    textCaseSensitive: sortFn_textCaseSensitive,
+  },
+  columnMeta: metaHelper<DataGridColumnMeta>(),
+});
+
+/** The feature set `dataGridFeatures` registers. */
+export type DataGridFeatures = typeof dataGridFeatures;
+
+/** A column definition bound to the app's feature bundle. */
+export type DataGridColumnDef<TData extends RowData, TValue = unknown> = ColumnDef<
+  DataGridFeatures,
+  TData,
+  TValue
+>;
+
+/** A table instance bound to the app's feature bundle. */
+export type DataGridTableInstance<TData extends RowData> = TableInstance<
+  DataGridFeatures,
+  TData
+>;
+
+/** Label for a column: `meta.headerTitle`, a string `columnDef.header`, or `column.id`. */
+export function getColumnHeaderLabel<TData extends RowData, TValue>(
+  column: Column<DataGridFeatures, TData, TValue>,
+): string {
+  const meta = column.columnDef.meta;
+  if (typeof meta?.headerTitle === "string") return meta.headerTitle;
+  const defHeader = column.columnDef.header;
+  if (typeof defHeader === "string") return defHeader;
+  return String(column.id);
+}
+
+// ---------------------------------------------------------------------------
+// Sortable column header
+// ---------------------------------------------------------------------------
+
+interface DataGridColumnHeaderProps<TData extends RowData, TValue>
+  extends React.HTMLAttributes<HTMLDivElement> {
+  column: Column<DataGridFeatures, TData, TValue>;
+  /** Defaults to `meta.headerTitle`, then a string `columnDef.header`, then `column.id`. */
+  title?: string;
+  /** Horizontal alignment of the header label. */
+  align?: "start" | "center" | "end";
+}
+
+/**
+ * Replaces the ad-hoc `<Button onClick={() => column.toggleSorting(...)}>`
+ * blocks the per-route column files used to repeat. Cycles asc → desc → none
+ * on click, and falls back to a plain label for non-sortable columns.
+ */
+export function DataGridColumnHeader<TData extends RowData, TValue>({
+  column,
+  title,
+  align = "start",
+  className,
+  ...props
+}: DataGridColumnHeaderProps<TData, TValue>) {
+  const label = title ?? getColumnHeaderLabel(column);
+  const alignClass =
+    align === "center"
+      ? "justify-center"
+      : align === "end"
+        ? "justify-end"
+        : "justify-start";
+
+  if (!column.getCanSort()) {
+    return (
+      <div className={cn("flex items-center", alignClass, className)} {...props}>
+        {label}
+      </div>
+    );
+  }
+
+  const sorted = column.getIsSorted();
+  const SortIcon =
+    sorted === "asc"
+      ? ArrowUpIcon
+      : sorted === "desc"
+        ? ArrowDownIcon
+        : ChevronsUpDownIcon;
+
+  const handleSort = () => {
+    if (sorted === "asc") {
+      column.toggleSorting(true);
+    } else if (sorted === "desc") {
+      column.clearSorting();
+    } else {
+      column.toggleSorting(false);
+    }
+  };
+
+  return (
+    <div className={cn("flex items-center", alignClass, className)} {...props}>
+      <button
+        type="button"
+        onClick={handleSort}
+        className="text-muted-foreground hover:text-foreground data-[sorted=true]:text-foreground -mx-2 inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium transition-colors"
+        data-sorted={sorted !== false}
+      >
+        {label}
+        <SortIcon className="size-4 opacity-60" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Column-visibility toggle
+// ---------------------------------------------------------------------------
+
+/**
+ * The "Columns" dropdown, shared by every data table. Reads each hideable
+ * column's label from `meta.headerTitle` (falling back to a string header or
+ * the column id), replacing the near-identical dropdown each route used to
+ * inline. Uses this app's Radix-based dropdown, not upstream's Base UI one.
+ */
+export function DataGridColumnVisibility<TData extends RowData>({
+  table,
+  label = "Columns",
+  align = "end",
+}: {
+  table: DataGridTableInstance<TData>;
+  label?: ReactNode;
+  align?: "start" | "center" | "end";
+}) {
+  const columns = table
+    .getAllColumns()
+    .filter((column) => column.getCanHide());
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="ml-auto bg-card">
+          {label} <ChevronDownIcon className="ml-2 h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align}>
+        {columns.map((column) => (
+          <DropdownMenuCheckboxItem
+            key={column.id}
+            className="capitalize"
+            checked={column.getIsVisible()}
+            onCheckedChange={(value) => column.toggleVisibility(!!value)}
+          >
+            {getColumnHeaderLabel(column)}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table renderer
+// ---------------------------------------------------------------------------
+
+interface DataGridTableProps<TData extends RowData> {
+  table: DataGridTableInstance<TData>;
+  /** Number of leaf columns, used for the empty-state colSpan. */
+  columnCount: number;
+  /** Row click handler; when set, rows become keyboard-focusable and clickable. */
+  onRowClick?: (row: TData) => void;
+  /** Message shown when there are no rows. */
+  emptyMessage?: ReactNode;
+  /** Renders skeleton rows instead of data. */
+  isLoading?: boolean;
+  /** Skeleton row count while loading. */
+  loadingRowCount?: number;
+  /** Extra classes for the outer card shell. */
+  className?: string;
+}
+
+// Interactive descendants that should swallow a row click instead of
+// triggering row navigation.
+const INTERACTIVE_SELECTOR =
+  'a,button,input,textarea,select,[role="button"],[role="menuitem"],[data-row-click="ignore"]';
+
+/**
+ * The shared table body. Owns the `bg-card rounded-md border` shell, header and
+ * cell rendering, the empty state, an optional loading skeleton and optional
+ * row-click navigation (with a guard so clicks on inner controls don't
+ * navigate) — all previously copy-pasted across the route data tables.
+ */
+export function DataGridTable<TData extends RowData>({
+  table,
+  columnCount,
+  onRowClick,
+  emptyMessage = "No results.",
+  isLoading = false,
+  loadingRowCount = 5,
+  className,
+}: DataGridTableProps<TData>) {
+  const rows = table.getRowModel().rows;
+  const clickable = Boolean(onRowClick);
+
+  return (
+    <div className={cn("bg-card rounded-md border", className)}>
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead
+                  key={header.id}
+                  className={header.column.columnDef.meta?.headerClassName}
+                >
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {isLoading ? (
+            Array.from({ length: loadingRowCount }).map((_, rowIndex) => (
+              <TableRow key={`skeleton-${rowIndex}`}>
+                {Array.from({ length: columnCount }).map((__, cellIndex) => (
+                  <TableCell key={`skeleton-${rowIndex}-${cellIndex}`}>
+                    <Skeleton className="h-5 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : rows.length ? (
+            rows.map((row) => (
+              <TableRow
+                key={row.id}
+                tabIndex={clickable ? 0 : undefined}
+                className={cn(clickable && "cursor-pointer")}
+                onClick={
+                  clickable
+                    ? (event) => {
+                        const target = event.target as HTMLElement | null;
+                        if (!target) return;
+                        if (event.defaultPrevented) return;
+                        // Don't navigate when interacting with inner controls/links.
+                        if (target.closest(INTERACTIVE_SELECTOR)) return;
+                        onRowClick?.(row.original);
+                      }
+                    : undefined
+                }
+                onKeyDown={
+                  clickable
+                    ? (event) => {
+                        // Only navigate when the row itself has focus.
+                        if (event.target !== event.currentTarget) return;
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          onRowClick?.(row.original);
+                        }
+                      }
+                    : undefined
+                }
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell
+                    key={cell.id}
+                    className={cell.column.columnDef.meta?.cellClassName}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columnCount} className="h-24 text-center">
+                {emptyMessage}
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -30,7 +30,7 @@
         "@shikijs/transformers": "^3.19.0",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.49.8",
-        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-table": "^9.0.1",
         "@trigger.dev/sdk": "4.0.0-v4-beta.27",
         "@unkey/api": "^2.2.0",
         "class-variance-authority": "^0.7.1",
@@ -553,9 +553,13 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
 
-    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+    "@tanstack/react-store": ["@tanstack/react-store@0.11.1", "", { "dependencies": { "@tanstack/store": "0.11.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ=="],
 
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+    "@tanstack/react-table": ["@tanstack/react-table@9.0.1", "", { "dependencies": { "@tanstack/react-store": "^0.11.0", "@tanstack/table-core": "9.0.1" }, "peerDependencies": { "react": ">=18" } }, "sha512-xjIeydBG7FeCuFtRSQW9Zbca16JfXcl6mxowxdN3UQYczcmYmVJbzkFGxXesSfZY3o11zh7/xnBDU2YZKsG6qA=="],
+
+    "@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@9.0.1", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-7YDowUPKz6yfCZfAVO6nti9FMF3kstOhqwTEDbJY6bYmTI2ED90J5rrsQbIIkXrMZ3S4CNorFQq9cSkNaNjgTA=="],
 
     "@trigger.dev/core": ["@trigger.dev/core@4.0.0-v4-beta.27", "", { "dependencies": { "@bugsnag/cuid": "^3.1.1", "@electric-sql/client": "1.0.0-beta.1", "@google-cloud/precise-date": "^4.0.0", "@jsonhero/path": "^1.0.21", "@opentelemetry/api": "1.9.0", "@opentelemetry/api-logs": "0.203.0", "@opentelemetry/core": "2.0.1", "@opentelemetry/exporter-logs-otlp-http": "0.203.0", "@opentelemetry/exporter-trace-otlp-http": "0.203.0", "@opentelemetry/instrumentation": "0.203.0", "@opentelemetry/resources": "2.0.1", "@opentelemetry/sdk-logs": "0.203.0", "@opentelemetry/sdk-trace-base": "2.0.1", "@opentelemetry/sdk-trace-node": "2.0.1", "@opentelemetry/semantic-conventions": "1.36.0", "dequal": "^2.0.3", "eventsource": "^3.0.5", "eventsource-parser": "^3.0.0", "execa": "^8.0.1", "humanize-duration": "^3.27.3", "jose": "^5.4.0", "lodash.get": "^4.4.2", "nanoid": "3.3.8", "prom-client": "^15.1.0", "socket.io": "4.7.4", "socket.io-client": "4.7.5", "std-env": "^3.8.1", "superjson": "^2.2.1", "tinyexec": "^0.3.2", "uncrypto": "^0.1.3", "zod": "3.25.76", "zod-error": "1.5.0", "zod-validation-error": "^1.5.0" } }, "sha512-PJzW07GbxeHKigZ0AiO4aAtDdb2r5iioI7P6TLTqp3XfsxLb1ezPNv3zt6dy1uvZsefGR/EO4y7X0VN1pJyLTA=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -40,7 +40,7 @@
     "@shikijs/transformers": "^3.19.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.49.8",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.0.1",
     "@trigger.dev/sdk": "4.0.0-v4-beta.27",
     "@unkey/api": "^2.2.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary

Upgrades the dashboard's data tables to **TanStack Table v9** by vendoring a **trimmed** copy of the new [ReUI Data Grid](https://reui.io/docs/components/base/data-grid) as a shared component. Per the issue, this is a *merge of relevant new features* — not a replacement — so our intentional style/organizational divergences are retained.

Closes PFM-978

## What changed

- **New `dashboard/app/ui/data-grid.tsx`** — a trimmed, vendored ReUI Data Grid on the v9 `useTable` / `tableFeatures` architecture. Exports:
  - `dataGridFeatures` — a lean feature bundle (`columnVisibilityFeature`, `rowSortingFeature` + `sortedRowModel`, `sortFns`, `columnMeta`).
  - `DataGridTable` — the shared renderer (the `bg-card` shell, header/cell rendering, empty + loading states, and row-click navigation with an interactive-element guard).
  - `DataGridColumnHeader` — a reusable sortable header (asc → desc → none).
  - `DataGridColumnVisibility` — the shared "Columns" toggle, reading labels from `meta.headerTitle`.
- **Migrated all three tables** (posts, accounts, account feed) from per-route `useReactTable` setups onto the shared component + `useTable`.
- **Bumped `@tanstack/react-table`** `^8.21.3` → `^9.0.1` (v9 is stable), following the official v8→v9 migration guide shipped in the package (`useReactTable` → `useTable`, row-model options → feature slots, `ColumnDef<TData>` → `ColumnDef<TFeatures, TData, TValue>`, `VisibilityState` → `ColumnVisibilityState`).

### Retained (our intentional divergences)
- Our `~/ui/table` primitives + `bg-card rounded-md border` shell and Radix-based dropdown (not upstream's Base UI).
- Row-click navigation + keyboard nav with the guard for inner controls (posts).
- Server-driven filters and pagination, the account-feed "Load More" and YouTube column filtering, and default-hidden metric columns.
- Per-column labels, moved from the ad-hoc `CustomColumnDef.label` onto typed `meta.headerTitle`.

### Trimmed (upstream features we don't use)
Virtualization, drag-and-drop, row/column pinning, tree rows, aggregate footers, and client-side pagination.

### Cleanup
Removes ~600 lines of duplicated table markup, sort-header buttons, and column-visibility dropdowns across the six route files, plus dead code (an unreachable `Copyable` branch and unused client `columnFilters`/`rowSelection` state).

## Verification
- `bun run typecheck` — passes
- `bun run lint` — passes (0 warnings)
- `bun run build` — passes (client + SSR)

> Note: runtime/visual QA of sorting, column visibility, and row navigation across the three tables is worth a manual pass before merge.

<!-- generated-by-cyrus -->