### PR TITLE
feat(app): upgrade data grid to TanStack Table v9 (PFM-978)

### DIFF
--- a/app/app/components/data-grid/data-grid-column-filter.tsx
+++ b/app/app/components/data-grid/data-grid-column-filter.tsx
@@ -1,6 +1,10 @@
-import type { Column } from "@tanstack/react-table"
+import type { CellData, Column, RowData } from "@tanstack/react-table"
 
 import { useMemo, useState } from "react"
+
+import type {
+  DataGridFeatures,
+} from "~/components/data-grid/data-grid"
 
 import { CheckIcon, CirclePlusIcon } from "~/icons"
 import { cn } from "~/lib/utils"
@@ -14,8 +18,8 @@ import {
 } from "~/ui/popover"
 import { Separator } from "~/ui/separator"
 
-interface DataGridColumnFilterProps<TData, TValue> {
-  column?: Column<TData, TValue>
+interface DataGridColumnFilterProps<TData extends RowData, TValue extends CellData> {
+  column?: Column<DataGridFeatures, TData, TValue>
   options: {
     icon?: React.ComponentType<{ className?: string }>
     label: string
@@ -24,7 +28,7 @@ interface DataGridColumnFilterProps<TData, TValue> {
   title?: string
 }
 
-function DataGridColumnFilter<TData, TValue>({
+function DataGridColumnFilter<TData extends RowData, TValue extends CellData>({
   column,
   title,
   options,

--- a/app/app/components/data-grid/data-grid-column-header.tsx
+++ b/app/app/components/data-grid/data-grid-column-header.tsx
@@ -1,8 +1,12 @@
-import type { Column } from "@tanstack/react-table"
+import type { CellData, Column, RowData } from "@tanstack/react-table"
 import type { HTMLAttributes, ReactNode } from "react"
 
 import { memo, useMemo } from "react"
 import { useTranslation } from "react-i18next";
+
+import type {
+  DataGridFeatures,
+} from "~/components/data-grid/data-grid"
 
 import {
   getColumnHeaderLabel,
@@ -26,10 +30,10 @@ import {
 } from "~/ui/dropdown-menu"
 
 interface DataGridColumnHeaderProps<
-  TData,
-  TValue,
+  TData extends RowData,
+  TValue extends CellData,
 > extends HTMLAttributes<HTMLDivElement> {
-  column: Column<TData, TValue>
+  column: Column<DataGridFeatures, TData, TValue>
   filter?: ReactNode
   icon?: ReactNode
   /** Reserved; pin controls are gated by tableLayout.columnsPinnable + column.getCanPin(). */
@@ -39,7 +43,7 @@ interface DataGridColumnHeaderProps<
   visibility?: boolean
 }
 
-function DataGridColumnHeaderInner<TData, TValue>({
+function DataGridColumnHeaderInner<TData extends RowData, TValue extends CellData>({
   column,
   title,
   icon,
@@ -53,14 +57,14 @@ function DataGridColumnHeaderInner<TData, TValue>({
 
   // TanStack's columnOrder defaults to [] until a consumer seeds it; fall
   // back to the definition order so Move Left/Right work out of the box.
-  const columnOrderState = table.getState().columnOrder
+  const columnOrderState = table.store.state.columnOrder
   const columnOrder =
     columnOrderState.length > 0
       ? columnOrderState
       : table.getAllLeafColumns().map((leafColumn) => leafColumn.id)
   const columnVisibilityKey =
     props.tableLayout?.columnsVisibility && visibility
-      ? JSON.stringify(table.getState().columnVisibility)
+      ? JSON.stringify(table.store.state.columnVisibility)
       : ""
   const isSorted = column.getIsSorted()
   const isPinned = column.getIsPinned()
@@ -167,22 +171,26 @@ function DataGridColumnHeaderInner<TData, TValue>({
       if (hasPreviousSection) {
         items.push(<DropdownMenuSeparator key="sep-pin" />)
       }
+      // The pin targets are v9's logical regions now ("start"/"end"), while
+      // the labels and icons stay physical — unchanged in LTR, which is what
+      // these strings are written for. Making the copy direction-aware is an
+      // i18n change, not part of this port.
       items.push(
         <DropdownMenuItem
-          key="pin-left"
-          onClick={() => column.pin(isPinned === "left" ? false : "left")}
+          key="pin-start"
+          onClick={() => column.pin(isPinned === "start" ? false : "start")}
         >
           <ArrowLeftToLineIcon className="size-3.5!" aria-hidden="true" />
           <span className="grow">{t("dataGrid.pinLeft")}</span>
-          {isPinned === "left" ? <CheckIcon className="text-primary size-4 opacity-100!" /> : null}
+          {isPinned === "start" ? <CheckIcon className="text-primary size-4 opacity-100!" /> : null}
         </DropdownMenuItem>,
         <DropdownMenuItem
-          key="pin-right"
-          onClick={() => column.pin(isPinned === "right" ? false : "right")}
+          key="pin-end"
+          onClick={() => column.pin(isPinned === "end" ? false : "end")}
         >
           <ArrowRightToLineIcon className="size-3.5!" aria-hidden="true" />
           <span className="grow">{t("dataGrid.pinRight")}</span>
-          {isPinned === "right" ? <CheckIcon className="text-primary size-4 opacity-100!" /> : null}
+          {isPinned === "end" ? <CheckIcon className="text-primary size-4 opacity-100!" /> : null}
         </DropdownMenuItem>
       )
       hasPreviousSection = true

--- a/app/app/components/data-grid/data-grid-column-header.tsx
+++ b/app/app/components/data-grid/data-grid-column-header.tsx
@@ -57,14 +57,14 @@ function DataGridColumnHeaderInner<TData extends RowData, TValue extends CellDat
 
   // TanStack's columnOrder defaults to [] until a consumer seeds it; fall
   // back to the definition order so Move Left/Right work out of the box.
-  const columnOrderState = table.store.state.columnOrder
+  const columnOrderState = table.state.columnOrder
   const columnOrder =
     columnOrderState.length > 0
       ? columnOrderState
       : table.getAllLeafColumns().map((leafColumn) => leafColumn.id)
   const columnVisibilityKey =
     props.tableLayout?.columnsVisibility && visibility
-      ? JSON.stringify(table.store.state.columnVisibility)
+      ? JSON.stringify(table.state.columnVisibility)
       : ""
   const isSorted = column.getIsSorted()
   const isPinned = column.getIsPinned()

--- a/app/app/components/data-grid/data-grid-column-header.tsx
+++ b/app/app/components/data-grid/data-grid-column-header.tsx
@@ -347,6 +347,22 @@ function DataGridColumnHeaderInner<TData extends RowData, TValue extends CellDat
   )
 }
 
+/**
+ * LOAD-BEARING COUPLING — sort/pin state reaches this header through builder
+ * calls on `column` (`getIsSorted()`, `getIsPinned()`), and `column` is a
+ * stable reference, so `memo` sees unchanged props on every state change and
+ * would skip the render. What saves it is context: this component consumes
+ * `useDataGrid()`, and the provider republishes its value whenever `sorting`,
+ * `columnPinning`, `columnVisibility`, or `columnOrder` change — a context
+ * change re-renders a memoized consumer even when props are equal.
+ *
+ * Dropping any of those four slices from the context memo deps in
+ * `data-grid.tsx` would therefore silently freeze the sort arrows and pin
+ * controls here, with no type error. Upstream ReUI instead wraps this in a
+ * `Subscribe` over exactly those four slices, making the dependency explicit
+ * and narrowing the re-render to headers; worth adopting if the context dep
+ * list is ever trimmed for performance.
+ */
 const DataGridColumnHeader = memo(
   DataGridColumnHeaderInner
 ) as typeof DataGridColumnHeaderInner

--- a/app/app/components/data-grid/data-grid-column-visibility.tsx
+++ b/app/app/components/data-grid/data-grid-column-visibility.tsx
@@ -1,5 +1,9 @@
-import type { Table } from "@tanstack/react-table"
+import type { RowData } from "@tanstack/react-table"
 import type { ReactElement } from "react"
+
+import type {
+  DataGridTableInstance,
+} from "~/components/data-grid/data-grid"
 
 import { getColumnHeaderLabel } from "~/components/data-grid/data-grid"
 import {
@@ -11,11 +15,11 @@ import {
   DropdownMenuTrigger,
 } from "~/ui/dropdown-menu"
 
-function DataGridColumnVisibility<TData>({
+function DataGridColumnVisibility<TData extends RowData>({
   table,
   trigger,
 }: {
-  table: Table<TData>
+  table: DataGridTableInstance<TData>
   trigger: ReactElement<Record<string, unknown>>
 }) {
   return (

--- a/app/app/components/data-grid/data-grid-pagination.tsx
+++ b/app/app/components/data-grid/data-grid-pagination.tsx
@@ -52,8 +52,8 @@ function DataGridPagination(props: DataGridPaginationProps): JSX.Element {
   // scale, matching the tighter cell padding.
   const btnBaseClasses = "size-7 p-0 text-sm"
   const btnArrowClasses = btnBaseClasses + " rtl:transform rtl:rotate-180"
-  const pageIndex = table.getState().pagination.pageIndex
-  const pageSize = table.getState().pagination.pageSize
+  const pageIndex = table.store.state.pagination.pageIndex
+  const pageSize = table.store.state.pagination.pageSize
   const from = recordCount === 0 ? 0 : pageIndex * pageSize + 1
   const to = Math.min((pageIndex + 1) * pageSize, recordCount)
   const pageCount = table.getPageCount()

--- a/app/app/components/data-grid/data-grid-pagination.tsx
+++ b/app/app/components/data-grid/data-grid-pagination.tsx
@@ -52,8 +52,8 @@ function DataGridPagination(props: DataGridPaginationProps): JSX.Element {
   // scale, matching the tighter cell padding.
   const btnBaseClasses = "size-7 p-0 text-sm"
   const btnArrowClasses = btnBaseClasses + " rtl:transform rtl:rotate-180"
-  const pageIndex = table.store.state.pagination.pageIndex
-  const pageSize = table.store.state.pagination.pageSize
+  const pageIndex = table.state.pagination.pageIndex
+  const pageSize = table.state.pagination.pageSize
   const from = recordCount === 0 ? 0 : pageIndex * pageSize + 1
   const to = Math.min((pageIndex + 1) * pageSize, recordCount)
   const pageCount = table.getPageCount()

--- a/app/app/components/data-grid/data-grid-scroll-area.tsx
+++ b/app/app/components/data-grid/data-grid-scroll-area.tsx
@@ -113,8 +113,8 @@ function DataGridScrollArea({
   // Pinned columns are sticky and never scroll, so the horizontal scrollbar
   // track is inset to span only the scrollable center region between them.
   const isColumnsPinnable = !!dataGridProps.tableLayout?.columnsPinnable
-  const scrollbarInsetStart = isColumnsPinnable ? table.getLeftTotalSize() : 0
-  const scrollbarInsetEnd = isColumnsPinnable ? table.getRightTotalSize() : 0
+  const scrollbarInsetStart = isColumnsPinnable ? table.getStartTotalSize() : 0
+  const scrollbarInsetEnd = isColumnsPinnable ? table.getEndTotalSize() : 0
   const [hasCustomVerticalOverflow, setHasCustomVerticalOverflow] =
     useState(false)
 

--- a/app/app/components/data-grid/data-grid-table-dnd-rows.tsx
+++ b/app/app/components/data-grid/data-grid-table-dnd-rows.tsx
@@ -256,7 +256,7 @@ function DataGridTableDndRowsBody<TData extends RowData>({
   table: DataGridTableInstance<TData>
 }) {
   const { isLoading, props } = useDataGrid()
-  const pagination = table.store.state.pagination
+  const pagination = table.state.pagination
 
   if (props.loadingMode === "skeleton" && isLoading && pagination?.pageSize) {
     return (
@@ -304,7 +304,7 @@ function DataGridTableDndRowsBody<TData extends RowData>({
  */
 const MemoizedDataGridTableDndRowsBody = memo(
   DataGridTableDndRowsBody,
-  (_prev, next) => !!next.table.store.state.columnResizing.isResizingColumn
+  (_prev, next) => !!next.table.state.columnResizing.isResizingColumn
 ) as typeof DataGridTableDndRowsBody
 
 function DataGridTableDndRows<TData extends RowData>({

--- a/app/app/components/data-grid/data-grid-table-dnd-rows.tsx
+++ b/app/app/components/data-grid/data-grid-table-dnd-rows.tsx
@@ -1,4 +1,4 @@
-import type { Cell, HeaderGroup, Row, Table } from "@tanstack/react-table"
+import type { Cell, HeaderGroup, Row, RowData } from "@tanstack/react-table"
 import type { CSSProperties, ReactNode } from "react"
 
 import {
@@ -42,7 +42,12 @@ import {
 } from "react"
 import { useTranslation } from "react-i18next";
 
-import { useDataGrid } from "~/components/data-grid/data-grid"
+import type {
+  DataGridFeatures,
+  DataGridTableInstance,
+} from "~/components/data-grid/data-grid"
+
+import { useDataGrid, useDataGridOf } from "~/components/data-grid/data-grid"
 import {
   DataGridTableBase,
   DataGridTableBody,
@@ -93,10 +98,10 @@ type DataGridTableDndRowData = {
  * is positioned over the row, so it never adds a column, shifts striping, or
  * gets clipped by a truncating resizable cell.
  */
-type DataGridTableDndRowDecoration<TData> = (context: {
+type DataGridTableDndRowDecoration<TData extends RowData> = (context: {
   isDragging: boolean
   isOver: boolean
-  row: Row<TData>
+  row: Row<DataGridFeatures, TData>
 }) => ReactNode
 
 function DataGridTableDndRowHandle({
@@ -158,12 +163,12 @@ function DataGridTableDndRowHandle({
   )
 }
 
-function DataGridTableDndRow<TData>({
+function DataGridTableDndRow<TData extends RowData>({
   row,
   renderRowDecoration,
 }: {
   renderRowDecoration?: DataGridTableDndRowDecoration<TData>
-  row: Row<TData>
+  row: Row<DataGridFeatures, TData>
 }) {
   const rowData: DataGridTableDndRowData = {
     type: "data-grid-row",
@@ -206,7 +211,7 @@ function DataGridTableDndRow<TData>({
       <DataGridTableBodyRow row={row} dndRef={setNodeRef} dndStyle={style}>
         {row
           .getVisibleCells()
-          .map((cell: Cell<TData, unknown>, index, cells) => {
+          .map((cell: Cell<DataGridFeatures, TData, unknown>, index, cells) => {
             return (
               <DataGridTableBodyRowCell cell={cell} key={cell.id}>
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -239,7 +244,7 @@ function DataGridTableDndRow<TData>({
   )
 }
 
-function DataGridTableDndRowsBody<TData>({
+function DataGridTableDndRowsBody<TData extends RowData>({
   table,
   dataIds,
   renderRowDecoration,
@@ -248,10 +253,10 @@ function DataGridTableDndRowsBody<TData>({
   dataIds: UniqueIdentifier[]
   renderRowDecoration?: DataGridTableDndRowDecoration<TData>
   sortingStrategy: SortingStrategy
-  table: Table<TData>
+  table: DataGridTableInstance<TData>
 }) {
   const { isLoading, props } = useDataGrid()
-  const pagination = table.getState().pagination
+  const pagination = table.store.state.pagination
 
   if (props.loadingMode === "skeleton" && isLoading && pagination?.pageSize) {
     return (
@@ -279,7 +284,7 @@ function DataGridTableDndRowsBody<TData>({
 
   return (
     <SortableContext items={dataIds} strategy={sortingStrategy}>
-      {table.getRowModel().rows.map((row: Row<TData>) => {
+      {table.getRowModel().rows.map((row: Row<DataGridFeatures, TData>) => {
         return (
           <DataGridTableDndRow
             row={row}
@@ -299,10 +304,10 @@ function DataGridTableDndRowsBody<TData>({
  */
 const MemoizedDataGridTableDndRowsBody = memo(
   DataGridTableDndRowsBody,
-  (_prev, next) => !!next.table.getState().columnSizingInfo.isResizingColumn
+  (_prev, next) => !!next.table.store.state.columnResizing.isResizingColumn
 ) as typeof DataGridTableDndRowsBody
 
-function DataGridTableDndRows<TData>({
+function DataGridTableDndRows<TData extends RowData>({
   handleDragEnd,
   dataIds,
   footerContent,
@@ -344,7 +349,9 @@ function DataGridTableDndRows<TData>({
    */
   sortingStrategy?: SortingStrategy
 }) {
-  const { table, props } = useDataGrid()
+  // Row-typed: the carried row resolved off this table is rendered through
+  // the caller's TData-typed `renderRowDecoration`.
+  const { table, props } = useDataGridOf<TData>()
   const tableContainerRef = useRef<HTMLDivElement>(null)
   const [isDraggingRow, setIsDraggingRow] = useState(false)
   // The row being carried, plus the column widths measured off the header the
@@ -384,7 +391,7 @@ function DataGridTableDndRows<TData>({
   }, [])
 
   const carriedRow = carried
-    ? table.getRowModel().rows.find((row: Row<TData>) => row.id === carried.id)
+    ? table.getRowModel().rows.find((row: Row<DataGridFeatures, TData>) => row.id === carried.id)
     : undefined
 
   const sensors = useSensors(
@@ -488,7 +495,7 @@ function DataGridTableDndRows<TData>({
           <DataGridTableHead>
             {table
               .getHeaderGroups()
-              .map((headerGroup: HeaderGroup<TData>, index) => {
+              .map((headerGroup: HeaderGroup<DataGridFeatures, TData>, index) => {
                 return (
                   <DataGridTableHeadRow key={index} rowId={headerGroup.id}>
                     {headerGroup.headers.map((header, index) => {
@@ -557,7 +564,7 @@ function DataGridTableDndRows<TData>({
               <tr className="[&>td]:h-14 [&>td]:p-0 [&>td]:align-middle">
                 {carriedRow
                   .getVisibleCells()
-                  .map((cell: Cell<TData, unknown>, index: number) => (
+                  .map((cell: Cell<DataGridFeatures, TData, unknown>, index: number) => (
                     <td
                       key={cell.id}
                       // Falls back to the column's own size so an unforeseen

--- a/app/app/components/data-grid/data-grid-table-dnd.tsx
+++ b/app/app/components/data-grid/data-grid-table-dnd.tsx
@@ -3,7 +3,7 @@ import type {
   Header,
   HeaderGroup,
   Row,
-  Table,
+  RowData,
 } from "@tanstack/react-table"
 import type { CSSProperties, ReactNode } from "react"
 
@@ -37,6 +37,11 @@ import {
 } from "react"
 import { useTranslation } from "react-i18next";
 
+import type {
+  DataGridFeatures,
+  DataGridTableInstance,
+} from "~/components/data-grid/data-grid"
+
 import { useDataGrid } from "~/components/data-grid/data-grid"
 import {
   DataGridTableBase,
@@ -60,10 +65,10 @@ import {
 import { DragHandleIcon as GripVerticalIcon } from "~/icons"
 import { Button } from "~/ui/button"
 
-function DataGridTableDndHeader<TData>({
+function DataGridTableDndHeader<TData extends RowData>({
   header,
 }: {
-  header: Header<TData, unknown>
+  header: Header<DataGridFeatures, TData, unknown>
 }) {
   const { t } = useTranslation();
 
@@ -127,7 +132,7 @@ function DataGridTableDndHeader<TData>({
   )
 }
 
-function DataGridTableDndCell<TData>({ cell }: { cell: Cell<TData, unknown> }) {
+function DataGridTableDndCell<TData extends RowData>({ cell }: { cell: Cell<DataGridFeatures, TData, unknown> }) {
   const { props } = useDataGrid()
   const { isDragging, setNodeRef, transform, transition } = useSortable({
     id: cell.column.id,
@@ -152,9 +157,9 @@ function DataGridTableDndCell<TData>({ cell }: { cell: Cell<TData, unknown> }) {
   )
 }
 
-function DataGridTableDndBodyRows<TData>({ table }: { table: Table<TData> }) {
+function DataGridTableDndBodyRows<TData extends RowData>({ table }: { table: DataGridTableInstance<TData> }) {
   const { isLoading, props } = useDataGrid()
-  const pagination = table.getState().pagination
+  const pagination = table.store.state.pagination
 
   if (props.loadingMode === "skeleton" && isLoading && pagination?.pageSize) {
     return (
@@ -182,15 +187,15 @@ function DataGridTableDndBodyRows<TData>({ table }: { table: Table<TData> }) {
 
   return (
     <>
-      {table.getRowModel().rows.map((row: Row<TData>) => {
+      {table.getRowModel().rows.map((row: Row<DataGridFeatures, TData>) => {
         return (
           <Fragment key={row.id}>
             <DataGridTableBodyRow row={row}>
               <SortableContext
-                items={table.getState().columnOrder}
+                items={table.store.state.columnOrder}
                 strategy={horizontalListSortingStrategy}
               >
-                {row.getVisibleCells().map((cell: Cell<TData, unknown>) => (
+                {row.getVisibleCells().map((cell: Cell<DataGridFeatures, TData, unknown>) => (
                   <DataGridTableDndCell cell={cell} key={cell.id} />
                 ))}
               </SortableContext>
@@ -211,10 +216,10 @@ function DataGridTableDndBodyRows<TData>({ table }: { table: Table<TData> }) {
  */
 const MemoizedDataGridTableDndBodyRows = memo(
   DataGridTableDndBodyRows,
-  (_prev, next) => !!next.table.getState().columnSizingInfo.isResizingColumn
+  (_prev, next) => !!next.table.store.state.columnResizing.isResizingColumn
 ) as typeof DataGridTableDndBodyRows
 
-function DataGridTableDnd<TData>({
+function DataGridTableDnd<TData extends RowData>({
   handleDragEnd,
   footerContent,
 }: {
@@ -306,11 +311,11 @@ function DataGridTableDnd<TData>({
           <DataGridTableHead>
             {table
               .getHeaderGroups()
-              .map((headerGroup: HeaderGroup<TData>, index) => {
+              .map((headerGroup: HeaderGroup<DataGridFeatures, TData>, index) => {
                 return (
                   <DataGridTableHeadRow key={index} rowId={headerGroup.id}>
                     <SortableContext
-                      items={table.getState().columnOrder}
+                      items={table.store.state.columnOrder}
                       strategy={horizontalListSortingStrategy}
                     >
                       {headerGroup.headers.map((header) => (

--- a/app/app/components/data-grid/data-grid-table-dnd.tsx
+++ b/app/app/components/data-grid/data-grid-table-dnd.tsx
@@ -159,7 +159,7 @@ function DataGridTableDndCell<TData extends RowData>({ cell }: { cell: Cell<Data
 
 function DataGridTableDndBodyRows<TData extends RowData>({ table }: { table: DataGridTableInstance<TData> }) {
   const { isLoading, props } = useDataGrid()
-  const pagination = table.store.state.pagination
+  const pagination = table.state.pagination
 
   if (props.loadingMode === "skeleton" && isLoading && pagination?.pageSize) {
     return (
@@ -192,7 +192,7 @@ function DataGridTableDndBodyRows<TData extends RowData>({ table }: { table: Dat
           <Fragment key={row.id}>
             <DataGridTableBodyRow row={row}>
               <SortableContext
-                items={table.store.state.columnOrder}
+                items={table.state.columnOrder}
                 strategy={horizontalListSortingStrategy}
               >
                 {row.getVisibleCells().map((cell: Cell<DataGridFeatures, TData, unknown>) => (
@@ -216,7 +216,7 @@ function DataGridTableDndBodyRows<TData extends RowData>({ table }: { table: Dat
  */
 const MemoizedDataGridTableDndBodyRows = memo(
   DataGridTableDndBodyRows,
-  (_prev, next) => !!next.table.store.state.columnResizing.isResizingColumn
+  (_prev, next) => !!next.table.state.columnResizing.isResizingColumn
 ) as typeof DataGridTableDndBodyRows
 
 function DataGridTableDnd<TData extends RowData>({
@@ -315,7 +315,7 @@ function DataGridTableDnd<TData extends RowData>({
                 return (
                   <DataGridTableHeadRow key={index} rowId={headerGroup.id}>
                     <SortableContext
-                      items={table.store.state.columnOrder}
+                      items={table.state.columnOrder}
                       strategy={horizontalListSortingStrategy}
                     >
                       {headerGroup.headers.map((header) => (

--- a/app/app/components/data-grid/data-grid-table-virtual.tsx
+++ b/app/app/components/data-grid/data-grid-table-virtual.tsx
@@ -578,7 +578,7 @@ function DataGridTableVirtualBody<TData extends RowData>({
  */
 const MemoizedVirtualBody = memo(
   DataGridTableVirtualBody,
-  (_prev, next) => !!next.table.store.state.columnResizing.isResizingColumn
+  (_prev, next) => !!next.table.state.columnResizing.isResizingColumn
 ) as typeof DataGridTableVirtualBody
 
 function DataGridTableVirtual<TData extends RowData>({

--- a/app/app/components/data-grid/data-grid-table-virtual.tsx
+++ b/app/app/components/data-grid/data-grid-table-virtual.tsx
@@ -1,4 +1,4 @@
-import type { Column, Row, Table } from "@tanstack/react-table"
+import type { Column, Row, RowData } from "@tanstack/react-table"
 import type {
   VirtualItem,
   Virtualizer,
@@ -10,7 +10,12 @@ import { flexRender } from "@tanstack/react-table"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { memo, useCallback, useEffect, useRef, useState } from "react"
 
-import { useDataGrid } from "~/components/data-grid/data-grid"
+import type {
+  DataGridFeatures,
+  DataGridTableInstance,
+} from "~/components/data-grid/data-grid"
+
+import { useDataGrid, useDataGridOf } from "~/components/data-grid/data-grid"
 import {
   DataGridTableBase,
   DataGridTableBody,
@@ -240,18 +245,18 @@ function scrollDataGridTableRowIntoView({
   return true
 }
 
-type DataGridTableVirtualizerOptions<TData> = Omit<
+type DataGridTableVirtualizerOptions<TData extends RowData> = Omit<
   VirtualizerOptions<HTMLElement, HTMLTableRowElement>,
   "count" | "estimateSize" | "getItemKey" | "getScrollElement"
 > & {
-  estimateSize?: (index: number, row: Row<TData>) => number
-  getItemKey?: (index: number, row: Row<TData>) => string | number
+  estimateSize?: (index: number, row: Row<DataGridFeatures, TData>) => number
+  getItemKey?: (index: number, row: Row<DataGridFeatures, TData>) => string | number
   getScrollElement?: (
     elements: DataGridTableVirtualScrollElements
   ) => HTMLElement | null
 }
 
-interface DataGridTableVirtualProps<TData> {
+interface DataGridTableVirtualProps<TData extends RowData> {
   estimateSize?: number
   fetchMoreOffset?: number
   footerContent?: ReactNode
@@ -270,32 +275,32 @@ interface DataGridTableVirtualProps<TData> {
   virtualizerOptions?: DataGridTableVirtualizerOptions<TData>
 }
 
-interface VirtualBodyProps<TData> {
+interface VirtualBodyProps<TData extends RowData> {
   allRowsLoadedMessage: ReactNode
-  bottomRows: Row<TData>[]
-  centerRows: Row<TData>[]
+  bottomRows: Row<DataGridFeatures, TData>[]
+  centerRows: Row<DataGridFeatures, TData>[]
   hasMore?: boolean
   isFetchingMore: boolean
   isInfiniteMode: boolean
   isVirtualizationEnabled: boolean
   loadingMoreMessage: ReactNode
   measureRowRef?: (element: HTMLTableRowElement | null) => void
-  table: Table<TData>
-  topRows: Row<TData>[]
+  table: DataGridTableInstance<TData>
+  topRows: Row<DataGridFeatures, TData>[]
   totalSize: number
   virtualItems: VirtualItem[]
 }
 
-function DataGridTableVirtualPinnedPlaceholderCell<TData>({
+function DataGridTableVirtualPinnedPlaceholderCell<TData extends RowData>({
   column,
 }: {
-  column: Column<TData>
+  column: Column<DataGridFeatures, TData>
 }) {
   const { props } = useDataGrid()
   const isPinned = column.getIsPinned()
-  const isLastLeftPinned = isPinned === "left" && column.getIsLastColumn("left")
-  const isFirstRightPinned =
-    isPinned === "right" && column.getIsFirstColumn("right")
+  const isLastStartPinned =
+    isPinned === "start" && column.getIsLastColumn("start")
+  const isFirstEndPinned = isPinned === "end" && column.getIsFirstColumn("end")
 
   return (
     <td
@@ -310,20 +315,20 @@ function DataGridTableVirtualPinnedPlaceholderCell<TData>({
       }}
       data-pinned={isPinned || undefined}
       data-last-col={
-        isLastLeftPinned ? "left" : isFirstRightPinned ? "right" : undefined
+        isLastStartPinned ? "left" : isFirstEndPinned ? "right" : undefined
       }
       className={cn(
         "p-0",
         props.tableLayout?.cellBorder && "border-e",
         props.tableLayout?.columnsPinnable &&
           column.getCanPin() &&
-          "data-pinned:bg-background data-pinned:isolate [&[data-pinned=left][data-last-col=left]]:shadow-[inset_-1px_0_0_0_var(--border)] [&[data-pinned=right][data-last-col=right]]:shadow-[inset_1px_0_0_0_var(--border)]"
+          "data-pinned:bg-background data-pinned:isolate [&[data-pinned=start][data-last-col=start]]:shadow-[inset_-1px_0_0_0_var(--border)] [&[data-pinned=end][data-last-col=end]]:shadow-[inset_1px_0_0_0_var(--border)]"
       )}
     />
   )
 }
 
-function DataGridTableVirtualUtilityRow<TData>({
+function DataGridTableVirtualUtilityRow<TData extends RowData>({
   table,
   children,
   centerCellClassName,
@@ -336,12 +341,12 @@ function DataGridTableVirtualUtilityRow<TData>({
   centerCellStyle?: CSSProperties
   children: ReactNode
   rowClassName?: string
-  table: Table<TData>
+  table: DataGridTableInstance<TData>
 }) {
   const { props } = useDataGrid()
-  const leftVisibleColumns = table.getLeftVisibleLeafColumns()
+  const leftVisibleColumns = table.getStartVisibleLeafColumns()
   const centerVisibleColumns = table.getCenterVisibleLeafColumns()
-  const rightVisibleColumns = table.getRightVisibleLeafColumns()
+  const rightVisibleColumns = table.getEndVisibleLeafColumns()
   const hasRightPinnedColumns = hasDataGridTableRightPinnedColumns(table)
 
   return (
@@ -375,12 +380,12 @@ function DataGridTableVirtualUtilityRow<TData>({
   )
 }
 
-function DataGridTableVirtualSpacer<TData>({
+function DataGridTableVirtualSpacer<TData extends RowData>({
   table,
   height,
 }: {
   height: number
-  table: Table<TData>
+  table: DataGridTableInstance<TData>
 }) {
   if (height <= 0) return null
 
@@ -396,14 +401,14 @@ function DataGridTableVirtualSpacer<TData>({
   )
 }
 
-function DataGridTableVirtualStatusRow<TData>({
+function DataGridTableVirtualStatusRow<TData extends RowData>({
   table,
   children,
   className,
 }: {
   children: ReactNode
   className?: string
-  table: Table<TData>
+  table: DataGridTableInstance<TData>
 }) {
   return (
     <DataGridTableVirtualUtilityRow
@@ -418,7 +423,7 @@ function DataGridTableVirtualStatusRow<TData>({
   )
 }
 
-function DataGridTableVirtualBody<TData>({
+function DataGridTableVirtualBody<TData extends RowData>({
   table,
   topRows,
   centerRows,
@@ -573,10 +578,10 @@ function DataGridTableVirtualBody<TData>({
  */
 const MemoizedVirtualBody = memo(
   DataGridTableVirtualBody,
-  (_prev, next) => !!next.table.getState().columnSizingInfo.isResizingColumn
+  (_prev, next) => !!next.table.store.state.columnResizing.isResizingColumn
 ) as typeof DataGridTableVirtualBody
 
-function DataGridTableVirtual<TData>({
+function DataGridTableVirtual<TData extends RowData>({
   height,
   estimateSize = 48,
   overscan = 10,
@@ -591,7 +596,9 @@ function DataGridTableVirtual<TData>({
   fetchMoreOffset = 0,
   virtualizerOptions,
 }: DataGridTableVirtualProps<TData>) {
-  const { table, props } = useDataGrid()
+  // Row-typed: the rows read off this table are handed to the caller's
+  // `estimateSize`/`getItemKey` callbacks, which are typed against TData.
+  const { table, props } = useDataGridOf<TData>()
   const mergedHeaderGroups = getDataGridTableMergedHeaderGroups(table)
   const hasRightPinnedColumns = hasDataGridTableRightPinnedColumns(table)
   const { topRows, centerRows, bottomRows } = getDataGridTableRowSections(
@@ -864,7 +871,7 @@ function DataGridTableVirtual<TData>({
             {mergedHeaderGroups.map((headerGroup) => (
               <DataGridTableHeadRow key={headerGroup.id} rowId={headerGroup.id}>
                 {headerGroup.headers
-                  .filter((header) => header.column.getIsPinned() !== "right")
+                  .filter((header) => header.column.getIsPinned() !== "end")
                   .map((header) => {
                     const { column } = header
 
@@ -886,7 +893,7 @@ function DataGridTableVirtual<TData>({
                   <DataGridTableFillHeadCell />
                 ) : null}
                 {headerGroup.headers
-                  .filter((header) => header.column.getIsPinned() === "right")
+                  .filter((header) => header.column.getIsPinned() === "end")
                   .map((header) => {
                     const { column } = header
 

--- a/app/app/components/data-grid/data-grid-table.tsx
+++ b/app/app/components/data-grid/data-grid-table.tsx
@@ -890,6 +890,26 @@ function DataGridTableHeadRowCell<TData extends RowData>({
   )
 }
 
+/**
+ * TanStack's own default, restated here on purpose.
+ *
+ * v8 merged each feature's default table options into `table.options`, so
+ * reading `table.options.columnResizeMode` gave you `"onEnd"` even when the
+ * consumer never set it. v9 resolves feature defaults internally and leaves
+ * the option `undefined` on the instance, so the v8 `?? table.options...`
+ * fallback quietly produces `undefined` — and every grid that has not opted
+ * into a mode explicitly loses the onEnd drag session: no cursor lock, no
+ * vertical indicator, and an immediate commit instead of a deferred one.
+ */
+const DATA_GRID_DEFAULT_COLUMN_RESIZE_MODE = "onEnd" as const
+
+function getDataGridColumnResizeMode(
+  layoutMode: "onChange" | "onEnd" | undefined,
+  tableMode: "onChange" | "onEnd" | undefined
+) {
+  return layoutMode ?? tableMode ?? DATA_GRID_DEFAULT_COLUMN_RESIZE_MODE
+}
+
 function DataGridTableHeadRowCellResize<TData extends RowData>({
   header,
 }: {
@@ -904,8 +924,10 @@ function DataGridTableHeadRowCellResize<TData extends RowData>({
     column.getIndex() ===
     header.getContext().table.getVisibleLeafColumns().length - 1
   const isResizeModeOnEnd =
-    (props.tableLayout?.columnsResizeMode ?? table.options.columnResizeMode) ===
-    "onEnd"
+    getDataGridColumnResizeMode(
+      props.tableLayout?.columnsResizeMode,
+      table.options.columnResizeMode
+    ) === "onEnd"
   const stopResizeSessionRef = useRef<(() => void) | undefined>(undefined)
 
   // End a live drag if the handle unmounts mid-resize so document listeners
@@ -1011,8 +1033,10 @@ function DataGridTableResizeIndicator({
   }>({ key: false, value: 0 })
   const columnResizing = table.state.columnResizing
   const resizingColumnId = columnResizing.isResizingColumn
-  const resizeMode =
-    props.tableLayout?.columnsResizeMode ?? table.options.columnResizeMode
+  const resizeMode = getDataGridColumnResizeMode(
+    props.tableLayout?.columnsResizeMode,
+    table.options.columnResizeMode
+  )
   const isActive = !!(
     props.tableLayout?.columnsResizable &&
     resizeMode === "onEnd" &&

--- a/app/app/components/data-grid/data-grid-table.tsx
+++ b/app/app/components/data-grid/data-grid-table.tsx
@@ -507,7 +507,7 @@ function getDataGridTableMergedHeaderGroups<TData extends RowData>(table: DataGr
 }
 
 function hasDataGridTableRightPinnedColumns<TData extends RowData>(table: DataGridTableInstance<TData>) {
-  return (table.store.state.columnPinning.end?.length ?? 0) > 0
+  return (table.state.columnPinning.end?.length ?? 0) > 0
 }
 
 function DataGridTableFillCol() {
@@ -595,10 +595,10 @@ function DataGridTableBase({ children }: { children: ReactNode }) {
     props.tableLayout?.columnsResizable,
     // Visibility/order/pinning change the flat header set, so a column shown
     // after mount must get its size variable even though sizing is untouched.
-    table.store.state.columnSizing,
-    table.store.state.columnVisibility,
-    table.store.state.columnOrder,
-    table.store.state.columnPinning,
+    table.state.columnSizing,
+    table.state.columnVisibility,
+    table.state.columnOrder,
+    table.state.columnPinning,
   ])
 
   return (
@@ -1009,7 +1009,7 @@ function DataGridTableResizeIndicator({
     key: string | false
     value: number
   }>({ key: false, value: 0 })
-  const columnResizing = table.store.state.columnResizing
+  const columnResizing = table.state.columnResizing
   const resizingColumnId = columnResizing.isResizingColumn
   const resizeMode =
     props.tableLayout?.columnsResizeMode ?? table.options.columnResizeMode
@@ -1672,7 +1672,7 @@ function DataGridTableRowExpand<TData extends RowData>({
 
 function DataGridTableBodyRows<TData extends RowData>({ table }: { table: DataGridTableInstance<TData> }) {
   const { isLoading, props } = useDataGrid()
-  const pagination = table.store.state.pagination
+  const pagination = table.state.pagination
 
   if (isLoading && props.loadingMode === "skeleton" && pagination?.pageSize) {
     const leftVisibleColumns = table.getStartVisibleLeafColumns()
@@ -1771,7 +1771,7 @@ function DataGridTableBodyRows<TData extends RowData>({ table }: { table: DataGr
  */
 const MemoizedDataGridTableBodyRows = memo(
   DataGridTableBodyRows,
-  (_prev, next) => !!next.table.store.state.columnResizing.isResizingColumn
+  (_prev, next) => !!next.table.state.columnResizing.isResizingColumn
 ) as typeof DataGridTableBodyRows
 
 function DataGridTableHeader<TData extends RowData>() {

--- a/app/app/components/data-grid/data-grid-table.tsx
+++ b/app/app/components/data-grid/data-grid-table.tsx
@@ -1,4 +1,4 @@
-import type { Cell, Column, Header, Row, Table } from "@tanstack/react-table"
+import type { Cell, Column, Header, Row, RowData } from "@tanstack/react-table"
 import type {
   CSSProperties,
   MouseEvent as ReactMouseEvent,
@@ -20,7 +20,12 @@ import {
 } from "react"
 import { useTranslation } from "react-i18next";
 
-import { useDataGrid } from "~/components/data-grid/data-grid"
+import type {
+  DataGridFeatures,
+  DataGridTableInstance,
+} from "~/components/data-grid/data-grid"
+
+import { useDataGrid, useDataGridOf } from "~/components/data-grid/data-grid"
 import { cn } from "~/lib/utils"
 import { Checkbox } from "~/ui/checkbox"
 import { Spinner } from "~/ui/spinner"
@@ -48,17 +53,17 @@ const footerCellSpacingVariants = ({ size }: { size?: "dense" | "default" }) =>
   size === "dense" ? "px-2 py-1" : "px-2.5 py-1.5"
 // ─── end density skin ──────────────────────────────────────────────────────
 
-function getPinningStyles<TData>(column: Column<TData>): CSSProperties {
+function getPinningStyles<TData extends RowData>(column: Column<DataGridFeatures, TData>): CSSProperties {
   const isPinned = column.getIsPinned()
 
   return {
-    // Logical offsets: TanStack's "left"/"right" buckets are start/end
-    // semantics, so pinned columns stick to the correct edge in RTL too
-    // (identical to left/right in LTR).
+    // v9 names the pinning buckets logically ("start"/"end") rather than
+    // physically, which is what these logical inset properties already
+    // assumed — pinned columns stick to the correct edge in RTL too.
     insetInlineStart:
-      isPinned === "left" ? `${column.getStart("left")}px` : undefined,
+      isPinned === "start" ? `${column.getStart("start")}px` : undefined,
     insetInlineEnd:
-      isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
+      isPinned === "end" ? `${column.getAfter("end")}px` : undefined,
     position: isPinned ? "sticky" : undefined,
     transform: isPinned ? "translateZ(0)" : undefined,
     contain: isPinned ? "paint" : undefined,
@@ -71,8 +76,8 @@ function getPinningStyles<TData>(column: Column<TData>): CSSProperties {
 // Shared indent contract for tree rows: DataGridTableRowExpand consumes it,
 // and fully custom cells can reuse it for depth alignment without the
 // built-in toggle.
-function getDataGridTreeIndentStyle<TData>(
-  row: Row<TData>,
+function getDataGridTreeIndentStyle<TData extends RowData>(
+  row: Row<DataGridFeatures, TData>,
   indent: number = 20
 ): CSSProperties {
   return {
@@ -153,10 +158,10 @@ function getDataGridResizeEventClientX(
   return event.clientX
 }
 
-function startDataGridColumnResizeOnEnd<TData>(
+function startDataGridColumnResizeOnEnd<TData extends RowData>(
   event: DataGridResizeStartEvent,
-  header: Header<TData, unknown>,
-  table: Table<TData>
+  header: Header<DataGridFeatures, TData, unknown>,
+  table: DataGridTableInstance<TData>
 ): (() => void) | undefined {
   const column = table.getColumn(header.column.id)
 
@@ -259,7 +264,7 @@ function startDataGridColumnResizeOnEnd<TData>(
         ) / 100
     })
 
-    table.setColumnSizingInfo((old) => ({
+    table.setColumnResizing((old) => ({
       ...old,
       startOffset,
       startSize,
@@ -286,7 +291,7 @@ function startDataGridColumnResizeOnEnd<TData>(
 
     stopListeners.forEach((stop) => stop())
     updateOffset(clientXPos, true)
-    table.setColumnSizingInfo((old) => ({
+    table.setColumnResizing((old) => ({
       ...old,
       isResizingColumn: false,
       startOffset: null,
@@ -381,7 +386,7 @@ function startDataGridColumnResizeOnEnd<TData>(
     )
   }
 
-  table.setColumnSizingInfo((old) => ({
+  table.setColumnResizing((old) => ({
     ...old,
     startOffset,
     startSize,
@@ -396,27 +401,27 @@ function startDataGridColumnResizeOnEnd<TData>(
 
 type DataGridTablePinnedBoundary = "top" | "bottom"
 
-function getDataGridTableRowSections<TData>(
-  table: Table<TData>,
+function getDataGridTableRowSections<TData extends RowData>(
+  table: DataGridTableInstance<TData>,
   rowsPinnable?: boolean
 ) {
   if (!rowsPinnable) {
     return {
-      topRows: [] as Row<TData>[],
-      centerRows: table.getRowModel().rows as Row<TData>[],
-      bottomRows: [] as Row<TData>[],
+      topRows: [] as Row<DataGridFeatures, TData>[],
+      centerRows: table.getRowModel().rows as Row<DataGridFeatures, TData>[],
+      bottomRows: [] as Row<DataGridFeatures, TData>[],
     }
   }
 
   return {
-    topRows: table.getTopRows() as Row<TData>[],
-    centerRows: table.getCenterRows() as Row<TData>[],
-    bottomRows: table.getBottomRows() as Row<TData>[],
+    topRows: table.getTopRows() as Row<DataGridFeatures, TData>[],
+    centerRows: table.getCenterRows() as Row<DataGridFeatures, TData>[],
+    bottomRows: table.getBottomRows() as Row<DataGridFeatures, TData>[],
   }
 }
 
-function getDataGridTableResolvedRows<TData>(
-  table: Table<TData>,
+function getDataGridTableResolvedRows<TData extends RowData>(
+  table: DataGridTableInstance<TData>,
   rowsPinnable?: boolean
 ) {
   const { topRows, centerRows, bottomRows } = getDataGridTableRowSections(
@@ -425,7 +430,7 @@ function getDataGridTableResolvedRows<TData>(
   )
   const resolvedRows: Array<{
     pinnedBoundary?: DataGridTablePinnedBoundary
-    row: Row<TData>
+    row: Row<DataGridFeatures, TData>
   }> = []
 
   topRows.forEach((row, index) => {
@@ -456,26 +461,26 @@ function getDataGridTableResolvedRows<TData>(
   return resolvedRows
 }
 
-function getDataGridTableOrderedVisibleColumns<TData>(table: Table<TData>) {
+function getDataGridTableOrderedVisibleColumns<TData extends RowData>(table: DataGridTableInstance<TData>) {
   return [
-    ...table.getLeftVisibleLeafColumns(),
+    ...table.getStartVisibleLeafColumns(),
     ...table.getCenterVisibleLeafColumns(),
-    ...table.getRightVisibleLeafColumns(),
-  ] as Column<TData>[]
+    ...table.getEndVisibleLeafColumns(),
+  ] as Column<DataGridFeatures, TData>[]
 }
 
-function getDataGridTableOrderedVisibleCells<TData>(row: Row<TData>) {
+function getDataGridTableOrderedVisibleCells<TData extends RowData>(row: Row<DataGridFeatures, TData>) {
   return [
-    ...row.getLeftVisibleCells(),
+    ...row.getStartVisibleCells(),
     ...row.getCenterVisibleCells(),
-    ...row.getRightVisibleCells(),
-  ] as Cell<TData, unknown>[]
+    ...row.getEndVisibleCells(),
+  ] as Cell<DataGridFeatures, TData, unknown>[]
 }
 
-function getDataGridTableMergedHeaderGroups<TData>(table: Table<TData>) {
-  const leftHeaderGroups = table.getLeftHeaderGroups()
+function getDataGridTableMergedHeaderGroups<TData extends RowData>(table: DataGridTableInstance<TData>) {
+  const leftHeaderGroups = table.getStartHeaderGroups()
   const centerHeaderGroups = table.getCenterHeaderGroups()
-  const rightHeaderGroups = table.getRightHeaderGroups()
+  const rightHeaderGroups = table.getEndHeaderGroups()
   const headerGroupCount = Math.max(
     leftHeaderGroups.length,
     centerHeaderGroups.length,
@@ -496,13 +501,13 @@ function getDataGridTableMergedHeaderGroups<TData>(table: Table<TData>) {
         ...(leftGroup?.headers ?? []),
         ...(centerGroup?.headers ?? []),
         ...(rightGroup?.headers ?? []),
-      ] as Header<TData, unknown>[],
+      ] as Header<DataGridFeatures, TData, unknown>[],
     }
   })
 }
 
-function hasDataGridTableRightPinnedColumns<TData>(table: Table<TData>) {
-  return (table.getState().columnPinning.right?.length ?? 0) > 0
+function hasDataGridTableRightPinnedColumns<TData extends RowData>(table: DataGridTableInstance<TData>) {
+  return (table.store.state.columnPinning.end?.length ?? 0) > 0
 }
 
 function DataGridTableFillCol() {
@@ -565,9 +570,9 @@ function DataGridTableFillFootCell() {
 
 function DataGridTableBase({ children }: { children: ReactNode }) {
   const { props, table } = useDataGrid()
-  const leftVisibleColumns = table.getLeftVisibleLeafColumns()
+  const leftVisibleColumns = table.getStartVisibleLeafColumns()
   const centerVisibleColumns = table.getCenterVisibleLeafColumns()
-  const rightVisibleColumns = table.getRightVisibleLeafColumns()
+  const rightVisibleColumns = table.getEndVisibleLeafColumns()
   const hasRightPinnedColumns = hasDataGridTableRightPinnedColumns(table)
 
   /**
@@ -590,10 +595,10 @@ function DataGridTableBase({ children }: { children: ReactNode }) {
     props.tableLayout?.columnsResizable,
     // Visibility/order/pinning change the flat header set, so a column shown
     // after mount must get its size variable even though sizing is untouched.
-    table.getState().columnSizing,
-    table.getState().columnVisibility,
-    table.getState().columnOrder,
-    table.getState().columnPinning,
+    table.store.state.columnSizing,
+    table.store.state.columnVisibility,
+    table.store.state.columnOrder,
+    table.store.state.columnPinning,
   ])
 
   return (
@@ -791,7 +796,7 @@ function DataGridTableHeadRow({
   )
 }
 
-function DataGridTableHeadRowCell<TData>({
+function DataGridTableHeadRowCell<TData extends RowData>({
   children,
   header,
   dndRef,
@@ -800,19 +805,18 @@ function DataGridTableHeadRowCell<TData>({
   children: ReactNode
   dndRef?: React.Ref<HTMLTableCellElement>
   dndStyle?: CSSProperties
-  header: Header<TData, unknown>
+  header: Header<DataGridFeatures, TData, unknown>
 }) {
   const { props } = useDataGrid()
 
   const { column } = header
   const isPinned = column.getIsPinned()
-  const isFirstLeftPinned =
-    isPinned === "left" && column.getIsFirstColumn("left")
-  const isLastLeftPinned = isPinned === "left" && column.getIsLastColumn("left")
-  const isFirstRightPinned =
-    isPinned === "right" && column.getIsFirstColumn("right")
-  const isLastRightPinned =
-    isPinned === "right" && column.getIsLastColumn("right")
+  const isFirstStartPinned =
+    isPinned === "start" && column.getIsFirstColumn("start")
+  const isLastStartPinned =
+    isPinned === "start" && column.getIsLastColumn("start")
+  const isFirstEndPinned = isPinned === "end" && column.getIsFirstColumn("end")
+  const isLastEndPinned = isPinned === "end" && column.getIsLastColumn("end")
   const isLastVisibleColumn =
     column.getIndex() ===
     header.getContext().table.getVisibleLeafColumns().length - 1
@@ -849,10 +853,10 @@ function DataGridTableHeadRowCell<TData>({
       }}
       data-pinned={isPinned || undefined}
       data-outer-pinned-col={
-        isFirstLeftPinned ? "left" : isLastRightPinned ? "right" : undefined
+        isFirstStartPinned ? "start" : isLastEndPinned ? "end" : undefined
       }
       data-last-col={
-        isLastLeftPinned ? "left" : isFirstRightPinned ? "right" : undefined
+        isLastStartPinned ? "start" : isFirstEndPinned ? "end" : undefined
       }
       className={cn(
         "text-foreground relative h-10 text-start align-middle font-medium rtl:text-right [&:has([role=checkbox])]:pe-0",
@@ -870,8 +874,8 @@ function DataGridTableHeadRowCell<TData>({
           column.getCanPin() &&
           cn(
             "data-pinned:bg-muted data-outer-pinned-col:bg-clip-padding data-pinned:isolate",
-            "[&[data-pinned=left][data-last-col=left]]:shadow-[inset_-1px_0_0_0_var(--border)] [&[data-pinned=right]:last-child_div.cursor-col-resize:last-child]:opacity-0 [&[data-pinned=right][data-last-col=right]]:shadow-[inset_1px_0_0_0_var(--border)]",
-            "[&:not([data-pinned]):has(+[data-pinned])_div.cursor-col-resize:last-child]:opacity-0 [&[data-last-col=left]_div.cursor-col-resize:last-child]:opacity-0"
+            "[&[data-pinned=start][data-last-col=start]]:shadow-[inset_-1px_0_0_0_var(--border)] [&[data-pinned=end]:last-child_div.cursor-col-resize:last-child]:opacity-0 [&[data-pinned=end][data-last-col=end]]:shadow-[inset_1px_0_0_0_var(--border)]",
+            "[&:not([data-pinned]):has(+[data-pinned])_div.cursor-col-resize:last-child]:opacity-0 [&[data-last-col=start]_div.cursor-col-resize:last-child]:opacity-0"
           ),
         header.column.columnDef.meta?.headerClassName,
         // Edge detection spans the full visible leaf order; the header's own
@@ -886,12 +890,14 @@ function DataGridTableHeadRowCell<TData>({
   )
 }
 
-function DataGridTableHeadRowCellResize<TData>({
+function DataGridTableHeadRowCellResize<TData extends RowData>({
   header,
 }: {
-  header: Header<TData, unknown>
+  header: Header<DataGridFeatures, TData, unknown>
 }) {
-  const { props, table } = useDataGrid()
+  // Row-typed: `table` is handed straight back to the resize session
+  // alongside this component's `header`.
+  const { props, table } = useDataGridOf<TData>()
   const { column } = header
   const isPinned = column.getIsPinned()
   const isLastVisibleColumn =
@@ -1003,8 +1009,8 @@ function DataGridTableResizeIndicator({
     key: string | false
     value: number
   }>({ key: false, value: 0 })
-  const columnSizingInfo = table.getState().columnSizingInfo
-  const resizingColumnId = columnSizingInfo.isResizingColumn
+  const columnResizing = table.store.state.columnResizing
+  const resizingColumnId = columnResizing.isResizingColumn
   const resizeMode =
     props.tableLayout?.columnsResizeMode ?? table.options.columnResizeMode
   const isActive = !!(
@@ -1040,7 +1046,7 @@ function DataGridTableResizeIndicator({
     const directionMultiplier =
       table.options.columnResizeDirection === "rtl" ? -1 : 1
     const deltaOffset =
-      (columnSizingInfo.deltaOffset ?? 0) * directionMultiplier
+      (columnResizing.deltaOffset ?? 0) * directionMultiplier
 
     if (headerHeightCacheRef.current.key !== resizingColumnId) {
       headerHeightCacheRef.current = {
@@ -1054,8 +1060,8 @@ function DataGridTableResizeIndicator({
 
     const headerHeight = headerHeightCacheRef.current.value
     const indicatorLeft =
-      typeof columnSizingInfo.startOffset === "number" && viewportElement
-        ? columnSizingInfo.startOffset -
+      typeof columnResizing.startOffset === "number" && viewportElement
+        ? columnResizing.startOffset -
           viewportElement.getBoundingClientRect().left
         : resizingHeader.getStart() + resizingHeader.getSize()
 
@@ -1194,12 +1200,12 @@ function DataGridTableBodyRowSkeleton({ children }: { children: ReactNode }) {
   )
 }
 
-function DataGridTableBodyRowSkeletonCell<TData>({
+function DataGridTableBodyRowSkeletonCell<TData extends RowData>({
   children,
   column,
 }: {
   children: ReactNode
-  column: Column<TData>
+  column: Column<DataGridFeatures, TData>
 }) {
   const { props, table } = useDataGrid()
   const bodyCellSpacing = bodyCellSpacingVariants({
@@ -1223,7 +1229,7 @@ function DataGridTableBodyRowSkeletonCell<TData>({
         column.columnDef.meta?.cellClassName,
         props.tableLayout?.columnsPinnable &&
           column.getCanPin() &&
-          "data-pinned:bg-background data-pinned:isolate [&[data-pinned=left][data-last-col=left]]:shadow-[inset_-1px_0_0_0_var(--border)] [&[data-pinned=right][data-last-col=right]]:shadow-[inset_1px_0_0_0_var(--border)]",
+          "data-pinned:bg-background data-pinned:isolate [&[data-pinned=start][data-last-col=start]]:shadow-[inset_-1px_0_0_0_var(--border)] [&[data-pinned=end][data-last-col=end]]:shadow-[inset_1px_0_0_0_var(--border)]",
         column.getIndex() === 0 ||
           column.getIndex() === table.getVisibleLeafColumns().length - 1
           ? props.tableClassNames?.edgeCell
@@ -1235,7 +1241,7 @@ function DataGridTableBodyRowSkeletonCell<TData>({
   )
 }
 
-function DataGridTableBodyRow<TData>({
+function DataGridTableBodyRow<TData extends RowData>({
   children,
   row,
   pinnedBoundary,
@@ -1249,7 +1255,7 @@ function DataGridTableBodyRow<TData>({
   dndRef?: React.Ref<HTMLTableRowElement>
   dndStyle?: CSSProperties
   pinnedBoundary?: DataGridTablePinnedBoundary
-  row: Row<TData>
+  row: Row<DataGridFeatures, TData>
   rowRef?: React.Ref<HTMLTableRowElement>
 }) {
   const { props, table } = useDataGrid()
@@ -1309,7 +1315,7 @@ function DataGridTableBodyRow<TData>({
   )
 }
 
-function DataGridTableBodyRowExpandded<TData>({ row }: { row: Row<TData> }) {
+function DataGridTableBodyRowExpandded<TData extends RowData>({ row }: { row: Row<DataGridFeatures, TData> }) {
   const { props, table } = useDataGrid()
   const expandedContent = table
     .getAllColumns()
@@ -1340,13 +1346,13 @@ function DataGridTableBodyRowExpandded<TData>({ row }: { row: Row<TData> }) {
   )
 }
 
-function DataGridTableBodyRowCell<TData>({
+function DataGridTableBodyRowCell<TData extends RowData>({
   children,
   cell,
   dndRef,
   dndStyle,
 }: {
-  cell: Cell<TData, unknown>
+  cell: Cell<DataGridFeatures, TData, unknown>
   children: ReactNode
   dndRef?: React.Ref<HTMLTableCellElement>
   dndStyle?: CSSProperties
@@ -1355,9 +1361,9 @@ function DataGridTableBodyRowCell<TData>({
 
   const { column, row } = cell
   const isPinned = column.getIsPinned()
-  const isLastLeftPinned = isPinned === "left" && column.getIsLastColumn("left")
-  const isFirstRightPinned =
-    isPinned === "right" && column.getIsFirstColumn("right")
+  const isLastStartPinned =
+    isPinned === "start" && column.getIsLastColumn("start")
+  const isFirstEndPinned = isPinned === "end" && column.getIsFirstColumn("end")
   const bodyCellSpacing = bodyCellSpacingVariants({
     size: props.tableLayout?.dense ? "dense" : "default",
   })
@@ -1376,7 +1382,7 @@ function DataGridTableBodyRowCell<TData>({
       }}
       data-pinned={isPinned || undefined}
       data-last-col={
-        isLastLeftPinned ? "left" : isFirstRightPinned ? "right" : undefined
+        isLastStartPinned ? "start" : isFirstEndPinned ? "end" : undefined
       }
       className={cn(
         "align-middle",
@@ -1390,8 +1396,8 @@ function DataGridTableBodyRowCell<TData>({
           column.getCanPin() &&
           cn(
             "data-pinned:bg-background data-pinned:isolate",
-            "[&[data-pinned=left][data-last-col=left]]:shadow-[inset_-1px_0_0_0_var(--border)]",
-            "[&[data-pinned=right][data-last-col=right]]:shadow-[inset_1px_0_0_0_var(--border)]"
+            "[&[data-pinned=start][data-last-col=start]]:shadow-[inset_-1px_0_0_0_var(--border)]",
+            "[&[data-pinned=end][data-last-col=end]]:shadow-[inset_1px_0_0_0_var(--border)]"
           ),
         column.getIndex() === 0 ||
           column.getIndex() === row.getVisibleCells().length - 1
@@ -1404,22 +1410,22 @@ function DataGridTableBodyRowCell<TData>({
   )
 }
 
-function DataGridTableRenderedRow<TData>({
+function DataGridTableRenderedRow<TData extends RowData>({
   row,
   pinnedBoundary,
   rowRef,
   rowIndex,
 }: {
   pinnedBoundary?: DataGridTablePinnedBoundary
-  row: Row<TData>
+  row: Row<DataGridFeatures, TData>
   /** Virtualized list index, rendered as data-index for measureElement. */
   rowIndex?: number
   rowRef?: React.Ref<HTMLTableRowElement>
 }) {
   const { props, table } = useDataGrid()
-  const leftVisibleCells = row.getLeftVisibleCells()
+  const leftVisibleCells = row.getStartVisibleCells()
   const centerVisibleCells = row.getCenterVisibleCells()
-  const rightVisibleCells = row.getRightVisibleCells()
+  const rightVisibleCells = row.getEndVisibleCells()
   const hasRightPinnedColumns = hasDataGridTableRightPinnedColumns(table)
 
   return (
@@ -1431,7 +1437,7 @@ function DataGridTableRenderedRow<TData>({
         dataIndex={rowIndex}
       >
         {[...leftVisibleCells, ...centerVisibleCells].map(
-          (cell: Cell<TData, unknown>) => (
+          (cell: Cell<DataGridFeatures, TData, unknown>) => (
             <DataGridTableBodyRowCell cell={cell} key={cell.id}>
               {flexRender(cell.column.columnDef.cell, cell.getContext())}
             </DataGridTableBodyRowCell>
@@ -1440,7 +1446,7 @@ function DataGridTableRenderedRow<TData>({
         {props.tableLayout?.columnsResizable && hasRightPinnedColumns ? (
           <DataGridTableFillBodyCell />
         ) : null}
-        {rightVisibleCells.map((cell: Cell<TData, unknown>) => (
+        {rightVisibleCells.map((cell: Cell<DataGridFeatures, TData, unknown>) => (
           <DataGridTableBodyRowCell cell={cell} key={cell.id}>
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </DataGridTableBodyRowCell>
@@ -1487,7 +1493,7 @@ function DataGridTableLoader() {
   )
 }
 
-function DataGridTableRowPin<TData>({ row }: { row: Row<TData> }) {
+function DataGridTableRowPin<TData extends RowData>({ row }: { row: Row<DataGridFeatures, TData> }) {
   const isPinned = row.getIsPinned()
 
   return (
@@ -1540,7 +1546,7 @@ function DataGridTableRowPin<TData>({ row }: { row: Row<TData> }) {
   )
 }
 
-function DataGridTableRowSelect<TData>({ row }: { row: Row<TData> }) {
+function DataGridTableRowSelect<TData extends RowData>({ row }: { row: Row<DataGridFeatures, TData> }) {
   const { t } = useTranslation();
 
   return (
@@ -1576,6 +1582,11 @@ function DataGridTableRowSelectAll() {
   const { table, recordCount, isLoading } = useDataGrid()
 
   const isAllSelected = table.getIsAllPageRowsSelected()
+  // v9 redefined this to mean "at least one", including the all-selected
+  // case, where v8 meant "some but not all". The `!isAllSelected` below
+  // already excludes that case, so this stays correct — it just now yields
+  // `false` rather than `undefined` when everything is selected, which Base
+  // UI treats identically (`indeterminate?: boolean | undefined`).
   const isSomeSelected = table.getIsSomePageRowsSelected()
 
   return (
@@ -1591,7 +1602,7 @@ function DataGridTableRowSelectAll() {
   )
 }
 
-function DataGridTableRowExpand<TData>({
+function DataGridTableRowExpand<TData extends RowData>({
   row,
   indent = 20,
   className,
@@ -1602,7 +1613,7 @@ function DataGridTableRowExpand<TData>({
   className?: string
   /** Horizontal offset in px applied per tree depth level. */
   indent?: number
-  row: Row<TData>
+  row: Row<DataGridFeatures, TData>
 }) {
   const { props } = useDataGrid()
   const isExpanded = row.getIsExpanded()
@@ -1659,14 +1670,14 @@ function DataGridTableRowExpand<TData>({
   )
 }
 
-function DataGridTableBodyRows<TData>({ table }: { table: Table<TData> }) {
+function DataGridTableBodyRows<TData extends RowData>({ table }: { table: DataGridTableInstance<TData> }) {
   const { isLoading, props } = useDataGrid()
-  const pagination = table.getState().pagination
+  const pagination = table.store.state.pagination
 
   if (isLoading && props.loadingMode === "skeleton" && pagination?.pageSize) {
-    const leftVisibleColumns = table.getLeftVisibleLeafColumns()
+    const leftVisibleColumns = table.getStartVisibleLeafColumns()
     const centerVisibleColumns = table.getCenterVisibleLeafColumns()
-    const rightVisibleColumns = table.getRightVisibleLeafColumns()
+    const rightVisibleColumns = table.getEndVisibleLeafColumns()
     const hasRightPinnedColumns = hasDataGridTableRightPinnedColumns(table)
 
     return (
@@ -1760,10 +1771,10 @@ function DataGridTableBodyRows<TData>({ table }: { table: Table<TData> }) {
  */
 const MemoizedDataGridTableBodyRows = memo(
   DataGridTableBodyRows,
-  (_prev, next) => !!next.table.getState().columnSizingInfo.isResizingColumn
+  (_prev, next) => !!next.table.store.state.columnResizing.isResizingColumn
 ) as typeof DataGridTableBodyRows
 
-function DataGridTableHeader<TData>() {
+function DataGridTableHeader<TData extends RowData>() {
   const { table, props } = useDataGrid()
   const mergedHeaderGroups = getDataGridTableMergedHeaderGroups(table)
   const hasRightPinnedColumns = hasDataGridTableRightPinnedColumns(table)
@@ -1776,7 +1787,7 @@ function DataGridTableHeader<TData>() {
             return (
               <DataGridTableHeadRow key={headerGroup.id} rowId={headerGroup.id}>
                 {headerGroup.headers
-                  .filter((header) => header.column.getIsPinned() !== "right")
+                  .filter((header) => header.column.getIsPinned() !== "end")
                   .map((header) => {
                     const { column } = header
 
@@ -1798,7 +1809,7 @@ function DataGridTableHeader<TData>() {
                   <DataGridTableFillHeadCell />
                 ) : null}
                 {headerGroup.headers
-                  .filter((header) => header.column.getIsPinned() === "right")
+                  .filter((header) => header.column.getIsPinned() === "end")
                   .map((header) => {
                     const { column } = header
 
@@ -1828,7 +1839,7 @@ function DataGridTableHeader<TData>() {
   )
 }
 
-function DataGridTable<TData>({
+function DataGridTable<TData extends RowData>({
   footerContent,
   renderHeader = true,
 }: {
@@ -1850,7 +1861,7 @@ function DataGridTable<TData>({
                   rowId={headerGroup.id}
                 >
                   {headerGroup.headers
-                    .filter((header) => header.column.getIsPinned() !== "right")
+                    .filter((header) => header.column.getIsPinned() !== "end")
                     .map((header) => {
                       const { column } = header
 
@@ -1875,7 +1886,7 @@ function DataGridTable<TData>({
                     <DataGridTableFillHeadCell />
                   ) : null}
                   {headerGroup.headers
-                    .filter((header) => header.column.getIsPinned() === "right")
+                    .filter((header) => header.column.getIsPinned() === "end")
                     .map((header) => {
                       const { column } = header
 

--- a/app/app/components/data-grid/data-grid.tsx
+++ b/app/app/components/data-grid/data-grid.tsx
@@ -2,9 +2,9 @@ import type {
   CellData,
   Column,
   ColumnFiltersState,
+  ReactTable,
   RowData,
   SortingState,
-  Table,
   TableFeatures,
 } from "@tanstack/react-table"
 import type { ReactNode } from "react"
@@ -20,6 +20,7 @@ import {
   createFacetedRowModel,
   createFacetedUniqueValues,
   globalFilteringFeature,
+  metaHelper,
   rowExpandingFeature,
   rowPaginationFeature,
   rowPinningFeature,
@@ -69,6 +70,7 @@ export const dataGridFeatures = tableFeatures({
   rowSortingFeature,
   facetedRowModel: createFacetedRowModel(),
   facetedUniqueValues: createFacetedUniqueValues(),
+  columnMeta: metaHelper<DataGridColumnMeta>(),
   // `'auto'` resolves only against registered names, so the built-ins a
   // client-sorting consumer would reach for are registered up front.
   sortFns: {
@@ -81,27 +83,38 @@ export const dataGridFeatures = tableFeatures({
 
 export type DataGridFeatures = typeof dataGridFeatures
 
-/** The table instance shape every shared grid component consumes. */
-export type DataGridTableInstance<TData extends RowData> = Table<
+/**
+ * The table instance shape every shared grid component consumes.
+ *
+ * `ReactTable`, not core `Table`: the render-time state surface these
+ * components read (`table.state`) is contributed by the React adapter, which
+ * also deprecates the `table.store.state` snapshot for render reads.
+ */
+export type DataGridTableInstance<TData extends RowData> = ReactTable<
   DataGridFeatures,
   TData
 >
 
-declare module "@tanstack/react-table" {
-  // Must mirror v9's declaration exactly — parameter list and variance
-  // annotations included — or the merge is rejected.
-  interface ColumnMeta<
-    in out TFeatures extends TableFeatures,
-    in out TData extends RowData,
-    TValue extends CellData = CellData,
-  > {
-    autoSize?: boolean
-    cellClassName?: string
-    expandedContent?: (row: TData) => ReactNode
-    headerClassName?: string
-    headerTitle?: string
-    skeleton?: ReactNode
-  }
+/**
+ * The type of `columnDef.meta` for every grid in this app.
+ *
+ * Registered as the features-level `columnMeta` slot rather than by
+ * augmenting the global `ColumnMeta` interface, which is what v9 (and the
+ * upstream ReUI grid) call for. The two are not additive: a features-level
+ * slot *overrides* the global interface, so keeping a `declare module`
+ * augmentation alongside one would silently drop these fields.
+ *
+ * `expandedContent` is row-untyped because a type-only slot is fixed for the
+ * table and cannot be generic over `TData`; the renderer calls it with
+ * `row.original`.
+ */
+export type DataGridColumnMeta = {
+  autoSize?: boolean
+  cellClassName?: string
+  expandedContent?: (row: any) => ReactNode
+  headerClassName?: string
+  headerTitle?: string
+  skeleton?: ReactNode
 }
 
 /** Label for headers / column visibility: `meta.headerTitle`, string `columnDef.header`, or `column.id`. */
@@ -156,16 +169,18 @@ export type DataGridAutoSizeController = {
 }
 
 function createDataGridAutoSizeController<TData extends RowData>(
-  table: DataGridTableInstance<TData>
+  // Resolved per call rather than captured: v9's `useTable` returns a fresh
+  // wrapper on nearly every render (see `DataGridProvider`), and this
+  // controller must outlive that churn to keep its "grown at most once per
+  // column" guard. The ref behind this getter always holds the newest wrapper.
+  getTable: () => DataGridTableInstance<TData>
 ): DataGridAutoSizeController {
   let applied: { base: number; columnId: string; grown: number } | null = null
 
   return {
     apply(fillWidth: number) {
-      // A point-in-time read, not a subscription — this runs from viewport
-      // measurement, and `table.store.state` is v9's snapshot surface now that
-      // `getState()` is gone.
-      const columnSizing = table.store.state.columnSizing
+      const table = getTable()
+      const columnSizing = table.state.columnSizing
 
       // Re-arm after reset flows (double-click resetSize, resetColumnSizing,
       // controlled state replacement) so the column re-fills instead of
@@ -302,11 +317,7 @@ function DataGridProvider<TData extends RowData>({
   table,
   ...props
 }: DataGridProps<TData> & { table: DataGridTableInstance<TData> }) {
-  // Snapshot, not a subscription. `useTable` hands back a fresh table
-  // reference whenever any registered slice changes, so `table` in the memo
-  // deps below is what actually drives recomputation; the per-slice deps stay
-  // to keep documenting which slices this context is meant to track.
-  const tableState = table.store.state
+  const tableState = table.state
 
   // Latest-props ref: context reads always resolve fresh props through the
   // getter below without the memoized context value depending on unstable
@@ -315,6 +326,17 @@ function DataGridProvider<TData extends RowData>({
   // mousemove rate during a resize drag, piercing the body-rows memo).
   const propsRef = useRef(props)
   propsRef.current = props
+
+  // Latest-table ref, for exactly the same reason. Under v8 the table instance
+  // was stable, so depending on it was free. v9's `useTable` returns
+  // `useMemo(() => ({ ...table, options, state }), [table, tableOptions, state])`
+  // and `tableOptions` is a fresh object literal on every consumer render, so
+  // the wrapper identity now churns constantly. Keeping it out of the memo
+  // deps below is what preserves the resize-drag guarantee those comments
+  // describe; the underlying core instance is stable, so serving the newest
+  // wrapper through a getter loses nothing.
+  const tableRef = useRef(table)
+  tableRef.current = table
 
   // Re-assert an explicit tableLayout resize mode every render so
   // consumer-level useTable options cannot flip it back between drags.
@@ -327,11 +349,13 @@ function DataGridProvider<TData extends RowData>({
     table.options.columnResizeMode = props.tableLayout.columnsResizeMode
   }
 
-  // One autoSize coordinator per table instance so split header/body viewports
-  // cannot apply the growth twice.
+  // One autoSize coordinator per grid so split header/body viewports cannot
+  // apply the growth twice. Created once: rebuilding it would reset the
+  // "applied at most once per column" guard, and a column-visibility toggle
+  // could then ratchet the table wider on every pass.
   const autoSize = useMemo(
-    () => createDataGridAutoSizeController(table),
-    [table]
+    () => createDataGridAutoSizeController(() => tableRef.current),
+    []
   )
 
   // Memoize context value so consumers don't re-render during column resize.
@@ -345,14 +369,16 @@ function DataGridProvider<TData extends RowData>({
       get props() {
         return propsRef.current
       },
-      // The one row-type erasure, per the context's note above.
-      table: table as DataGridTableInstance<any>,
+      // Served through the ref, and the one row-type erasure — see the notes
+      // on `tableRef` and on the context itself.
+      get table() {
+        return tableRef.current as DataGridTableInstance<any>
+      },
       recordCount: props.recordCount,
       isLoading: props.isLoading || false,
       autoSize,
     }),
     [
-      table,
       autoSize,
       props.recordCount,
       props.isLoading,

--- a/app/app/components/data-grid/data-grid.tsx
+++ b/app/app/components/data-grid/data-grid.tsx
@@ -32,7 +32,7 @@ import {
   sortFn_text,
   tableFeatures,
 } from "@tanstack/react-table"
-import { createContext, useContext, useMemo, useRef } from "react"
+import { createContext, useContext, useEffect, useMemo, useRef } from "react"
 
 import { cn } from "~/lib/utils"
 
@@ -338,16 +338,23 @@ function DataGridProvider<TData extends RowData>({
   const tableRef = useRef(table)
   tableRef.current = table
 
-  // Re-assert an explicit tableLayout resize mode every render so
-  // consumer-level useTable options cannot flip it back between drags.
-  // Without one, the consumer's own tanstack columnResizeMode (default
-  // "onEnd") is honored.
-  if (
-    props.tableLayout?.columnsResizable &&
-    props.tableLayout.columnsResizeMode
-  ) {
-    table.options.columnResizeMode = props.tableLayout.columnsResizeMode
-  }
+  // Re-assert an explicit tableLayout resize mode so consumer-level useTable
+  // options cannot flip it back between drags. This used to be a render-phase
+  // mutation of `table.options`, which v9 no longer honours: the wrapper's
+  // `options` is the consumer's own literal, and the core table has already
+  // resolved its copy by the time we could touch it. It goes through
+  // `setOptions` in an effect now. Without an explicit mode, the consumer's
+  // own tanstack columnResizeMode is honored.
+  const resizeMode =
+    props.tableLayout?.columnsResizable && props.tableLayout.columnsResizeMode
+      ? props.tableLayout.columnsResizeMode
+      : undefined
+
+  useEffect(() => {
+    if (!resizeMode) return
+    if (table.options.columnResizeMode === resizeMode) return
+    table.setOptions((old) => ({ ...old, columnResizeMode: resizeMode }))
+  }, [table, resizeMode])
 
   // One autoSize coordinator per grid so split header/body viewports cannot
   // apply the growth twice. Created once: rebuilding it would reset the

--- a/app/app/components/data-grid/data-grid.tsx
+++ b/app/app/components/data-grid/data-grid.tsx
@@ -1,18 +1,100 @@
 import type {
+  CellData,
   Column,
   ColumnFiltersState,
   RowData,
   SortingState,
   Table,
+  TableFeatures,
 } from "@tanstack/react-table"
 import type { ReactNode } from "react"
 
+import {
+  columnFacetingFeature,
+  columnFilteringFeature,
+  columnOrderingFeature,
+  columnPinningFeature,
+  columnResizingFeature,
+  columnSizingFeature,
+  columnVisibilityFeature,
+  createFacetedRowModel,
+  createFacetedUniqueValues,
+  globalFilteringFeature,
+  rowExpandingFeature,
+  rowPaginationFeature,
+  rowPinningFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_basic,
+  sortFn_datetime,
+  sortFn_text,
+  tableFeatures,
+} from "@tanstack/react-table"
 import { createContext, useContext, useMemo, useRef } from "react"
 
 import { cn } from "~/lib/utils"
 
+/**
+ * The one feature bundle every grid in this app is built with.
+ *
+ * v9 only exposes a feature's API when that feature is registered, and the
+ * shared renderers below call pinning, sizing, resizing, expanding, and
+ * selection APIs unconditionally — so a consumer with a narrower set would
+ * break the shared components rather than merely shrink its own bundle. One
+ * bundle keeps that invariant honest, and lets the components stay generic
+ * over `TData` alone instead of threading a `TFeatures` parameter through
+ * ~5k lines.
+ *
+ * Client-side row models (`filteredRowModel`, `sortedRowModel`,
+ * `paginatedRowModel`) are deliberately absent: every grid here is
+ * server-driven via `manualPagination`/`manualSorting`. A consumer that wants
+ * client-side processing registers the model it needs on its own table.
+ * Faceting is the exception — it is inherently client-side, so its slots ship
+ * here to keep `column.getFacetedUniqueValues()` working.
+ */
+export const dataGridFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  columnFacetingFeature,
+  columnOrderingFeature,
+  columnPinningFeature,
+  columnSizingFeature,
+  columnResizingFeature,
+  columnVisibilityFeature,
+  rowExpandingFeature,
+  rowPaginationFeature,
+  rowPinningFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  facetedRowModel: createFacetedRowModel(),
+  facetedUniqueValues: createFacetedUniqueValues(),
+  // `'auto'` resolves only against registered names, so the built-ins a
+  // client-sorting consumer would reach for are registered up front.
+  sortFns: {
+    alphanumeric: sortFn_alphanumeric,
+    basic: sortFn_basic,
+    datetime: sortFn_datetime,
+    text: sortFn_text,
+  },
+})
+
+export type DataGridFeatures = typeof dataGridFeatures
+
+/** The table instance shape every shared grid component consumes. */
+export type DataGridTableInstance<TData extends RowData> = Table<
+  DataGridFeatures,
+  TData
+>
+
 declare module "@tanstack/react-table" {
-  interface ColumnMeta<TData extends RowData, TValue> {
+  // Must mirror v9's declaration exactly — parameter list and variance
+  // annotations included — or the merge is rejected.
+  interface ColumnMeta<
+    in out TFeatures extends TableFeatures,
+    in out TData extends RowData,
+    TValue extends CellData = CellData,
+  > {
     autoSize?: boolean
     cellClassName?: string
     expandedContent?: (row: TData) => ReactNode
@@ -23,9 +105,11 @@ declare module "@tanstack/react-table" {
 }
 
 /** Label for headers / column visibility: `meta.headerTitle`, string `columnDef.header`, or `column.id`. */
-export function getColumnHeaderLabel<TData, TValue>(
-  column: Column<TData, TValue>
-): string {
+export function getColumnHeaderLabel<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData,
+>(column: Column<TFeatures, TData, TValue>): string {
   const meta = column.columnDef.meta as { headerTitle?: string } | undefined
   if (typeof meta?.headerTitle === "string") return meta.headerTitle
   const defHeader = column.columnDef.header
@@ -50,7 +134,7 @@ export type DataGridApiResponse<T> = {
   }
 }
 
-export interface DataGridContextProps<TData extends object> {
+export interface DataGridContextProps<TData extends RowData> {
   /**
    * Internal coordinator for `meta.autoSize` columns. Lives at the core level
    * so every table variant and viewport instance shares one application state.
@@ -59,7 +143,7 @@ export interface DataGridContextProps<TData extends object> {
   isLoading: boolean
   props: DataGridProps<TData>
   recordCount: number
-  table: Table<TData>
+  table: DataGridTableInstance<TData>
 }
 
 export type DataGridAutoSizeController = {
@@ -71,14 +155,17 @@ export type DataGridAutoSizeController = {
   apply: (fillWidth: number) => boolean
 }
 
-function createDataGridAutoSizeController<TData extends object>(
-  table: Table<TData>
+function createDataGridAutoSizeController<TData extends RowData>(
+  table: DataGridTableInstance<TData>
 ): DataGridAutoSizeController {
   let applied: { base: number; columnId: string; grown: number } | null = null
 
   return {
     apply(fillWidth: number) {
-      const columnSizing = table.getState().columnSizing
+      // A point-in-time read, not a subscription — this runs from viewport
+      // measurement, and `table.store.state` is v9's snapshot surface now that
+      // `getState()` is gone.
+      const columnSizing = table.store.state.columnSizing
 
       // Re-arm after reset flows (double-click resetSize, resetColumnSizing,
       // controlled state replacement) so the column re-fills instead of
@@ -131,7 +218,7 @@ export type DataGridRequestParams = {
   sorting?: SortingState
 }
 
-export interface DataGridProps<TData extends object> {
+export interface DataGridProps<TData extends RowData> {
   allRowsLoadedMessage?: ReactNode | string
   children?: ReactNode
   className?: string
@@ -142,7 +229,7 @@ export interface DataGridProps<TData extends object> {
   loadingMode?: "skeleton" | "spinner"
   onRowClick?: (row: TData) => void
   recordCount: number
-  table?: Table<TData>
+  table?: DataGridTableInstance<TData>
   tableClassNames?: {
     base?: string
     body?: string
@@ -175,6 +262,16 @@ export interface DataGridProps<TData extends object> {
   }
 }
 
+/**
+ * The context is row-type erased on purpose: one provider serves grids of
+ * every row shape, and each renderer re-narrows `TData` at its own boundary.
+ *
+ * v9 declares `Table<in out TFeatures, in out TData>`, making `TData`
+ * invariant — so unlike v8, a `Table<F, Post>` is not assignable to a
+ * `Table<F, any>` and the erasure can no longer happen implicitly. It is done
+ * once, explicitly, in `DataGridProvider` below rather than at each of the
+ * consumers.
+ */
 const DataGridContext = createContext<
   DataGridContextProps<any> | undefined
 >(undefined)
@@ -187,12 +284,29 @@ function useDataGrid() {
   return context
 }
 
-function DataGridProvider<TData extends object>({
+/**
+ * `useDataGrid` re-narrowed to the row type of the component reading it.
+ *
+ * The counterpart to the erasure in `DataGridProvider`: because v9's `TData`
+ * is invariant, a component holding `Row<F, TData>`/`Header<F, TData>` values
+ * cannot mix them with the erased context table in either direction. Use this
+ * in components that pass context state back into row-typed APIs; plain
+ * `useDataGrid()` is fine for everything that only reads `props`.
+ */
+function useDataGridOf<TData extends RowData>() {
+  return useDataGrid() as DataGridContextProps<TData>
+}
+
+function DataGridProvider<TData extends RowData>({
   children,
   table,
   ...props
-}: DataGridProps<TData> & { table: Table<TData> }) {
-  const tableState = table.getState()
+}: DataGridProps<TData> & { table: DataGridTableInstance<TData> }) {
+  // Snapshot, not a subscription. `useTable` hands back a fresh table
+  // reference whenever any registered slice changes, so `table` in the memo
+  // deps below is what actually drives recomputation; the per-slice deps stay
+  // to keep documenting which slices this context is meant to track.
+  const tableState = table.store.state
 
   // Latest-props ref: context reads always resolve fresh props through the
   // getter below without the memoized context value depending on unstable
@@ -203,7 +317,7 @@ function DataGridProvider<TData extends object>({
   propsRef.current = props
 
   // Re-assert an explicit tableLayout resize mode every render so
-  // consumer-level useReactTable options cannot flip it back between drags.
+  // consumer-level useTable options cannot flip it back between drags.
   // Without one, the consumer's own tanstack columnResizeMode (default
   // "onEnd") is honored.
   if (
@@ -226,12 +340,13 @@ function DataGridProvider<TData extends object>({
   // ReactNode/function props (messages, onRowClick) are also excluded: they
   // are served fresh through the props getter, so unstable inline identities
   // cannot invalidate the context value.
-  const value = useMemo(
+  const value = useMemo<DataGridContextProps<any>>(
     () => ({
       get props() {
         return propsRef.current
       },
-      table,
+      // The one row-type erasure, per the context's note above.
+      table: table as DataGridTableInstance<any>,
       recordCount: props.recordCount,
       isLoading: props.isLoading || false,
       autoSize,
@@ -265,7 +380,7 @@ function DataGridProvider<TData extends object>({
   )
 }
 
-function DataGrid<TData extends object>({
+function DataGrid<TData extends RowData>({
   children,
   table,
   ...props
@@ -365,4 +480,10 @@ function DataGridContainer({
   )
 }
 
-export { DataGrid, DataGridContainer, DataGridProvider, useDataGrid }
+export {
+  DataGrid,
+  DataGridContainer,
+  DataGridProvider,
+  useDataGrid,
+  useDataGridOf,
+}

--- a/app/app/routes/dev/showcase/components/data-grid-demo.tsx
+++ b/app/app/routes/dev/showcase/components/data-grid-demo.tsx
@@ -1,15 +1,17 @@
 import {
   type ColumnDef,
-  getCoreRowModel,
   type PaginationState,
   type SortingState,
-  useReactTable,
+  useTable,
 } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
+
+import type { DataGridFeatures } from "~/components/data-grid/data-grid";
 
 import {
   DataGrid,
   DataGridContainer,
+  dataGridFeatures,
 } from "~/components/data-grid/data-grid";
 import { DataGridColumnHeader } from "~/components/data-grid/data-grid-column-header";
 import { DataGridPagination } from "~/components/data-grid/data-grid-pagination";
@@ -46,7 +48,7 @@ const DATA: Member[] = [
   { id: 8, name: "Frances Allen", email: "frances@example.com", role: "Owner", status: "active", posts: 150 },
 ];
 
-const columns: ColumnDef<Member>[] = [
+const columns: ColumnDef<DataGridFeatures, Member>[] = [
   {
     accessorKey: "name",
     header: ({ column }) => <DataGridColumnHeader title="Name" column={column} />,
@@ -143,7 +145,8 @@ export function DataGridDemo() {
     return sortedData.slice(start, start + pagination.pageSize);
   }, [sortedData, pagination]);
 
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data: pageData,
     columns,
     pageCount: Math.ceil(DATA.length / pagination.pageSize),
@@ -152,7 +155,6 @@ export function DataGridDemo() {
     onPaginationChange: setPagination,
     manualPagination: true,
     manualSorting: true,
-    getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => String(row.id),
   });
 

--- a/app/app/routes/protected/_project.projects.$projectId.social-accounts._index/components/accounts-data-grid.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.social-accounts._index/components/accounts-data-grid.tsx
@@ -1,12 +1,12 @@
 import {
   type ColumnDef,
-  getCoreRowModel,
-  useReactTable,
+  useTable,
 } from "@tanstack/react-table";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
+import type { DataGridFeatures } from "~/components/data-grid/data-grid";
 import type {
   SocialAccount,
   SocialAccountListParams,
@@ -15,6 +15,7 @@ import type {
 import {
   DataGrid,
   DataGridContainer,
+  dataGridFeatures,
 } from "~/components/data-grid/data-grid";
 import { DataGridColumnHeader } from "~/components/data-grid/data-grid-column-header";
 import { DataGridPagination } from "~/components/data-grid/data-grid-pagination";
@@ -168,7 +169,7 @@ export function AccountsDataGrid({
     defaultPageSize: DEFAULT_PAGE_SIZE,
   });
 
-  const columns = useMemo<ColumnDef<SocialAccount>[]>(
+  const columns = useMemo<ColumnDef<DataGridFeatures, SocialAccount>[]>(
     () => [
       {
         accessorKey: "username",
@@ -287,14 +288,14 @@ export function AccountsDataGrid({
     [t, onDisconnect],
   );
 
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data: accounts,
     columns,
     pageCount: Math.max(1, Math.ceil(total / pagination.pageSize)),
     state: { pagination },
     onPaginationChange,
     manualPagination: true,
-    getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.id,
   });
 

--- a/app/app/routes/protected/_project.projects.$projectId.social-posts._index/components/posts-data-grid.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.social-posts._index/components/posts-data-grid.tsx
@@ -1,12 +1,9 @@
-import {
-  type ColumnDef,
-  getCoreRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
+import { type ColumnDef, useTable } from "@tanstack/react-table";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
+import type { DataGridFeatures } from "~/components/data-grid/data-grid";
 import type {
   SocialPost,
   SocialPostListParams,
@@ -16,6 +13,7 @@ import { AccountAvatars } from "~/components/account-avatars";
 import {
   DataGrid,
   DataGridContainer,
+  dataGridFeatures,
 } from "~/components/data-grid/data-grid";
 import { DataGridColumnHeader } from "~/components/data-grid/data-grid-column-header";
 import { DataGridPagination } from "~/components/data-grid/data-grid-pagination";
@@ -59,7 +57,7 @@ export function PostsDataGrid({
     defaultPageSize: DEFAULT_PAGE_SIZE,
   });
 
-  const columns = useMemo<ColumnDef<SocialPost>[]>(
+  const columns = useMemo<ColumnDef<DataGridFeatures, SocialPost>[]>(
     () => [
       {
         accessorKey: "caption",
@@ -169,14 +167,14 @@ export function PostsDataGrid({
     [t],
   );
 
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data: posts,
     columns,
     pageCount: Math.max(1, Math.ceil(total / pagination.pageSize)),
     state: { pagination },
     onPaginationChange,
     manualPagination: true,
-    getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.id,
   });
 

--- a/app/app/routes/protected/_project.projects.$projectId.webhooks.$webhookId._index/components/webhook-events-grid.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.webhooks.$webhookId._index/components/webhook-events-grid.tsx
@@ -1,13 +1,13 @@
 import {
   type ColumnDef,
-  getCoreRowModel,
   type OnChangeFn,
   type SortingState,
-  useReactTable,
+  useTable,
 } from "@tanstack/react-table";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { DataGridFeatures } from "~/components/data-grid/data-grid";
 import type {
   WebhookEvent,
   WebhookEventListParams,
@@ -18,6 +18,7 @@ import type {
 import {
   DataGrid,
   DataGridContainer,
+  dataGridFeatures,
 } from "~/components/data-grid/data-grid";
 import { DataGridColumnHeader } from "~/components/data-grid/data-grid-column-header";
 import { DataGridPagination } from "~/components/data-grid/data-grid-pagination";
@@ -86,7 +87,7 @@ export function WebhookEventsGrid({
     onParamsChange({ ...params, sort: nextSort, page: 1 });
   };
 
-  const columns = useMemo<ColumnDef<WebhookEvent>[]>(
+  const columns = useMemo<ColumnDef<DataGridFeatures, WebhookEvent>[]>(
     () => [
       {
         accessorKey: "type",
@@ -153,7 +154,8 @@ export function WebhookEventsGrid({
     [t],
   );
 
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data: events,
     columns,
     pageCount: Math.max(1, Math.ceil(total / pagination.pageSize)),
@@ -162,7 +164,6 @@ export function WebhookEventsGrid({
     onPaginationChange,
     manualSorting: true,
     manualPagination: true,
-    getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.id,
   });
 

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -21,7 +21,7 @@
         "@react-router/serve": "8.2.0",
         "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.108.1",
-        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-table": "^9.1.0",
         "@tanstack/react-virtual": "^3.14.9",
         "@unkey/api": "^2.4.0",
         "class-variance-authority": "^0.7.1",
@@ -427,11 +427,15 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
 
-    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+    "@tanstack/react-store": ["@tanstack/react-store@0.11.1", "", { "dependencies": { "@tanstack/store": "0.11.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ=="],
+
+    "@tanstack/react-table": ["@tanstack/react-table@9.1.0", "", { "dependencies": { "@tanstack/react-store": "^0.11.0", "@tanstack/table-core": "9.1.0" }, "peerDependencies": { "react": ">=18" } }, "sha512-KXZDQ+MjmacO6KG0Fo019UMHJV7nXVzf/GeBiwSK7a52RVcycFJWRx88OYtOfGPMDRfAK5vyyguC8B2zvc95HA=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.9", "", { "dependencies": { "@tanstack/virtual-core": "3.17.7" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ=="],
 
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+    "@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@9.1.0", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-tvnnqdWlvF/l6P65yS4ca4keW2VCC3e+OTT8/pUM7ZF5OQBJ7zTVy67T0lLpWBpkELrZN8sFJxY5DHF05fLUDQ=="],
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.7", "", {}, "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,7 @@
     "@react-router/serve": "8.2.0",
     "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.108.1",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.1.0",
     "@tanstack/react-virtual": "^3.14.9",
     "@unkey/api": "^2.4.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary

Upgrades `app/`'s vendored ReUI Data Grid — and the routes that use it — from `@tanstack/react-table` v8 to v9 (`^9.1.0`, current stable). This is the retargeted replacement for #318, which was built against `main` and migrated the legacy `dashboard/` sibling instead of the new dashboard in #315.

Scope is **full parity**: all ten `app/app/components/data-grid/` modules move to v9, including the virtualization and DnD variants. Nothing is trimmed.

The port was written against the v8→v9 skills shipped inside the installed package (`node_modules/@tanstack/{table-core,react-table}/skills/migrate-v8-to-v9`), then reviewed against [ReUI's published v9 Data Grid docs and migration prompt](https://reui.io/docs/components/base/data-grid#tanstack-table-v9). Second commit applies the corrections that review turned up.

## Changes

**Dependency**
- `@tanstack/react-table` `^8.21.3` → `^9.1.0`. Nothing else changed; `@tanstack/react-virtual` stays on `^3.14.9` and still interops.

**Shared feature bundle — `dataGridFeatures` (`data-grid.tsx`)**
- v9 exposes a feature's API only when that feature is registered. The shared renderers call pinning, sizing, resizing, expanding, and selection APIs *unconditionally*, so a consumer with a narrower set would break them rather than just shrink a bundle. One exported bundle keeps that enforceable and lets components stay generic over `TData` alone instead of threading `TFeatures` through ~5k lines. This matches upstream, which exports the same `dataGridFeatures` / `DataGridFeatures` pair.
- Client-side row models (`filteredRowModel`, `sortedRowModel`, `paginatedRowModel`) are deliberately **not** registered — every grid here is server-driven via `manualPagination`/`manualSorting`. Faceting is the exception (inherently client-side), so its slots ship in the bundle to keep `column.getFacetedUniqueValues()` working.

**Column meta via the features slot, not global augmentation**
- `columnDef.meta` is typed by an exported `DataGridColumnMeta` registered as the bundle's `columnMeta` slot; the `declare module "@tanstack/react-table"` augmentation is gone.
- This is a correctness matter, not style: the two are **not additive** — a features-level slot *overrides* the global `ColumnMeta` interface. Upstream now ships such a slot, so keeping our augmentation would have silently dropped `headerTitle` / `cellClassName` / `skeleton` / `expandedContent` typing on the next merge.

**State reads**
- `table.getState()` is removed in v9. Render reads go through `table.state`; the React adapter explicitly deprecates `table.store.state` for render code, so the grid types against `ReactTable` rather than core `Table`.

**Table identity — the subtle one**
- v9's `useTable` returns `useMemo(() => ({ ...table, options, state }), [table, tableOptions, state])`, and `tableOptions` is a fresh object literal on every consumer render, so **the table reference now churns on nearly every render** where v8's instance was stable.
- The provider therefore holds the table in a ref and serves it through a getter (the pattern the file already used for `props`) instead of listing it as a memo dependency. Depending on it directly republished the grid context at mousemove rate during a resize drag — precisely what that memo exists to prevent — and reset the autoSize controller's "grown at most once per column" guard on every pass, letting column-visibility toggles ratchet the table ever wider.

**Mechanical API migrations**
- `useReactTable` → `useTable({ features, ... })`; `getCoreRowModel()` option dropped (automatic in v9).
- Column pinning is logical: `left`/`right` → `start`/`end` across `getIsPinned`, `pin()`, `getStart`/`getAfter`, `getIsFirstColumn`/`getIsLastColumn`, the `getLeft*`/`getRight*` method families, and `columnPinning` state keys. `data-pinned` / `data-last-col` / `data-outer-pinned-col` emit `start`/`end`, and their Tailwind selectors moved with them; shadow *directions* stay physically identical, so LTR rendering is unchanged.
- Sizing split from resizing: `columnSizingInfo` → `columnResizing`, `setColumnSizingInfo` → `setColumnResizing`.
- Core types take `TFeatures` first: `ColumnDef<DataGridFeatures, T>`, `Row<…>`, `Cell<…>`, `Header<…>`, and `Table<…>` (aliased `DataGridTableInstance<T>`).

**Row-type erasure**
- v9 declares `Table<in out TFeatures, in out TData>`, making `TData` **invariant**. Under v8 one provider could serve grids of every row shape because `Table<Post>` flowed implicitly into `Table<any>`; in v9 it flows in neither direction.
- The erasure is now explicit, in one place (`DataGridProvider`), with a `useDataGridOf<TData>()` hook re-narrowing at the three boundaries that feed context values back into row-typed APIs (resize sessions, virtualizer `estimateSize`/`getItemKey`, DnD carried-row decoration). Plain `useDataGrid()` still serves the ~17 sites that only read `props`.

## Testing

From `app/`:
- `bun run typecheck` — passes
- `bun run lint` — passes, 0 warnings
- `bun run build` — passes, client + SSR

ReUI's STEP 4 "prove it's complete" search returns **zero** results across `app/` for all five of their required greps: `useReactTable`, `getCoreRowModel`, `data-pinned="left"`, `table.getState(`, and `declare module "@tanstack/react-table"`.

Verified by inspection against the flagged breaking changes:
- **Row pinning untouched** — still `top`/`bottom`, so the `left`/`right` → `start`/`end` rename deliberately does not apply to `row.getIsPinned()` / `row.pin()`.
- **Indeterminate select-all** — v9 redefined `getIsSomePageRowsSelected()` to "at least one" (v8: "some but not all"). The existing `isSomeSelected ? !isAllSelected : undefined` stays correct; it now yields `false` rather than `undefined` when all rows are selected, which Base UI treats identically (`indeterminate?: boolean | undefined`). Commented in place.
- **Controlled slices** — every `state.<slice>` still has its matching `on<Slice>Change`, so no slice is frozen.
- **Stricter state shapes** (`ColumnPinningState` needing `start`+`end`, `RowPinningState` needing `top`+`bottom`, `RowSelectionState` narrowed to `Record<string, true>`) — no code here constructs these literals.
- No `useLegacyTable` or `stockFeatures` shortcut; no `"use no memo"` pragmas; no `any`/casts added to paper over migration failures beyond the single documented variance erasure.

> **Runtime QA is the remaining gap and is worth a pass before merge.** Everything above is compile-time or by-inspection. Per ReUI's STEP 5, exercise each grid for sorting, paging, column visibility, pinning to each side while scrolling horizontally, row selection including the header checkbox, and column resizing — across the posts, social-accounts, and webhook-events grids plus `/dev/showcase`, which is what covers the virtual and DnD variants.

## Notes

- Based on `feat/post-for-me-app` (#315), so this needs a rebase if that branch moves, and should merge after it.
- The column-header pin menu targets logical regions while its labels and icons stay physical ("Pin left"/"Pin right", `dataGrid.pinLeft`/`pinRight`). Identical in LTR; making that copy direction-aware is an i18n change, intentionally out of scope.
- Upstream types `DataGrid`'s own `table` prop as `Table<TFeatures, TData>` for any bundle and widens internally, where this copy types it to `DataGridFeatures` directly. Worth revisiting only if a grid here ever needs a different feature set.
- Replaces #318 (closed).

Closes PFM-978

🤖 Generated with AI