### PR TITLE
feat(app): add table skeletons and move remaining tables onto the DataGrid

### DIFF
--- a/app/app/lib/i18n/locales/en/common.json
+++ b/app/app/lib/i18n/locales/en/common.json
@@ -787,6 +787,9 @@
       "title": "Delete this API key?",
       "description": "Any request using this key will immediately stop working. This can't be undone.",
       "confirm": "Delete key"
+    },
+    "grid": {
+      "empty": "No API keys yet"
     }
   },
   "webhooks": {
@@ -887,6 +890,9 @@
         "title": "No deliveries yet",
         "description": "Events will appear here once this webhook starts receiving them."
       }
+    },
+    "grid": {
+      "empty": "No webhooks yet"
     }
   },
   "billing": {

--- a/app/app/routes/protected/_project.projects.$projectId.api-keys._index/components/api-keys-table.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.api-keys._index/components/api-keys-table.tsx
@@ -1,7 +1,17 @@
+import { type ColumnDef, useTable } from "@tanstack/react-table";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { DataGridFeatures } from "~/components/data-grid/data-grid";
 import type { ApiKey } from "~/lib/types/api-key";
 
+import {
+  DataGrid,
+  DataGridContainer,
+  dataGridFeatures,
+} from "~/components/data-grid/data-grid";
+import { DataGridColumnHeader } from "~/components/data-grid/data-grid-column-header";
+import { DataGridTable } from "~/components/data-grid/data-grid-table";
 import { DeleteIcon, EditIcon, MoreIcon } from "~/icons";
 import { Button } from "~/ui/button";
 import { LocaleDateTime } from "~/ui/date-time";
@@ -11,96 +21,216 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "~/ui/dropdown-menu";
+import { Skeleton } from "~/ui/skeleton";
 
 /**
- * Dumb, composable table of a project's API keys — Name · Key reference (masked
- * preview) · Created · Created by, plus a per-row actions menu (rename / delete)
- * wired to the host's passthrough handlers. Renders our domain {@link ApiKey}
- * (never the provider's shape) and does no fetching.
+ * How many skeleton rows to show while the list is in flight. The paginated
+ * grids take this from `pageSize`; this list has no pagination, so it names a
+ * plausible number instead — enough to read as "a table is coming" without
+ * implying a count.
  */
-export function ApiKeysTable({
-  apiKeys,
+const SKELETON_ROW_COUNT = 5;
+
+function RowActions({
+  apiKey,
   onRename,
   onDelete,
 }: {
-  apiKeys: ApiKey[];
+  apiKey: ApiKey;
   onDelete: (apiKey: ApiKey) => void;
   onRename: (apiKey: ApiKey) => void;
 }) {
   const { t } = useTranslation();
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border">
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border bg-muted/40 text-xs text-muted-foreground [&>th]:px-4 [&>th]:py-2.5 [&>th]:text-left [&>th]:font-medium [&>th]:whitespace-nowrap">
-              <th>{t("apiKeys.columns.name")}</th>
-              <th>{t("apiKeys.columns.reference")}</th>
-              <th>{t("apiKeys.columns.created")}</th>
-              <th>{t("apiKeys.columns.createdBy")}</th>
-              <th className="w-14 text-right">
-                <span className="sr-only">{t("common.actions")}</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {apiKeys.map((apiKey) => (
-              <tr
-                key={apiKey.id}
-                className="border-b border-border last:border-0 [&>td]:px-4 [&>td]:py-3 [&>td]:align-middle"
-              >
-                <td className="font-medium">
-                  {apiKey.name ?? (
-                    <span className="text-muted-foreground">
-                      {t("apiKeys.unnamed")}
-                    </span>
-                  )}
-                </td>
-                <td>
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {apiKey.reference}…
-                  </span>
-                </td>
-                <td className="whitespace-nowrap text-muted-foreground">
-                  <LocaleDateTime value={apiKey.createdAt} />
-                </td>
-                <td className="whitespace-nowrap text-muted-foreground">
-                  {apiKey.createdBy?.label ?? "—"}
-                </td>
-                <td className="text-right">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger
-                      render={
-                        <Button
-                          variant="ghost"
-                          size="icon-sm"
-                          aria-label={t("apiKeys.actions.menu")}
-                        >
-                          <MoreIcon />
-                        </Button>
-                      }
-                    />
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={() => onRename(apiKey)}>
-                        <EditIcon />
-                        {t("apiKeys.actions.rename")}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onClick={() => onDelete(apiKey)}
-                      >
-                        <DeleteIcon />
-                        {t("common.delete")}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={t("apiKeys.actions.menu")}
+          >
+            <MoreIcon />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => onRename(apiKey)}>
+          <EditIcon />
+          {t("apiKeys.actions.rename")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          variant="destructive"
+          onClick={() => onDelete(apiKey)}
+        >
+          <DeleteIcon />
+          {t("common.delete")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/**
+ * Dumb, composable table of a project's API keys — Name · Key reference (masked
+ * preview) · Created · Created by, plus a per-row actions menu (rename / delete)
+ * wired to the host's passthrough handlers. Renders our domain {@link ApiKey}
+ * (never the provider's shape) and does no fetching.
+ *
+ * Built on the shared DataGrid rather than hand-rolled `<table>` markup, so it
+ * inherits the same shell, density, and skeleton treatment as every other table
+ * in the app. There is no pagination — a project has few keys — so no
+ * `DataGridPagination` is rendered and `pageSize` serves only to size the
+ * loading state.
+ */
+export function ApiKeysTable({
+  apiKeys,
+  onRename,
+  onDelete,
+  isLoading = false,
+}: {
+  apiKeys: ApiKey[];
+  /** Renders the loading skeleton in place of rows — see the route's Suspense boundary. */
+  isLoading?: boolean;
+  onDelete: (apiKey: ApiKey) => void;
+  onRename: (apiKey: ApiKey) => void;
+}) {
+  const { t } = useTranslation();
+
+  const columns = useMemo<ColumnDef<DataGridFeatures, ApiKey>[]>(
+    () => [
+      {
+        accessorKey: "name",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("apiKeys.columns.name")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) =>
+          row.original.name ?? (
+            <span className="text-muted-foreground">{t("apiKeys.unnamed")}</span>
+          ),
+        enableSorting: false,
+        size: 220,
+        meta: {
+          cellClassName: "font-medium",
+          skeleton: <Skeleton className="h-3.5 w-32" />,
+        },
+      },
+      {
+        accessorKey: "reference",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("apiKeys.columns.reference")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className="font-mono text-xs text-muted-foreground">
+            {row.original.reference}…
+          </span>
+        ),
+        enableSorting: false,
+        size: 200,
+        // The masked preview is `text-xs`, so its bar is shorter than the rest.
+        meta: { skeleton: <Skeleton className="h-3 w-24" /> },
+      },
+      {
+        accessorKey: "createdAt",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("apiKeys.columns.created")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => (
+          <LocaleDateTime
+            value={row.original.createdAt}
+            className="text-muted-foreground"
+          />
+        ),
+        enableSorting: false,
+        size: 180,
+        meta: {
+          cellClassName: "whitespace-nowrap",
+          skeleton: <Skeleton className="h-3.5 w-28" />,
+        },
+      },
+      {
+        accessorKey: "createdBy",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("apiKeys.columns.createdBy")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className="text-muted-foreground">
+            {row.original.createdBy?.label ?? "—"}
+          </span>
+        ),
+        enableSorting: false,
+        size: 180,
+        meta: {
+          cellClassName: "whitespace-nowrap",
+          skeleton: <Skeleton className="h-3.5 w-20" />,
+        },
+      },
+      {
+        id: "actions",
+        // No visible label, but the header cell still needs an accessible name
+        // — an empty `<th>` leaves screen-reader table navigation announcing an
+        // unnamed column.
+        header: () => <span className="sr-only">{t("common.actions")}</span>,
+        cell: ({ row }) => (
+          <RowActions
+            apiKey={row.original}
+            onRename={onRename}
+            onDelete={onDelete}
+          />
+        ),
+        enableSorting: false,
+        size: 56,
+        meta: {
+          cellClassName: "text-right",
+          skeleton: <Skeleton className="ms-auto size-7 rounded-md" />,
+        },
+      },
+    ],
+    [t, onRename, onDelete],
+  );
+
+  const table = useTable({
+    features: dataGridFeatures,
+    data: apiKeys,
+    columns,
+    getRowId: (row) => row.id,
+    // `initialState`, not `state`: nothing here drives pagination, and an
+    // uncontrolled slice needs no change handler to avoid freezing.
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: SKELETON_ROW_COUNT },
+    },
+    manualPagination: true,
+  });
+
+  return (
+    <DataGrid
+      table={table}
+      recordCount={apiKeys.length}
+      isLoading={isLoading}
+      tableLayout={{ rowBorder: true, width: "fixed" }}
+      // Force a min content width so narrow viewports scroll the table
+      // horizontally instead of crushing the columns.
+      tableClassNames={{ base: "min-w-[44rem]!" }}
+      emptyMessage={t("apiKeys.grid.empty")}
+    >
+      <DataGridContainer>
+        <div className="overflow-x-auto">
+          <DataGridTable />
+        </div>
+      </DataGridContainer>
+    </DataGrid>
   );
 }

--- a/app/app/routes/protected/_project.projects.$projectId.api-keys._index/route.component.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.api-keys._index/route.component.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useFetcher, useLoaderData } from "react-router";
+import { Await, useFetcher, useLoaderData } from "react-router";
 
 import type { ApiKey } from "~/lib/types/api-key";
 
@@ -40,7 +40,7 @@ function isCreateSuccess(value: unknown): value is CreateResult {
  * replaces the actions.
  */
 export function Component() {
-  const { keys, unavailable } = useLoaderData<typeof loader>();
+  const { keysResult } = useLoaderData<typeof loader>();
   const { t } = useTranslation();
 
   const createFetcher = useFetcher();
@@ -110,18 +110,103 @@ export function Component() {
     );
   }
 
-  const showEmptyState = keys.length === 0 && !unavailable;
-
   return (
     <div className="flex flex-col gap-6 p-6">
+      {/* The list streams in. The fallback is this same view in its loading
+          state, so the heading and the Create button paint immediately and
+          only the rows are replaced by skeletons. */}
+      <Suspense
+        fallback={
+          <ApiKeysView
+            keys={[]}
+            unavailable={false}
+            isLoading
+            onCreate={openCreate}
+            onRename={setRenameTarget}
+            onDelete={setDeleteTarget}
+          />
+        }
+      >
+        <Await resolve={keysResult}>
+          {({ keys, unavailable }) => (
+            <ApiKeysView
+              keys={keys}
+              unavailable={unavailable}
+              onCreate={openCreate}
+              onRename={setRenameTarget}
+              onDelete={setDeleteTarget}
+            />
+          )}
+        </Await>
+      </Suspense>
+
+      <ApiKeyCreateDialog
+        open={createOpen}
+        onOpenChange={handleCreateOpenChange}
+        pending={createPending}
+        createdSecret={createdSecret}
+        onSubmit={submitCreate}
+      />
+
+      <ApiKeyRenameDialog
+        open={renameTarget !== null}
+        onOpenChange={(open) => (open ? undefined : setRenameTarget(null))}
+        defaultName={renameTarget?.name ?? ""}
+        pending={rowPending}
+        onSubmit={submitRename}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => (open ? undefined : setDeleteTarget(null))}
+        title={t("apiKeys.delete.title")}
+        description={t("apiKeys.delete.description")}
+        confirmLabel={t("apiKeys.delete.confirm")}
+        destructive
+        pending={rowPending}
+        onConfirm={confirmDelete}
+      />
+    </div>
+  );
+}
+
+/**
+ * The data-dependent half of the page: heading + create affordance, the
+ * degraded-backend notice, and then either the empty state or the table.
+ *
+ * Rendered twice — once as the Suspense fallback with `isLoading`, once with
+ * resolved data — so the chrome is identical across the transition and only
+ * the rows change. While loading, the empty state is suppressed: an empty list
+ * we haven't fetched yet is not the same as a project with no keys.
+ */
+function ApiKeysView({
+  keys,
+  unavailable,
+  isLoading = false,
+  onCreate,
+  onRename,
+  onDelete,
+}: {
+  isLoading?: boolean;
+  keys: ApiKey[];
+  onCreate: () => void;
+  onDelete: (apiKey: ApiKey) => void;
+  onRename: (apiKey: ApiKey) => void;
+  unavailable: boolean;
+}) {
+  const { t } = useTranslation();
+  const showEmptyState = !isLoading && keys.length === 0 && !unavailable;
+
+  return (
+    <>
       <div className="flex items-center justify-between gap-4">
         <h1 className="font-heading text-2xl font-semibold text-foreground">
           {t("apiKeys.pageTitle")}
         </h1>
         {!showEmptyState ? (
           <Button
-            onClick={openCreate}
-            disabled={unavailable}
+            onClick={onCreate}
+            disabled={unavailable || isLoading}
             className="shrink-0"
           >
             <AddIcon />
@@ -152,46 +237,20 @@ export function Component() {
             </EmptyDescription>
           </EmptyHeader>
           <EmptyContent>
-            <Button onClick={openCreate}>
+            <Button onClick={onCreate}>
               <AddIcon />
               {t("apiKeys.create.submit")}
             </Button>
           </EmptyContent>
         </Empty>
-      ) : keys.length > 0 ? (
+      ) : isLoading || keys.length > 0 ? (
         <ApiKeysTable
           apiKeys={keys}
-          onRename={setRenameTarget}
-          onDelete={setDeleteTarget}
+          isLoading={isLoading}
+          onRename={onRename}
+          onDelete={onDelete}
         />
       ) : null}
-
-      <ApiKeyCreateDialog
-        open={createOpen}
-        onOpenChange={handleCreateOpenChange}
-        pending={createPending}
-        createdSecret={createdSecret}
-        onSubmit={submitCreate}
-      />
-
-      <ApiKeyRenameDialog
-        open={renameTarget !== null}
-        onOpenChange={(open) => (open ? undefined : setRenameTarget(null))}
-        defaultName={renameTarget?.name ?? ""}
-        pending={rowPending}
-        onSubmit={submitRename}
-      />
-
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        onOpenChange={(open) => (open ? undefined : setDeleteTarget(null))}
-        title={t("apiKeys.delete.title")}
-        description={t("apiKeys.delete.description")}
-        confirmLabel={t("apiKeys.delete.confirm")}
-        destructive
-        pending={rowPending}
-        onConfirm={confirmDelete}
-      />
-    </div>
+    </>
   );
 }

--- a/app/app/routes/protected/_project.projects.$projectId.api-keys._index/route.loader.ts
+++ b/app/app/routes/protected/_project.projects.$projectId.api-keys._index/route.loader.ts
@@ -22,11 +22,20 @@ export async function loader({ params, context }: Route.LoaderArgs) {
   const project = await projects.get(projectId);
   await requireTeamMember(context, project.teamId);
 
-  try {
-    const keys = await apiKeys.list(projectId);
-    return { keys, projectId, unavailable: false };
-  } catch (error) {
-    logError(error, { projectId, surface: "api-keys.loader" });
-    return { keys: [], projectId, unavailable: true };
-  }
+  // Streamed rather than awaited, so the page shell — and the table's skeleton
+  // rows — paint immediately and the rows land when the keys backend answers.
+  // The guards above stay awaited: a non-member must never reach the shell.
+  //
+  // The degrade path rides on the promise instead of a try/catch, so an
+  // unconfigured or unreachable backend still resolves to the "unavailable"
+  // notice rather than rejecting into the error boundary.
+  const keysResult = apiKeys
+    .list(projectId)
+    .then((keys) => ({ keys, unavailable: false }))
+    .catch((error) => {
+      logError(error, { projectId, surface: "api-keys.loader" });
+      return { keys: [], unavailable: true };
+    });
+
+  return { keysResult, projectId };
 }

--- a/app/app/routes/protected/_project.projects.$projectId.social-accounts._index/components/accounts-data-grid.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.social-accounts._index/components/accounts-data-grid.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "~/ui/dropdown-menu";
+import { Skeleton } from "~/ui/skeleton";
 import { toast } from "~/ui/sonner";
 
 /** Format an ISO timestamp in the viewer's locale (medium date). */
@@ -209,6 +210,20 @@ export function AccountsDataGrid({
         },
         enableSorting: false,
         size: 240,
+        meta: {
+          // Mirrors the identity cell above: `size="sm"` avatar (size-6) plus
+          // the stacked username / platform lines, at the same gaps. Matching
+          // the shape is what keeps rows from resizing when data lands.
+          skeleton: (
+            <div className="flex items-center gap-2.5">
+              <Skeleton className="size-6 shrink-0 rounded-full" />
+              <div className="flex flex-col gap-1">
+                <Skeleton className="h-3.5 w-24" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+          ),
+        },
       },
       {
         accessorKey: "id",
@@ -223,6 +238,7 @@ export function AccountsDataGrid({
         ),
         enableSorting: false,
         size: 200,
+        meta: { skeleton: <Skeleton className="h-3.5 w-32" /> },
       },
       {
         accessorKey: "platformId",
@@ -237,6 +253,7 @@ export function AccountsDataGrid({
         ),
         enableSorting: false,
         size: 180,
+        meta: { skeleton: <Skeleton className="h-3.5 w-28" /> },
       },
       {
         accessorKey: "externalId",
@@ -254,6 +271,7 @@ export function AccountsDataGrid({
           ),
         enableSorting: false,
         size: 180,
+        meta: { skeleton: <Skeleton className="h-3.5 w-24" /> },
       },
       {
         accessorKey: "connectedAt",
@@ -269,6 +287,7 @@ export function AccountsDataGrid({
         ),
         enableSorting: false,
         size: 140,
+        meta: { skeleton: <Skeleton className="h-3.5 w-20" /> },
       },
       {
         id: "actions",
@@ -283,6 +302,8 @@ export function AccountsDataGrid({
         ),
         enableSorting: false,
         size: 56,
+        // Matches the `size="icon-sm"` trigger, so the column doesn't twitch.
+        meta: { skeleton: <Skeleton className="size-7 rounded-md" /> },
       },
     ],
     [t, onDisconnect],

--- a/app/app/routes/protected/_project.projects.$projectId.social-posts._index/components/posts-data-grid.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.social-posts._index/components/posts-data-grid.tsx
@@ -25,6 +25,7 @@ import { MediaIcon, TextIcon } from "~/icons";
 import { DEFAULT_PAGE_SIZE } from "~/lib/types/social-account";
 import { cn } from "~/lib/utils";
 import { LocaleDateTime } from "~/ui/date-time";
+import { Skeleton } from "~/ui/skeleton";
 
 /**
  * The dumb posts grid (PFM-703). It renders the page the loader handed it and
@@ -95,6 +96,15 @@ export function PostsDataGrid({
         },
         enableSorting: false,
         size: 300,
+        meta: {
+          // The media/text glyph plus the caption line, at the cell's own gap.
+          skeleton: (
+            <div className="flex items-center gap-2">
+              <Skeleton className="size-3.5 shrink-0 rounded-sm" />
+              <Skeleton className="h-3.5 w-48" />
+            </div>
+          ),
+        },
       },
       {
         accessorKey: "status",
@@ -108,6 +118,14 @@ export function PostsDataGrid({
         ),
         enableSorting: false,
         size: 80,
+        meta: {
+          // Centered like the status icon it stands in for.
+          skeleton: (
+            <div className="flex justify-center">
+              <Skeleton className="size-4 rounded-full" />
+            </div>
+          ),
+        },
       },
       {
         id: "accounts",
@@ -117,6 +135,17 @@ export function PostsDataGrid({
         cell: ({ row }) => <AccountAvatars accounts={row.original.accounts} />,
         enableSorting: false,
         size: 200,
+        meta: {
+          // Three `size-6` circles at the group's own `gap-1.5` — a stand-in
+          // for a set whose real length isn't knowable until the rows land.
+          skeleton: (
+            <div className="flex items-center gap-1.5">
+              <Skeleton className="size-6 shrink-0 rounded-full" />
+              <Skeleton className="size-6 shrink-0 rounded-full" />
+              <Skeleton className="size-6 shrink-0 rounded-full" />
+            </div>
+          ),
+        },
       },
       {
         accessorKey: "postAt",
@@ -131,6 +160,7 @@ export function PostsDataGrid({
         ),
         enableSorting: false,
         size: 180,
+        meta: { skeleton: <Skeleton className="h-3.5 w-28" /> },
       },
       {
         accessorKey: "id",
@@ -145,6 +175,7 @@ export function PostsDataGrid({
         ),
         enableSorting: false,
         size: 200,
+        meta: { skeleton: <Skeleton className="h-3.5 w-32" /> },
       },
       {
         accessorKey: "externalId",
@@ -162,6 +193,7 @@ export function PostsDataGrid({
           ),
         enableSorting: false,
         size: 180,
+        meta: { skeleton: <Skeleton className="h-3.5 w-24" /> },
       },
     ],
     [t],

--- a/app/app/routes/protected/_project.projects.$projectId.webhooks.$webhookId._index/components/webhook-events-grid.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.webhooks.$webhookId._index/components/webhook-events-grid.tsx
@@ -27,6 +27,7 @@ import { useGridPagination } from "~/hooks/use-grid-pagination";
 import { WEBHOOK_EVENTS_DEFAULT_PAGE_SIZE } from "~/lib/types/webhook";
 import { Badge } from "~/ui/badge";
 import { LocaleDateTime } from "~/ui/date-time";
+import { Skeleton } from "~/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/ui/tooltip";
 
 const DEFAULT_SORT: WebhookEventSort = { field: "createdAt", direction: "desc" };
@@ -103,6 +104,14 @@ export function WebhookEventsGrid({
           </Badge>
         ),
         size: 260,
+        meta: {
+          // Absorbs the leftover width. Without a fill column the grid's
+          // default `width: "fixed"` spreads the surplus across all three,
+          // which strands Status and Received in the middle of empty space.
+          autoSize: true,
+          // `size="xs"` badges are h-4 — matched so the row height holds.
+          skeleton: <Skeleton className="h-4 w-40 rounded-md" />,
+        },
       },
       {
         accessorKey: "status",
@@ -130,6 +139,7 @@ export function WebhookEventsGrid({
           );
         },
         size: 140,
+        meta: { skeleton: <Skeleton className="h-4 w-16 rounded-md" /> },
       },
       {
         accessorKey: "createdAt",
@@ -149,6 +159,7 @@ export function WebhookEventsGrid({
             <span className="text-muted-foreground">—</span>
           ),
         size: 220,
+        meta: { skeleton: <Skeleton className="h-3.5 w-28" /> },
       },
     ],
     [t],

--- a/app/app/routes/protected/_project.projects.$projectId.webhooks.$webhookId._index/route.component.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.webhooks.$webhookId._index/route.component.tsx
@@ -73,6 +73,7 @@ export function Component() {
   );
 }
 
+
 /**
  * The webhook config (URL · event types · revealable signing secret) with an
  * edit action, the server-driven delivery-events grid, and a danger zone. Edit
@@ -244,7 +245,7 @@ function WebhookDetailView({
         )}
       </section>
 
-      <section className="flex flex-col items-start gap-3 rounded-xl border border-destructive/10 bg-card p-6">
+      <section className="flex flex-row items-center justify-between gap-3 rounded-xl border border-destructive/10 bg-card p-6">
         <div className="flex flex-col gap-1">
           <h2 className="font-heading text-sm font-semibold text-destructive">
             {t("webhooks.detail.dangerTitle")}

--- a/app/app/routes/protected/_project.projects.$projectId.webhooks._index/components/webhooks-table.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.webhooks._index/components/webhooks-table.tsx
@@ -1,8 +1,18 @@
+import { type ColumnDef, useTable } from "@tanstack/react-table";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
+import type { DataGridFeatures } from "~/components/data-grid/data-grid";
 import type { WebhookSummary } from "~/lib/types/webhook";
 
+import {
+  DataGrid,
+  DataGridContainer,
+  dataGridFeatures,
+} from "~/components/data-grid/data-grid";
+import { DataGridColumnHeader } from "~/components/data-grid/data-grid-column-header";
+import { DataGridTable } from "~/components/data-grid/data-grid-table";
 import { RowLink } from "~/components/grid-cells";
 import { DeleteIcon, EditIcon, MoreIcon } from "~/icons";
 import { Badge } from "~/ui/badge";
@@ -13,19 +23,75 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "~/ui/dropdown-menu";
+import { Skeleton } from "~/ui/skeleton";
+
+/** See the note in the API keys table — this list has no pagination either. */
+const SKELETON_ROW_COUNT = 4;
+
+function RowActions({
+  webhook,
+  onEdit,
+  onDelete,
+}: {
+  onDelete: (webhook: WebhookSummary) => void;
+  onEdit: (webhook: WebhookSummary) => void;
+  webhook: WebhookSummary;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    // Stop propagation so the menu doesn't trigger the row's
+    // navigate-to-detail click.
+    <div onClick={(event) => event.stopPropagation()}>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={t("webhooks.actions.menu")}
+            >
+              <MoreIcon />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => onEdit(webhook)}>
+            <EditIcon />
+            {t("common.edit")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => onDelete(webhook)}
+          >
+            <DeleteIcon />
+            {t("common.delete")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
 
 /**
- * Dumb table of a project's webhooks — URL · subscribed event types · created,
- * plus a per-row actions menu (edit / delete) wired to the host's passthrough
- * handlers. A row click opens the webhook's detail page. Few webhooks per
- * project, so this is a plain table (no server pagination/filters).
+ * Dumb table of a project's webhooks — URL · subscribed event types, plus a
+ * per-row actions menu (edit / delete) wired to the host's passthrough
+ * handlers. A row click opens the webhook's detail page.
+ *
+ * Built on the shared DataGrid rather than hand-rolled `<table>` markup, so it
+ * inherits the same shell, density, and skeleton treatment as every other table
+ * in the app. Few webhooks per project, so there is no pagination and no
+ * `DataGridPagination`; `pageSize` serves only to size the loading state.
  */
 export function WebhooksTable({
   webhooks,
   projectId,
   onEdit,
   onDelete,
+  isLoading = false,
 }: {
+  /** Renders the loading skeleton in place of rows — see the route's Suspense boundary. */
+  isLoading?: boolean;
   onDelete: (webhook: WebhookSummary) => void;
   onEdit: (webhook: WebhookSummary) => void;
   projectId: string;
@@ -34,90 +100,116 @@ export function WebhooksTable({
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  return (
-    <div className="overflow-hidden rounded-xl border border-border">
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border bg-muted/40 text-xs text-muted-foreground [&>th]:px-4 [&>th]:py-2.5 [&>th]:text-left [&>th]:font-medium [&>th]:whitespace-nowrap">
-              <th>{t("webhooks.columns.url")}</th>
-              <th>{t("webhooks.columns.eventTypes")}</th>
-              <th className="w-14 text-right">
-                <span className="sr-only">{t("common.actions")}</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {webhooks.map((webhook) => (
-              <tr
-                key={webhook.id}
-                onClick={() =>
-                  navigate(`/projects/${projectId}/webhooks/${webhook.id}`)
-                }
-                className="cursor-pointer border-b border-border last:border-0 transition-colors hover:bg-muted/30 [&>td]:px-4 [&>td]:py-3 [&>td]:align-middle"
+  const columns = useMemo<ColumnDef<DataGridFeatures, WebhookSummary>[]>(
+    () => [
+      {
+        accessorKey: "url",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("webhooks.columns.url")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => (
+          // The URL cell is this row's navigating link — a `<tr>` onClick alone
+          // is mouse-only.
+          <RowLink to={`/projects/${projectId}/webhooks/${row.original.id}`}>
+            <span className="block truncate font-medium">
+              {row.original.url}
+            </span>
+          </RowLink>
+        ),
+        enableSorting: false,
+        size: 360,
+        meta: { skeleton: <Skeleton className="h-3.5 w-56" /> },
+      },
+      {
+        accessorKey: "eventTypes",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("webhooks.columns.eventTypes")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => (
+          <div className="flex flex-wrap gap-1">
+            {row.original.eventTypes.map((type) => (
+              <Badge
+                key={type}
+                variant="secondary"
+                size="xs"
+                className="font-mono"
               >
-                <td className="max-w-xs">
-                  {/* The URL cell is this row's navigating link — a `<tr>`
-                      onClick alone is mouse-only. */}
-                  <RowLink
-                    to={`/projects/${projectId}/webhooks/${webhook.id}`}
-                  >
-                    <span className="block truncate font-medium">
-                      {webhook.url}
-                    </span>
-                  </RowLink>
-                </td>
-                <td>
-                  <div className="flex flex-wrap gap-1">
-                    {webhook.eventTypes.map((type) => (
-                      <Badge
-                        key={type}
-                        variant="secondary"
-                        size="xs"
-                        className="font-mono"
-                      >
-                        {type}
-                      </Badge>
-                    ))}
-                  </div>
-                </td>
-                <td className="text-right">
-                  {/* Stop propagation so the menu doesn't trigger the row's
-                      navigate-to-detail click. */}
-                  <div onClick={(event) => event.stopPropagation()}>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger
-                        render={
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            aria-label={t("webhooks.actions.menu")}
-                          >
-                            <MoreIcon />
-                          </Button>
-                        }
-                      />
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => onEdit(webhook)}>
-                          <EditIcon />
-                          {t("common.edit")}
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          variant="destructive"
-                          onClick={() => onDelete(webhook)}
-                        >
-                          <DeleteIcon />
-                          {t("common.delete")}
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                </td>
-              </tr>
+                {type}
+              </Badge>
             ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+          </div>
+        ),
+        enableSorting: false,
+        size: 280,
+        meta: {
+          // Two `size="xs"` (h-4) badges — a subscription is rarely just one,
+          // and the real count isn't knowable before the rows land.
+          skeleton: (
+            <div className="flex gap-1">
+              <Skeleton className="h-4 w-20 rounded-md" />
+              <Skeleton className="h-4 w-16 rounded-md" />
+            </div>
+          ),
+        },
+      },
+      {
+        id: "actions",
+        // No visible label, but the header cell still needs an accessible name
+        // — an empty `<th>` leaves screen-reader table navigation announcing an
+        // unnamed column.
+        header: () => <span className="sr-only">{t("common.actions")}</span>,
+        cell: ({ row }) => (
+          <RowActions
+            webhook={row.original}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        ),
+        enableSorting: false,
+        size: 56,
+        meta: {
+          cellClassName: "text-right",
+          skeleton: <Skeleton className="ms-auto size-7 rounded-md" />,
+        },
+      },
+    ],
+    [t, projectId, onEdit, onDelete],
+  );
+
+  const table = useTable({
+    features: dataGridFeatures,
+    data: webhooks,
+    columns,
+    getRowId: (row) => row.id,
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: SKELETON_ROW_COUNT },
+    },
+    manualPagination: true,
+  });
+
+  return (
+    <DataGrid
+      table={table}
+      recordCount={webhooks.length}
+      isLoading={isLoading}
+      tableLayout={{ rowBorder: true, width: "fixed" }}
+      tableClassNames={{ base: "min-w-[44rem]!" }}
+      emptyMessage={t("webhooks.grid.empty")}
+      onRowClick={(webhook) =>
+        navigate(`/projects/${projectId}/webhooks/${webhook.id}`)
+      }
+    >
+      <DataGridContainer>
+        <div className="overflow-x-auto">
+          <DataGridTable />
+        </div>
+      </DataGridContainer>
+    </DataGrid>
   );
 }

--- a/app/app/routes/protected/_project.social-posts.$socialPostId._index/components/accounts-table-row.tsx
+++ b/app/app/routes/protected/_project.social-posts.$socialPostId._index/components/accounts-table-row.tsx
@@ -1,6 +1,6 @@
 import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useNavigate } from "react-router";
+import { Link } from "react-router";
 
 import type {
   PostAccountResult,
@@ -8,7 +8,6 @@ import type {
 } from "~/lib/types/social-post";
 
 import { PostAccountAvatar } from "~/components/account-avatars";
-import { CopyableId } from "~/components/copyable-id";
 import { ChevronRightIcon, ExternalLinkIcon } from "~/icons";
 import { platformMeta } from "~/lib/platform-meta";
 import { cn } from "~/lib/utils";
@@ -29,170 +28,159 @@ const STATUS_DOT: Record<PostAccountStatus, StatusName> = {
   error: "destructive",
 };
 
-const TABLE_COLUMNS = 6;
-
-/**
- * One account as a grouped `<tbody>`: the identity + status + legacy identifier
- * cells, and — when the account's resolved config diverges from the global base —
- * a caret toggling an attached, collapsible "custom configuration" sub-row. The
- * row navigates to its standalone result page when one exists.
- *
- * Memoized: each row owns its own expand state, so isolating it keeps a toggle
- * (or any sibling's) from re-rendering the rest of the table.
- */
-export const AccountRow = memo(function AccountRow({
+/** The identity cell: avatar + label, and a link out to the result page. */
+export function AccountIdentityCell({
   result,
 }: {
   result: PostAccountResult;
 }) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const {
-    account,
-    status,
-    resultId,
-    providerPostId,
-    providerPostUrl,
-    overrides,
-    errorMessage,
-  } = result;
+  const { account, status, resultId } = result;
   const meta = platformMeta(account.platform);
   const label = account.username ?? meta?.label ?? account.platform;
-  const hasOverrides = overrides.length > 0;
+  const resultHref = resultId ? `/social-post-results/${resultId}` : null;
+
+  return (
+    <div className="flex items-center gap-2.5">
+      <PostAccountAvatar account={account} status={status} size="sm" />
+      <div className="flex flex-col">
+        <span className="font-medium text-foreground">{label}</span>
+        {resultHref ? (
+          <Link
+            to={resultHref}
+            onClick={(e) => e.stopPropagation()}
+            className="text-xs text-primary hover:underline"
+          >
+            {t("socialPosts.detail.viewDetails")}
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** The status cell: a dot, plus the error message behind a tooltip when failed. */
+export function AccountStatusCell({
+  result,
+}: {
+  result: PostAccountResult;
+}) {
+  const { t } = useTranslation();
+  const { status, errorMessage } = result;
+
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <StatusIndicator status={STATUS_DOT[status]} className="size-2" />
+      {status === "error" && errorMessage ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={(e) => e.stopPropagation()}
+                className={cn(
+                  "cursor-help font-medium underline decoration-dotted decoration-destructive/50 underline-offset-2",
+                  STATUS_TEXT_CLASS[status],
+                )}
+              >
+                {t("socialPosts.detail.accountStatus.error")}
+              </button>
+            }
+          />
+          <TooltipContent className="max-w-xs whitespace-normal">
+            {errorMessage}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <span className={cn("font-medium", STATUS_TEXT_CLASS[status])}>
+          {t(`socialPosts.detail.accountStatus.${status}`)}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** The provider post URL cell, or an em dash when the post never landed. */
+export function AccountPostUrlCell({
+  result,
+}: {
+  result: PostAccountResult;
+}) {
+  const { providerPostUrl } = result;
+
+  if (!providerPostUrl) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  return (
+    <a
+      href={providerPostUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className="inline-flex items-center gap-1 font-mono text-xs text-primary hover:underline"
+    >
+      <span className="max-w-[28ch] truncate">{providerPostUrl}</span>
+      <ExternalLinkIcon className="size-3.5 shrink-0" />
+    </a>
+  );
+}
+
+/**
+ * The attached sub-row for an account whose resolved config diverges from the
+ * global base: a caret toggling the collapsible "custom configuration" list.
+ *
+ * This rides in the grid's expanded-row slot (`meta.expandedContent`). Rows
+ * with overrides are held open by the grid so the labelled caret bar is always
+ * visible — the caret toggles only the list beneath it, which is the behaviour
+ * this table had as hand-written `<tbody>` markup.
+ *
+ * Memoized: each panel owns its own expand state, so isolating it keeps a
+ * toggle (or any sibling's) from re-rendering the rest of the table.
+ */
+export const AccountOverridesPanel = memo(function AccountOverridesPanel({
+  result,
+}: {
+  result: PostAccountResult;
+}) {
+  const { t } = useTranslation();
+  const { account, overrides } = result;
   const [expanded, setExpanded] = useState(false);
   const toggleLabel = t(
     expanded
       ? "socialPosts.detail.customConfigHide"
       : "socialPosts.detail.customConfigShow",
   );
-  const resultHref = resultId ? `/social-post-results/${resultId}` : null;
 
   return (
-    <tbody className="border-b border-border last:border-b-0">
-      <tr
-        onClick={resultHref ? () => navigate(resultHref) : undefined}
-        className={cn(
-          "[&>td]:px-4 [&>td]:py-3 [&>td]:align-middle [&>td]:whitespace-nowrap",
-          resultHref && "cursor-pointer transition-colors hover:bg-muted/40",
-        )}
-      >
-        <td>
-          <div className="flex items-center gap-2.5">
-            <PostAccountAvatar account={account} status={status} size="sm" />
-            <div className="flex flex-col">
-              <span className="font-medium text-foreground">{label}</span>
-              {resultHref ? (
-                <Link
-                  to={resultHref}
-                  onClick={(e) => e.stopPropagation()}
-                  className="text-xs text-primary hover:underline"
-                >
-                  {t("socialPosts.detail.viewDetails")}
-                </Link>
-              ) : null}
-            </div>
-          </div>
-        </td>
-        <td>
-          <span className="inline-flex items-center gap-1.5">
-            <StatusIndicator status={STATUS_DOT[status]} className="size-2" />
-            {status === "error" && errorMessage ? (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <button
-                      type="button"
-                      onClick={(e) => e.stopPropagation()}
-                      className={cn(
-                        "cursor-help font-medium underline decoration-dotted decoration-destructive/50 underline-offset-2",
-                        STATUS_TEXT_CLASS[status],
-                      )}
-                    >
-                      {t("socialPosts.detail.accountStatus.error")}
-                    </button>
-                  }
-                />
-                <TooltipContent className="max-w-xs whitespace-normal">
-                  {errorMessage}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <span className={cn("font-medium", STATUS_TEXT_CLASS[status])}>
-                {t(`socialPosts.detail.accountStatus.${status}`)}
-              </span>
+    // The grid's expanded cell carries no padding of its own, so the surface
+    // and insets that used to live on the `<td>` live here instead.
+    <div className="bg-muted/30 px-4 pt-3.5 pb-3">
+      <div className="flex flex-col gap-3 ps-2">
+        {/* The caret is the expand control; the label stays visible. */}
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-label={toggleLabel}
+          title={toggleLabel}
+          className="flex items-center gap-1.5 self-start text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronRightIcon
+            className={cn(
+              "size-3.5 shrink-0 transition-transform duration-200",
+              expanded && "rotate-90",
             )}
+          />
+          <span className="text-[0.6875rem] font-medium tracking-wide uppercase">
+            {t("socialPosts.detail.customConfigTitle")}
           </span>
-        </td>
-        <td>
-          <CopyableId
-            value={resultId}
-            copyLabel={t("socialPosts.detail.copyResultId")}
-          />
-        </td>
-        <td>
-          <CopyableId
-            value={account.id}
-            copyLabel={t("socialPosts.detail.copyAccountId")}
-          />
-        </td>
-        <td>
-          <CopyableId
-            value={providerPostId}
-            copyLabel={t("socialPosts.detail.copyProviderPostId")}
-          />
-        </td>
-        <td>
-          {providerPostUrl ? (
-            <a
-              href={providerPostUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              className="inline-flex items-center gap-1 font-mono text-xs text-primary hover:underline"
-            >
-              <span className="max-w-[28ch] truncate">{providerPostUrl}</span>
-              <ExternalLinkIcon className="size-3.5 shrink-0" />
-            </a>
-          ) : (
-            <span className="text-muted-foreground">—</span>
-          )}
-        </td>
-      </tr>
+        </button>
 
-      {hasOverrides ? (
-        <tr>
-          <td colSpan={TABLE_COLUMNS} className="bg-muted/30 px-4 pt-3.5 pb-3">
-            <div className="flex flex-col gap-3 ps-2">
-              {/* The caret is the expand control; the label stays visible. */}
-              <button
-                type="button"
-                onClick={() => setExpanded((v) => !v)}
-                aria-expanded={expanded}
-                aria-label={toggleLabel}
-                title={toggleLabel}
-                className="flex items-center gap-1.5 self-start text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <ChevronRightIcon
-                  className={cn(
-                    "size-3.5 shrink-0 transition-transform duration-200",
-                    expanded && "rotate-90",
-                  )}
-                />
-                <span className="text-[0.6875rem] font-medium tracking-wide uppercase">
-                  {t("socialPosts.detail.customConfigTitle")}
-                </span>
-              </button>
-
-              {expanded ? (
-                <CustomConfigList
-                  overrides={overrides}
-                  platform={account.platform}
-                />
-              ) : null}
-            </div>
-          </td>
-        </tr>
-      ) : null}
-    </tbody>
+        {expanded ? (
+          <CustomConfigList overrides={overrides} platform={account.platform} />
+        ) : null}
+      </div>
+    </div>
   );
 });

--- a/app/app/routes/protected/_project.social-posts.$socialPostId._index/components/accounts-table.tsx
+++ b/app/app/routes/protected/_project.social-posts.$socialPostId._index/components/accounts-table.tsx
@@ -1,7 +1,21 @@
-import { useTranslation } from "react-i18next";
+import type { ExpandedState } from "@tanstack/react-table";
 
+import { type ColumnDef, useTable } from "@tanstack/react-table";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+
+import type { DataGridFeatures } from "~/components/data-grid/data-grid";
 import type { PostAccountResult } from "~/lib/types/social-post";
 
+import { CopyableId } from "~/components/copyable-id";
+import {
+  DataGrid,
+  DataGridContainer,
+  dataGridFeatures,
+} from "~/components/data-grid/data-grid";
+import { DataGridColumnHeader } from "~/components/data-grid/data-grid-column-header";
+import { DataGridTable } from "~/components/data-grid/data-grid-table";
 import { PostsIcon } from "~/icons";
 import {
   Empty,
@@ -10,26 +24,193 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "~/ui/empty";
+import { Skeleton } from "~/ui/skeleton";
 
-import { AccountRow } from "./accounts-table-row";
+import {
+  AccountIdentityCell,
+  AccountOverridesPanel,
+  AccountPostUrlCell,
+  AccountStatusCell,
+} from "./accounts-table-row";
+
+/** See the note in the API keys table — this fan-out has no pagination either. */
+const SKELETON_ROW_COUNT = 3;
 
 /**
- * The accounts fan-out: one row per targeted account ({@link AccountRow}),
- * retaining the legacy identifier columns, with an empty state when the post
- * targets none.
+ * The accounts fan-out: one row per targeted account, retaining the legacy
+ * identifier columns, with an empty state when the post targets none.
+ *
+ * Built on the shared DataGrid rather than hand-rolled `<table>` markup, so it
+ * inherits the same shell, density, and skeleton treatment as every other table
+ * in the app. An account whose resolved config diverges from the global base
+ * carries an attached sub-row ({@link AccountOverridesPanel}) through the grid's
+ * expanded-row slot.
  */
 export function AccountsTable({
   accounts,
+  isLoading = false,
 }: {
   accounts: PostAccountResult[];
+  /** Renders the loading skeleton in place of rows — see the route's Suspense boundary. */
+  isLoading?: boolean;
 }) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const columns = useMemo<ColumnDef<DataGridFeatures, PostAccountResult>[]>(
+    () => [
+      {
+        id: "account",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("socialPosts.detail.table.account")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => <AccountIdentityCell result={row.original} />,
+        enableSorting: false,
+        size: 240,
+        meta: {
+          // The sub-row hangs off this column: the grid takes the first
+          // `expandedContent` it finds across the column set.
+          expandedContent: (result: PostAccountResult) => (
+            <AccountOverridesPanel result={result} />
+          ),
+          skeleton: (
+            <div className="flex items-center gap-2.5">
+              <Skeleton className="size-6 shrink-0 rounded-full" />
+              <div className="flex flex-col gap-1">
+                <Skeleton className="h-3.5 w-24" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+          ),
+        },
+      },
+      {
+        id: "status",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("socialPosts.detail.table.status")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => <AccountStatusCell result={row.original} />,
+        enableSorting: false,
+        size: 140,
+        meta: {
+          skeleton: (
+            <div className="flex items-center gap-1.5">
+              <Skeleton className="size-2 shrink-0 rounded-full" />
+              <Skeleton className="h-3.5 w-14" />
+            </div>
+          ),
+        },
+      },
+      {
+        id: "resultId",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("socialPosts.detail.table.resultId")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => (
+          <CopyableId
+            value={row.original.resultId}
+            copyLabel={t("socialPosts.detail.copyResultId")}
+          />
+        ),
+        enableSorting: false,
+        size: 200,
+        meta: { skeleton: <Skeleton className="h-3.5 w-32" /> },
+      },
+      {
+        id: "accountId",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("socialPosts.detail.table.accountId")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => (
+          <CopyableId
+            value={row.original.account.id}
+            copyLabel={t("socialPosts.detail.copyAccountId")}
+          />
+        ),
+        enableSorting: false,
+        size: 200,
+        meta: { skeleton: <Skeleton className="h-3.5 w-32" /> },
+      },
+      {
+        id: "platformPostId",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("socialPosts.detail.table.platformPostId")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => (
+          <CopyableId
+            value={row.original.providerPostId}
+            copyLabel={t("socialPosts.detail.copyProviderPostId")}
+          />
+        ),
+        enableSorting: false,
+        size: 200,
+        meta: { skeleton: <Skeleton className="h-3.5 w-28" /> },
+      },
+      {
+        id: "url",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title={t("socialPosts.detail.table.url")}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => <AccountPostUrlCell result={row.original} />,
+        enableSorting: false,
+        size: 240,
+        meta: { skeleton: <Skeleton className="h-3 w-40" /> },
+      },
+    ],
+    [t],
+  );
+
+  // Derived from the data, not from user interaction: an account with
+  // overrides is held open so its labelled caret bar is always visible, which
+  // is what the hand-written `<tbody>` markup did. Nothing in the UI toggles
+  // grid expansion — the caret inside the panel toggles only its own list — so
+  // this slice is intentionally controlled with no change handler.
+  const expanded = useMemo<ExpandedState>(
+    () =>
+      Object.fromEntries(
+        accounts
+          .filter((result) => result.overrides.length > 0)
+          .map((result) => [result.account.id, true]),
+      ),
+    [accounts],
+  );
+
+  const table = useTable({
+    features: dataGridFeatures,
+    data: accounts,
+    columns,
+    getRowId: (row) => row.account.id,
+    state: { expanded },
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: SKELETON_ROW_COUNT },
+    },
+    manualPagination: true,
+  });
+
   return (
     <section className="flex flex-col gap-3">
       <h2 className="font-heading text-sm font-semibold text-foreground">
         {t("socialPosts.detail.accountsTitle", { count: accounts.length })}
       </h2>
-      {accounts.length === 0 ? (
+      {accounts.length === 0 && !isLoading ? (
         <Empty className="border">
           <EmptyHeader>
             <EmptyMedia variant="icon">
@@ -42,25 +223,26 @@ export function AccountsTable({
           </EmptyHeader>
         </Empty>
       ) : (
-        <div className="overflow-hidden rounded-xl border border-border">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border bg-muted/40 text-xs text-muted-foreground [&>th]:px-4 [&>th]:py-2.5 [&>th]:text-left [&>th]:font-medium [&>th]:whitespace-nowrap">
-                  <th>{t("socialPosts.detail.table.account")}</th>
-                  <th>{t("socialPosts.detail.table.status")}</th>
-                  <th>{t("socialPosts.detail.table.resultId")}</th>
-                  <th>{t("socialPosts.detail.table.accountId")}</th>
-                  <th>{t("socialPosts.detail.table.platformPostId")}</th>
-                  <th>{t("socialPosts.detail.table.url")}</th>
-                </tr>
-              </thead>
-              {accounts.map((result) => (
-                <AccountRow key={result.account.id} result={result} />
-              ))}
-            </table>
-          </div>
-        </div>
+        <DataGrid
+          table={table}
+          recordCount={accounts.length}
+          isLoading={isLoading}
+          tableLayout={{ rowBorder: true, width: "fixed" }}
+          tableClassNames={{ base: "min-w-[72rem]!" }}
+          emptyMessage={t("socialPosts.detail.resultsEmpty")}
+          // Only a row that produced a result has somewhere to go.
+          onRowClick={(result) =>
+            result.resultId
+              ? navigate(`/social-post-results/${result.resultId}`)
+              : undefined
+          }
+        >
+          <DataGridContainer>
+            <div className="overflow-x-auto">
+              <DataGridTable />
+            </div>
+          </DataGridContainer>
+        </DataGrid>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary

Follow-on to the TanStack Table v9 upgrade (#319). Three related changes that make every table in the app behave the same way: loading states exist, all tables use the shared grid, and one route streams its list so the skeletons are actually reachable.

Split out of #319 deliberately — that PR was the v9 migration, this is the UI work that grew out of reviewing it.

## Changes

**Skeletons — the reason they were missing**
- No column anywhere in the app defined `meta.skeleton`. The grid was correctly rendering `pageSize` skeleton rows and each cell was rendering `undefined`, so it looked like nothing. Our implementation matches upstream ReUI here line for line; the consumer side was simply never filled in.
- Every column across posts (6), accounts (6), webhook-events (3), and the three newly converted grids now supplies one, shaped to its real cell — `size-6` circles for avatars, `h-4` bars for `size="xs"` badges, matching widths per column — so rows don't resize when data lands.

**Three raw `<table>`s moved onto the DataGrid**
- `api-keys-table`, `webhooks-table`, and the per-post `accounts-table` fan-out were hand-rolled markup that had drifted from the grid: `rounded-xl` + `border` + `px-4 py-3` against the grid's `rounded-lg` + `ring` + density-skin padding. On the webhook detail page the Configuration card and the table below it were visibly different shapes.
- Row-click navigation, the `stopPropagation` guard on actions menus, and the `RowLink` keyboard affordance are preserved.
- The fan-out keeps its attached overrides sub-row by riding the grid's **expanded-row slot** (`meta.expandedContent`), with `expanded` derived from which accounts have overrides rather than from user interaction — so the labelled caret bar stays permanently visible exactly as before, and the caret still toggles only its own config list.

**Loading — api-keys streams its list**
- Its loader returns a promise instead of awaiting, so the page shell and the table's skeletons paint immediately. Auth guards stay awaited: a non-member never reaches the shell.
- The degraded-backend path rides on `.catch()` rather than a `try/catch`, so an unconfigured or unreachable keys backend still resolves to the "unavailable" notice instead of rejecting into the error boundary.
- The Suspense fallback is the same view with `isLoading`, so the heading and Create button don't pop in. The empty state is suppressed while loading — an empty list we haven't fetched yet is not the same as a project with no keys.

**One layout fix**
- The deliveries grid was the only one passing no `tableLayout`, so it inherited `width: "fixed"` and spread ~830px of surplus across all three columns, stranding Status and Received in whitespace. The event column is now the fill column via `meta.autoSize`.

## Testing

From `app/`: `bun run typecheck`, `bun run lint` (0 warnings), and `bun run build` (client + SSR) all pass, on top of the merged #319 base.

Manually reviewed in the dev server: the webhooks list, the per-post accounts fan-out (on a post with 5 accounts, 3 carrying config overrides, so the expanded sub-rows are exercised), and the deliveries grid.

> **Not yet verified by eye:** the `meta.autoSize` spacing fix on the deliveries grid, and the api-keys page — see below.

## Notes

- **The api-keys page had a reported error during review that I was never able to reproduce or get the message for.** Worth a look before merge. It may well have been dev-server staleness: several times this session the running Vite server kept serving stale modules after bulk file rewrites, which is what made the deliveries grid look broken for three rounds. Worth a clean restart before concluding anything.
- **Only api-keys has a deferred loader.** Posts, accounts, webhooks, deliveries, and the post detail still `await`, so those pages show skeletons on paging but not on initial load. Deferring them is the same pattern applied five more times, but each has its own header/empty/error interplay, so it wants its own review.
- To see skeletons on the paginated grids you need `?size=5` — the seed project has 19 accounts and 11 posts against a page size of 25, so nothing paginates by default.
- The temporary `REVIEW_EVENTS_RESULT` fixture used to review the deliveries grid has been removed; `webhook_events` is empty in seed data, so that page renders its empty state.
- Follow-ups already filed: PFM-998 (hand-rolled panels → `Card`/`Alert`, incl. a composable `DangerZone`), PFM-1001 (vendor a `Timeline` primitive, migrate `LogRail`), PFM-999 (deliveries as a timeline — which will replace the grid touched here).

🤖 Generated with AI