### PR TITLE
refactor(app): replace hand-rolled panels with Card / DangerZone primitives (PFM-998)

### DIFF
--- a/app/app/components/danger-zone.tsx
+++ b/app/app/components/danger-zone.tsx
@@ -1,0 +1,103 @@
+import type * as React from "react";
+
+import { cn } from "~/lib/utils";
+import { Card } from "~/ui/card";
+
+/**
+ * A destructive-framed panel — the "Danger zone" that closes a settings/detail
+ * page. It's a {@link Card} with the destructive ring baked in, plus the
+ * stacked-on-mobile / row-at-`sm` header+actions arrangement every danger zone
+ * used to hand-roll (and had quietly drifted apart on: `gap-1` vs `gap-0.5`,
+ * `text-sm` vs `text-xs/relaxed`). Those are settled here, so no call site
+ * passes any layout, radius, border, spacing, or destructive-colour class.
+ *
+ * Compound, because the three call sites differ in how their actions are wired
+ * (a plain button, a `ConfirmDialog` trigger, an n-button row):
+ *
+ * ```tsx
+ * <DangerZone>
+ *   <DangerZoneHeader>
+ *     <DangerZoneTitle>{t("…dangerTitle")}</DangerZoneTitle>
+ *     <DangerZoneDescription>{t("…dangerDescription")}</DangerZoneDescription>
+ *   </DangerZoneHeader>
+ *   <DangerZoneActions>
+ *     <Button variant="destructive">…</Button>
+ *   </DangerZoneActions>
+ *   {/* non-visual children (ConfirmDialog, fetcher wiring) sit here *\/}
+ * </DangerZone>
+ * ```
+ *
+ * The header and actions are the only two boxes in the row — non-visual children
+ * (a controlled `ConfirmDialog`) render nothing in flow, so `justify-between`
+ * keeps the title left / actions right regardless.
+ */
+function DangerZone({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof Card>) {
+  return (
+    <Card className={cn("ring-destructive/20", className)} {...props}>
+      <div className="flex flex-col gap-4 px-(--card-spacing) sm:flex-row sm:items-center sm:justify-between">
+        {children}
+      </div>
+    </Card>
+  );
+}
+
+/** Title + description, stacked and left-aligned. */
+function DangerZoneHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex min-w-0 flex-col gap-0.5", className)}
+      {...props}
+    />
+  );
+}
+
+/** The destructive-toned heading — call sites never pass `text-destructive`. */
+function DangerZoneTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <h2
+      className={cn(
+        "font-heading text-sm font-semibold text-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** The supporting copy under the title. */
+function DangerZoneDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-xs/relaxed text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+/** Wraps and right-aligns, so one control or several both land correctly. */
+function DangerZoneActions({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex flex-wrap justify-end gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DangerZone,
+  DangerZoneActions,
+  DangerZoneDescription,
+  DangerZoneHeader,
+  DangerZoneTitle,
+};

--- a/app/app/routes/protected/_project.projects.$projectId.settings._index/components/project-danger-zone.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.settings._index/components/project-danger-zone.tsx
@@ -4,6 +4,13 @@ import { useFetcher } from "react-router";
 import type { Project } from "~/lib/types/project";
 
 import { ConfirmDialog } from "~/components/confirm-dialog";
+import {
+  DangerZone,
+  DangerZoneActions,
+  DangerZoneDescription,
+  DangerZoneHeader,
+  DangerZoneTitle,
+} from "~/components/danger-zone";
 import { useActionErrorToast } from "~/hooks/use-action-error-toast";
 import { DeleteIcon } from "~/icons";
 import { Button } from "~/ui/button";
@@ -21,50 +28,52 @@ export function ProjectDangerZone({ project }: { project: Project }) {
   useActionErrorToast(fetcher);
 
   return (
-    <section className="flex flex-col gap-4 rounded-xl border border-destructive/10 bg-card p-6 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <h2 className="font-heading text-sm font-semibold text-destructive">
+    <DangerZone>
+      <DangerZoneHeader>
+        <DangerZoneTitle>
           {t("projectSettings.dangerZone.title")}
-        </h2>
-        <p className="text-xs/relaxed text-muted-foreground">
+        </DangerZoneTitle>
+        <DangerZoneDescription>
           {t("projectSettings.dangerZone.deleteDescription")}
-        </p>
-      </div>
+        </DangerZoneDescription>
+      </DangerZoneHeader>
 
-      <ConfirmDialog
-        trigger={
-          <Button type="button" variant="destructive" className="shrink-0">
-            <DeleteIcon />
-            {t("projectSettings.dangerZone.deleteButton")}
-          </Button>
-        }
-        title={t("projectSettings.dangerZone.confirmTitle", {
-          name: project.name,
-        })}
-        description={t("projectSettings.dangerZone.confirmBody")}
-        confirmStep={{
-          title: t("projectSettings.dangerZone.confirmStepTitle"),
-          description: t("projectSettings.dangerZone.confirmStepBody", {
+      <DangerZoneActions>
+        <ConfirmDialog
+          trigger={
+            <Button type="button" variant="destructive">
+              <DeleteIcon />
+              {t("projectSettings.dangerZone.deleteButton")}
+            </Button>
+          }
+          title={t("projectSettings.dangerZone.confirmTitle", {
             name: project.name,
-          }),
-          // Step 1's advance button: type the name first, then this advances to
-          // the "are you sure?" final beat.
-          continueLabel: t("projectSettings.dangerZone.deleteButton"),
-        }}
-        confirmLabel={t("projectSettings.dangerZone.permanentlyDelete")}
-        destructive
-        requireText={project.name}
-        requireTextLabel={t("projectSettings.dangerZone.confirmLabel", {
-          name: project.name,
-        })}
-        pending={fetcher.state !== "idle"}
-        onConfirm={() =>
-          fetcher.submit(
-            { intent: "delete" },
-            { method: "post", action: `/projects/${project.id}/settings` },
-          )
-        }
-      />
-    </section>
+          })}
+          description={t("projectSettings.dangerZone.confirmBody")}
+          confirmStep={{
+            title: t("projectSettings.dangerZone.confirmStepTitle"),
+            description: t("projectSettings.dangerZone.confirmStepBody", {
+              name: project.name,
+            }),
+            // Step 1's advance button: type the name first, then this advances
+            // to the "are you sure?" final beat.
+            continueLabel: t("projectSettings.dangerZone.deleteButton"),
+          }}
+          confirmLabel={t("projectSettings.dangerZone.permanentlyDelete")}
+          destructive
+          requireText={project.name}
+          requireTextLabel={t("projectSettings.dangerZone.confirmLabel", {
+            name: project.name,
+          })}
+          pending={fetcher.state !== "idle"}
+          onConfirm={() =>
+            fetcher.submit(
+              { intent: "delete" },
+              { method: "post", action: `/projects/${project.id}/settings` },
+            )
+          }
+        />
+      </DangerZoneActions>
+    </DangerZone>
   );
 }

--- a/app/app/routes/protected/_project.projects.$projectId.settings._index/components/project-settings-view.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.settings._index/components/project-settings-view.tsx
@@ -7,6 +7,14 @@ import type { Project } from "~/lib/types/project";
 
 import { InfoIcon } from "~/icons";
 import { Alert, AlertDescription, AlertTitle } from "~/ui/alert";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "~/ui/card";
 import { ProjectTypeBadge } from "~/ui/project-type-badge";
 
 import { ProjectCallbackUrlSection } from "./project-callback-url-section";
@@ -113,7 +121,7 @@ export function ProjectSettingsView({
 }
 
 /**
- * One settings card: a bordered panel with a header (title + description on the
+ * One settings card: a {@link Card} with a header (title + description on the
  * left, the optional edit action on the right) above the content.
  */
 function SettingsCard({
@@ -128,20 +136,14 @@ function SettingsCard({
   title: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex min-w-0 flex-col gap-0.5">
-          <h2 className="font-heading text-sm font-semibold text-foreground">
-            {title}
-          </h2>
-          {description ? (
-            <p className="text-xs/relaxed text-muted-foreground">{description}</p>
-          ) : null}
-        </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
-      </div>
-      {children}
-    </section>
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description ? <CardDescription>{description}</CardDescription> : null}
+        {action ? <CardAction>{action}</CardAction> : null}
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
   );
 }
 

--- a/app/app/routes/protected/_project.projects.$projectId.webhooks.$webhookId._index/route.component.tsx
+++ b/app/app/routes/protected/_project.projects.$projectId.webhooks.$webhookId._index/route.component.tsx
@@ -17,6 +17,13 @@ import type {
 } from "~/lib/types/webhook";
 
 import { ConfirmDialog } from "~/components/confirm-dialog";
+import {
+  DangerZone,
+  DangerZoneActions,
+  DangerZoneDescription,
+  DangerZoneHeader,
+  DangerZoneTitle,
+} from "~/components/danger-zone";
 import { SubscriptionRequired } from "~/components/subscription-required";
 import { WebhookFormDialog } from "~/components/webhook-form-dialog";
 import { useActionErrorToast } from "~/hooks/use-action-error-toast";
@@ -245,20 +252,20 @@ function WebhookDetailView({
         )}
       </section>
 
-      <section className="flex flex-row items-center justify-between gap-3 rounded-xl border border-destructive/10 bg-card p-6">
-        <div className="flex flex-col gap-1">
-          <h2 className="font-heading text-sm font-semibold text-destructive">
-            {t("webhooks.detail.dangerTitle")}
-          </h2>
-          <p className="text-sm text-muted-foreground">
+      <DangerZone>
+        <DangerZoneHeader>
+          <DangerZoneTitle>{t("webhooks.detail.dangerTitle")}</DangerZoneTitle>
+          <DangerZoneDescription>
             {t("webhooks.detail.dangerDescription")}
-          </p>
-        </div>
-        <Button variant="destructive" onClick={() => setDeleteOpen(true)}>
-          <DeleteIcon />
-          {t("webhooks.detail.delete")}
-        </Button>
-      </section>
+          </DangerZoneDescription>
+        </DangerZoneHeader>
+        <DangerZoneActions>
+          <Button variant="destructive" onClick={() => setDeleteOpen(true)}>
+            <DeleteIcon />
+            {t("webhooks.detail.delete")}
+          </Button>
+        </DangerZoneActions>
+      </DangerZone>
 
       <WebhookFormDialog
         open={editOpen}

--- a/app/app/routes/protected/_project.social-accounts.$socialAccountId._index/components/account-danger-zone.tsx
+++ b/app/app/routes/protected/_project.social-accounts.$socialAccountId._index/components/account-danger-zone.tsx
@@ -5,6 +5,13 @@ import { useFetcher } from "react-router";
 import type { SocialAccount } from "~/lib/types/social-account";
 
 import { ConfirmDialog } from "~/components/confirm-dialog";
+import {
+  DangerZone,
+  DangerZoneActions,
+  DangerZoneDescription,
+  DangerZoneHeader,
+  DangerZoneTitle,
+} from "~/components/danger-zone";
 import { useActionErrorToast } from "~/hooks/use-action-error-toast";
 import { DisconnectIcon } from "~/icons";
 import { isActionError } from "~/lib/action-result";
@@ -40,17 +47,17 @@ export function AccountDangerZone({ account }: { account: SocialAccount }) {
   }, [fetcher.state, fetcher.data]);
 
   return (
-    <section className="flex flex-col gap-4 rounded-xl border border-destructive/10 bg-card p-6">
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <h2 className="font-heading text-sm font-semibold text-destructive">
+    <DangerZone>
+      <DangerZoneHeader>
+        <DangerZoneTitle>
           {t("socialAccounts.detail.dangerTitle")}
-        </h2>
-        <p className="text-xs/relaxed text-muted-foreground">
+        </DangerZoneTitle>
+        <DangerZoneDescription>
           {t("socialAccounts.detail.dangerDescription")}
-        </p>
-      </div>
+        </DangerZoneDescription>
+      </DangerZoneHeader>
 
-      <div className="flex flex-wrap justify-end gap-2">
+      <DangerZoneActions>
         <Button
           type="button"
           variant="secondary"
@@ -60,7 +67,7 @@ export function AccountDangerZone({ account }: { account: SocialAccount }) {
           <DisconnectIcon />
           {t("socialAccounts.actions.disconnect")}
         </Button>
-      </div>
+      </DangerZoneActions>
 
       <ConfirmDialog
         open={disconnectOpen}
@@ -73,6 +80,6 @@ export function AccountDangerZone({ account }: { account: SocialAccount }) {
         pending={pending}
         onConfirm={() => fetcher.submit({ intent: "disconnect" }, { method: "post" })}
       />
-    </section>
+    </DangerZone>
   );
 }

--- a/app/app/routes/protected/_project.social-accounts.$socialAccountId._index/components/account-posts-table.tsx
+++ b/app/app/routes/protected/_project.social-accounts.$socialAccountId._index/components/account-posts-table.tsx
@@ -8,6 +8,7 @@ import type {
 
 import { ChevronRightIcon, PostsIcon } from "~/icons";
 import { Badge } from "~/ui/badge";
+import { Card } from "~/ui/card";
 import {
   Empty,
   EmptyDescription,
@@ -60,7 +61,9 @@ export function AccountPostsTable({ posts }: { posts: AccountPost[] }) {
           </EmptyHeader>
         </Empty>
       ) : (
-        <div className="overflow-hidden rounded-xl border border-border">
+        // A flush list, not a titled card: zero the Card's padding/gap so the
+        // divided rows sit edge-to-edge inside its ring + radius.
+        <Card className="gap-0 py-0">
           {posts.map((post) => (
             <Link
               key={post.id}
@@ -83,7 +86,7 @@ export function AccountPostsTable({ posts }: { posts: AccountPost[] }) {
               <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground" />
             </Link>
           ))}
-        </div>
+        </Card>
       )}
     </section>
   );

--- a/app/app/routes/protected/_project.social-accounts.$socialAccountId._index/components/detail-card.tsx
+++ b/app/app/routes/protected/_project.social-accounts.$socialAccountId._index/components/detail-card.tsx
@@ -1,8 +1,17 @@
 import type * as React from "react";
 
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "~/ui/card";
+
 /**
- * One detail card: a bordered panel with a header (title + optional description
- * on the left, an optional action on the right) above the content. Mirrors the
+ * One detail card: a {@link Card} with a header (title + optional description on
+ * the left, an optional action on the right) above the content. Mirrors the
  * Project Settings page's `SettingsCard` so the two read-only surfaces share the
  * same visual structure.
  */
@@ -18,20 +27,14 @@ export function DetailCard({
   title: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex min-w-0 flex-col gap-0.5">
-          <h2 className="font-heading text-sm font-semibold text-foreground">
-            {title}
-          </h2>
-          {description ? (
-            <p className="text-xs/relaxed text-muted-foreground">{description}</p>
-          ) : null}
-        </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
-      </div>
-      {children}
-    </section>
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description ? <CardDescription>{description}</CardDescription> : null}
+        {action ? <CardAction>{action}</CardAction> : null}
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
   );
 }
 

--- a/app/app/routes/protected/_project.social-post-results.$socialPostResultId._index/components/result-references.tsx
+++ b/app/app/routes/protected/_project.social-post-results.$socialPostResultId._index/components/result-references.tsx
@@ -7,6 +7,7 @@ import { CopyableId } from "~/components/copyable-id";
 import { ReferenceRow } from "~/components/reference-row";
 import { ExternalLinkIcon, InfoIcon } from "~/icons";
 import { Alert, AlertDescription } from "~/ui/alert";
+import { Card, CardContent, CardHeader, CardTitle } from "~/ui/card";
 import { LocaleDateTime } from "~/ui/date-time";
 
 /**
@@ -23,62 +24,64 @@ export function ResultReferences({
 
   return (
     <div className="flex flex-col gap-4 lg:sticky lg:top-6">
-      <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
-        <h2 className="font-heading text-sm font-semibold text-foreground">
-          {t("socialPostResults.referencesTitle")}
-        </h2>
-        <dl className="flex flex-col gap-3">
-          <ReferenceRow label={t("socialPostResults.columns.post")}>
-            <Link
-              to={`/social-posts/${result.postId}`}
-              className="font-mono text-xs break-all text-primary hover:underline"
-            >
-              {result.postId}
-            </Link>
-          </ReferenceRow>
-          <ReferenceRow label={t("socialPostResults.columns.resultId")}>
-            <CopyableId
-              value={result.id}
-              copyLabel={t("socialPosts.detail.copyResultId")}
-              className="break-all"
-            />
-          </ReferenceRow>
-          <ReferenceRow label={t("socialPostResults.columns.accountId")}>
-            <CopyableId
-              value={account.id}
-              copyLabel={t("socialPosts.detail.copyAccountId")}
-              className="break-all"
-            />
-          </ReferenceRow>
-          <ReferenceRow label={t("socialPostResults.columns.platformPostId")}>
-            <CopyableId
-              value={result.providerPostId}
-              copyLabel={t("socialPosts.detail.copyProviderPostId")}
-              className="break-all"
-            />
-          </ReferenceRow>
-          <ReferenceRow label={t("socialPostResults.columns.url")}>
-            {result.providerPostUrl ? (
-              <a
-                href={result.providerPostUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 font-mono text-xs break-all text-primary hover:underline"
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("socialPostResults.referencesTitle")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="flex flex-col gap-3">
+            <ReferenceRow label={t("socialPostResults.columns.post")}>
+              <Link
+                to={`/social-posts/${result.postId}`}
+                className="font-mono text-xs break-all text-primary hover:underline"
               >
-                <span className="min-w-0 break-all">
-                  {result.providerPostUrl}
-                </span>
-                <ExternalLinkIcon className="size-3.5 shrink-0" />
-              </a>
-            ) : (
-              <span className="text-muted-foreground">—</span>
-            )}
-          </ReferenceRow>
-          <ReferenceRow label={t("socialPostResults.columns.created")}>
-            <LocaleDateTime value={result.createdAt} />
-          </ReferenceRow>
-        </dl>
-      </div>
+                {result.postId}
+              </Link>
+            </ReferenceRow>
+            <ReferenceRow label={t("socialPostResults.columns.resultId")}>
+              <CopyableId
+                value={result.id}
+                copyLabel={t("socialPosts.detail.copyResultId")}
+                className="break-all"
+              />
+            </ReferenceRow>
+            <ReferenceRow label={t("socialPostResults.columns.accountId")}>
+              <CopyableId
+                value={account.id}
+                copyLabel={t("socialPosts.detail.copyAccountId")}
+                className="break-all"
+              />
+            </ReferenceRow>
+            <ReferenceRow label={t("socialPostResults.columns.platformPostId")}>
+              <CopyableId
+                value={result.providerPostId}
+                copyLabel={t("socialPosts.detail.copyProviderPostId")}
+                className="break-all"
+              />
+            </ReferenceRow>
+            <ReferenceRow label={t("socialPostResults.columns.url")}>
+              {result.providerPostUrl ? (
+                <a
+                  href={result.providerPostUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 font-mono text-xs break-all text-primary hover:underline"
+                >
+                  <span className="min-w-0 break-all">
+                    {result.providerPostUrl}
+                  </span>
+                  <ExternalLinkIcon className="size-3.5 shrink-0" />
+                </a>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </ReferenceRow>
+            <ReferenceRow label={t("socialPostResults.columns.created")}>
+              <LocaleDateTime value={result.createdAt} />
+            </ReferenceRow>
+          </dl>
+        </CardContent>
+      </Card>
 
       {status === "success" ? (
         <Alert variant="info">

--- a/app/app/routes/protected/_project.social-posts.$socialPostId._index/components/post-references.tsx
+++ b/app/app/routes/protected/_project.social-posts.$socialPostId._index/components/post-references.tsx
@@ -6,6 +6,7 @@ import { CopyableId } from "~/components/copyable-id";
 import { ReferenceRow } from "~/components/reference-row";
 import { InfoIcon } from "~/icons";
 import { Alert, AlertDescription } from "~/ui/alert";
+import { Card, CardContent, CardHeader, CardTitle } from "~/ui/card";
 import { LocaleDateTime } from "~/ui/date-time";
 
 /**
@@ -16,30 +17,32 @@ export function PostReferences({ post }: { post: SocialPostDetail }) {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
-        <h2 className="font-heading text-sm font-semibold text-foreground">
-          {t("socialPosts.detail.referencesTitle")}
-        </h2>
-        <dl className="flex flex-col gap-3">
-          <ReferenceRow label={t("socialPosts.columns.pfmId")}>
-            <CopyableId
-              value={post.id}
-              copyLabel={t("socialPosts.actions.copyPfmId")}
-              className="break-all"
-            />
-          </ReferenceRow>
-          <ReferenceRow label={t("socialPosts.columns.externalId")}>
-            <CopyableId
-              value={post.externalId}
-              copyLabel={t("socialPosts.actions.copyExternalId")}
-              className="break-all"
-            />
-          </ReferenceRow>
-          <ReferenceRow label={t("socialPosts.detail.createdAt")}>
-            <LocaleDateTime value={post.createdAt} />
-          </ReferenceRow>
-        </dl>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("socialPosts.detail.referencesTitle")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="flex flex-col gap-3">
+            <ReferenceRow label={t("socialPosts.columns.pfmId")}>
+              <CopyableId
+                value={post.id}
+                copyLabel={t("socialPosts.actions.copyPfmId")}
+                className="break-all"
+              />
+            </ReferenceRow>
+            <ReferenceRow label={t("socialPosts.columns.externalId")}>
+              <CopyableId
+                value={post.externalId}
+                copyLabel={t("socialPosts.actions.copyExternalId")}
+                className="break-all"
+              />
+            </ReferenceRow>
+            <ReferenceRow label={t("socialPosts.detail.createdAt")}>
+              <LocaleDateTime value={post.createdAt} />
+            </ReferenceRow>
+          </dl>
+        </CardContent>
+      </Card>
 
       {post.status === "processed" ? (
         <Alert variant="info">

--- a/app/app/routes/protected/_team.teams.$teamId.billing._index/components/legacy-upgrade-card.tsx
+++ b/app/app/routes/protected/_team.teams.$teamId.billing._index/components/legacy-upgrade-card.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 
 import { BillingPlansDialog } from "~/components/billing";
 import { CheckIcon } from "~/icons";
+import { Card } from "~/ui/card";
 import { Separator } from "~/ui/separator";
 
 /**
@@ -41,8 +42,12 @@ export function LegacyUpgradeCard({ teamId }: { teamId: string }) {
     /* A CONTAINER, not viewport breakpoints: this card is a third of the row on
        a wide screen and the full width of the page on a narrow one, so "is
        there room for two columns" is a question about the card, not the
-       window. `sm:` would have given it two columns at its narrowest. */
-    <section className="@container flex flex-col gap-4 rounded-xl border border-pop/20 bg-pop/5 p-6 dark:bg-pop/10">
+       window. `sm:` would have given it two columns at its narrowest.
+
+       Built on Card for the shared radius + ring, with the `--pop` tint and
+       `p-6` overriding the card defaults so it still reads as the one
+       promotional surface on an otherwise factual page. */
+    <Card className="@container bg-pop/5 p-6 ring-pop/20 dark:bg-pop/10">
       <div className="flex flex-col items-stretch gap-3 @md:flex-row @md:items-start @md:justify-between @md:gap-x-6">
         <div className="flex min-w-0 flex-col gap-1">
           <h2 className="font-heading text-base font-semibold text-foreground">
@@ -78,6 +83,6 @@ export function LegacyUpgradeCard({ teamId }: { teamId: string }) {
           </li>
         ))}
       </ul>
-    </section>
+    </Card>
   );
 }


### PR DESCRIPTION
## What & why

Across `app/` we hand-rolled bordered panels (`rounded-xl border … bg-card p-6`) instead of using the `~/ui/card` primitive that already models the exact layout. The result was visual drift — panels a subtly different radius/border/padding from the real `Card`s sitting next to them on the same page (most visibly, the webhook detail page's Danger zone directly below the Configuration `Card`).

Closes PFM-998.

## Changes

**New `DangerZone` composite** — `app/components/danger-zone.tsx` (deliberately in `~/components`, not `~/ui`, so `shadcn add` can't overwrite it). Built on `Card` with the destructive ring, the stacked-on-mobile → row-at-`sm` header+actions layout, and the destructive title tone all baked in. Compound (`DangerZone` / `DangerZoneHeader` / `DangerZoneTitle` / `DangerZoneDescription` / `DangerZoneActions`) because the three call sites differ in how their actions are wired.

The three danger zones had also quietly drifted apart in typography (`text-sm` vs `text-xs/relaxed`, `gap-1` vs `gap-0.5`) — that's settled **once** in the component. No call site passes any layout, radius, border, spacing, or destructive-colour class.

**Danger zones converted** → `DangerZone`:
- webhook detail `route.component.tsx`
- `project-danger-zone.tsx` (ConfirmDialog trigger)
- `account-danger-zone.tsx` (disconnect button)

**Other hand-rolled panels converted** → `~/ui/card`:
- `detail-card.tsx` and `SettingsCard` (project settings) → `Card` + `CardHeader`/`CardTitle`/`CardDescription`/`CardAction`/`CardContent`
- `post-references.tsx`, `result-references.tsx` → `Card`
- `account-posts-table.tsx` → padding/gap-zeroed `Card` so the divided rows stay edge-to-edge inside the ring (comment explains why)
- `legacy-upgrade-card.tsx` → `Card` shell with the promotional `--pop` tint preserved via overrides

## Visual delta (expected)

Converted panels are now `rounded-lg` + `ring-1` instead of `rounded-xl` + `border` — that's the point: they now match the real `Card`s beside them.

## Accessibility

Audited `role="alert"`: the remaining uses are all transient/contextual (the `Field` error slot, the `Alert` primitive itself, and two login form errors). No permanently-rendered section carries an assertive live region.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run build` ✅ (module graph compiles)
- Primary grep `rounded-xl border` → only `ui/empty.tsx` (the Empty primitive's own shell) and the dev-only `billing-states` showcase remain, both explicitly out of scope. `border-destructive/10` → zero hits.

Live browser screenshots weren't captured — the three danger-zone pages require the authenticated Supabase + API stack, which isn't running in this environment. The layout was verified against the primitives' source instead (`justify-between` sees only header + actions because a controlled/closed `ConfirmDialog` renders no DOM via base-ui's `Dialog.Portal`).

<!-- generated-by-cyrus -->