### PR TITLE
feat(app): vendor Timeline primitive and migrate LogRail onto it

### DIFF
--- a/app/app/lib/i18n/locales/en/common.json
+++ b/app/app/lib/i18n/locales/en/common.json
@@ -715,6 +715,7 @@
     "configurationTitle": "Resolved configuration",
     "logsTitle": "Logs",
     "logsEmpty": "No response data.",
+    "logsShowMore": "Show {{count}} more",
     "rawTab": "Raw JSON",
     "askLlm": "Ask LLM",
     "askLlmCopied": "Prompt copied",

--- a/app/app/routes/protected/_project.social-post-results.$socialPostResultId._index/components/result-logs-rail.tsx
+++ b/app/app/routes/protected/_project.social-post-results.$socialPostResultId._index/components/result-logs-rail.tsx
@@ -1,48 +1,80 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
 import { ExchangeIcon } from "~/icons";
-import { cn } from "~/lib/utils";
-import { StepIndicator } from "~/ui/steps";
+import { Button } from "~/ui/button";
+import {
+  Timeline,
+  TimelineContent,
+  TimelineIndicator,
+  TimelineItem,
+  TimelineSeparator,
+  TimelineTitle,
+} from "~/ui/timeline";
 
 import type { LogOperation } from "./result-logs-parse";
 
 import { LogSideBlock } from "./result-logs-side-block";
 
 /**
- * The operations as a vertical rail: an exchange-glyph node per operation (no
- * "completed" check), connected oldest → newest, each holding its request +
- * response.
+ * How many operations to show before collapsing behind a "Show more". The whole
+ * set is already in memory — `toOperations` parses one jsonb field client-side —
+ * so this is pure client truncation (no network), unlike the server-paged
+ * timelines the primitive also feeds. Keeps a long provider exchange from
+ * rendering unbounded.
+ */
+const DEFAULT_VISIBLE = 5;
+
+/**
+ * The operations as a vertical rail: an exchange-glyph node per operation,
+ * connected oldest → newest, each holding its request + response. Built on the
+ * shared {@link Timeline} primitive — it owns the rail geometry (indicator gutter,
+ * connector, drop-on-last), so nothing here hand-rolls a line or an "is last?"
+ * check. There is no status: `value={0}` means no node is "active", and the
+ * indicator is filled uniformly (an exchange glyph, not a progress state).
  */
 export function LogRail({ operations }: { operations: LogOperation[] }) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  const collapsed = !expanded && operations.length > DEFAULT_VISIBLE;
+  const visible = collapsed ? operations.slice(0, DEFAULT_VISIBLE) : operations;
+  const hiddenCount = operations.length - visible.length;
+
   return (
-    <div className="flex flex-col">
-      {operations.map((op, index) => {
-        const last = index === operations.length - 1;
-        return (
-          <div key={`${op.name}-${index}`} className="flex gap-4">
-            <div className="flex flex-col items-center">
-              <StepIndicator status="complete" className="relative z-10">
-                <ExchangeIcon />
-              </StepIndicator>
-              {!last ? <span className="my-1 w-px flex-1 bg-border" /> : null}
-            </div>
-            <div
-              className={cn(
-                "flex min-w-0 flex-1 flex-col gap-3",
-                !last && "pb-6",
-              )}
-            >
-              <span className="font-heading text-sm font-semibold text-foreground">
-                {op.name}
-              </span>
+    <div className="flex flex-col gap-4">
+      <Timeline value={0}>
+        {visible.map((op, index) => (
+          <TimelineItem key={`${op.name}-${index}`} step={index + 1}>
+            <TimelineIndicator className="flex items-center justify-center border-0 bg-primary text-primary-foreground [&_svg]:size-4">
+              <ExchangeIcon />
+            </TimelineIndicator>
+            <TimelineSeparator />
+            <TimelineTitle className="font-heading text-sm font-semibold text-foreground">
+              {op.name}
+            </TimelineTitle>
+            <TimelineContent className="mt-3 flex min-w-0 flex-col gap-3">
               {op.request ? (
                 <LogSideBlock side="request" data={op.request} />
               ) : null}
               {op.response ? (
                 <LogSideBlock side="response" data={op.response} />
               ) : null}
-            </div>
-          </div>
-        );
-      })}
+            </TimelineContent>
+          </TimelineItem>
+        ))}
+      </Timeline>
+      {hiddenCount > 0 ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="self-start"
+          onClick={() => setExpanded(true)}
+        >
+          {t("socialPostResults.logsShowMore", { count: hiddenCount })}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/app/app/routes/protected/_project.social-post-results.$socialPostResultId._index/components/result-logs-rail.tsx
+++ b/app/app/routes/protected/_project.social-post-results.$socialPostResultId._index/components/result-logs-rail.tsx
@@ -69,7 +69,7 @@ export function LogRail({ operations }: { operations: LogOperation[] }) {
           type="button"
           variant="outline"
           size="sm"
-          className="self-start"
+          className="self-center"
           onClick={() => setExpanded(true)}
         >
           {t("socialPostResults.logsShowMore", { count: hiddenCount })}

--- a/app/app/ui/timeline.tsx
+++ b/app/app/ui/timeline.tsx
@@ -1,0 +1,273 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { createContext, useCallback, useContext, useState } from "react"
+
+import { cn } from "~/lib/utils"
+
+// Types
+type TimelineContextValue = {
+  activeStep: number
+  setActiveStep: (step: number) => void
+}
+
+// Context
+const TimelineContext = createContext<TimelineContextValue | undefined>(
+  undefined
+)
+
+const useTimeline = () => {
+  const context = useContext(TimelineContext)
+  if (!context) {
+    throw new Error("useTimeline must be used within a Timeline")
+  }
+  return context
+}
+
+// Components
+interface TimelineProps extends useRender.ComponentProps<"div"> {
+  defaultValue?: number
+  onValueChange?: (value: number) => void
+  orientation?: "horizontal" | "vertical"
+  value?: number
+}
+
+function Timeline({
+  defaultValue = 1,
+  value,
+  onValueChange,
+  orientation = "vertical",
+  className,
+  render,
+  children,
+  ...props
+}: TimelineProps) {
+  const [activeStep, setInternalStep] = useState(defaultValue)
+
+  const setActiveStep = useCallback(
+    (step: number) => {
+      if (value === undefined) {
+        setInternalStep(step)
+      }
+      onValueChange?.(step)
+    },
+    [value, onValueChange]
+  )
+
+  const currentStep = value ?? activeStep
+
+  const defaultProps = {
+    className: cn(
+      "group/timeline flex data-[orientation=horizontal]:w-full data-[orientation=horizontal]:flex-row data-[orientation=vertical]:flex-col",
+      className
+    ),
+    "data-orientation": orientation,
+    "data-slot": "timeline",
+    children,
+  }
+
+  return (
+    <TimelineContext.Provider
+      value={{ activeStep: currentStep, setActiveStep }}
+    >
+      {useRender({
+        defaultTagName: "div",
+        render,
+        props: mergeProps<"div">(defaultProps, props),
+      })}
+    </TimelineContext.Provider>
+  )
+}
+
+// TimelineContent
+function TimelineContent({
+  className,
+  render,
+  children,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  const defaultProps = {
+    className: cn("text-muted-foreground text-sm", className),
+    "data-slot": "timeline-content",
+    children,
+  }
+
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: mergeProps<"div">(defaultProps, props),
+  })
+}
+
+// TimelineDate
+type TimelineDateProps = useRender.ComponentProps<"time">
+
+function TimelineDate({
+  className,
+  render,
+  children,
+  ...props
+}: TimelineDateProps) {
+  const defaultProps = {
+    className: cn(
+      "mb-1 block font-medium text-muted-foreground text-xs group-data-[orientation=vertical]/timeline:max-sm:h-4",
+      className
+    ),
+    "data-slot": "timeline-date",
+    children,
+  }
+
+  return useRender({
+    defaultTagName: "time",
+    render,
+    props: mergeProps<"time">(defaultProps, props),
+  })
+}
+
+// TimelineHeader
+function TimelineHeader({
+  className,
+  render,
+  children,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  const defaultProps = {
+    className: cn(className),
+    "data-slot": "timeline-header",
+    children,
+  }
+
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: mergeProps<"div">(defaultProps, props),
+  })
+}
+
+// TimelineIndicator
+type TimelineIndicatorProps = useRender.ComponentProps<"div">
+
+function TimelineIndicator({
+  className,
+  children,
+  render,
+  ...props
+}: TimelineIndicatorProps) {
+  const defaultProps = {
+    "aria-hidden": true,
+    // DASHBOARD SKIN (re-apply after a ReUI merge): upstream sizes the indicator
+    // `size-4`; our status discs are `size-6` (see `~/ui/steps` StepIndicator), so
+    // the item gutter and separator offsets below are retuned to match. Callers
+    // own the fill/glyph via `className` + children; the ring here is the neutral
+    // structural default.
+    className: cn(
+      "group-data-[orientation=horizontal]/timeline:-top-6 group-data-[orientation=horizontal]/timeline:-translate-y-1/2 group-data-[orientation=vertical]/timeline:-left-6 group-data-[orientation=vertical]/timeline:-translate-x-1/2 absolute size-6 rounded-full border-2 border-primary/20 group-data-[orientation=vertical]/timeline:top-0 group-data-[orientation=horizontal]/timeline:left-0 group-data-completed/timeline-item:border-primary",
+      className
+    ),
+    "data-slot": "timeline-indicator",
+    children,
+  }
+
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: mergeProps<"div">(defaultProps, props),
+  })
+}
+
+// TimelineItem
+interface TimelineItemProps extends useRender.ComponentProps<"div"> {
+  step: number
+}
+
+function TimelineItem({
+  step,
+  className,
+  render,
+  children,
+  ...props
+}: TimelineItemProps) {
+  const { activeStep } = useTimeline()
+
+  const defaultProps = {
+    // DASHBOARD SKIN (re-apply after a ReUI merge): gutter widened `ms-8`→`ms-10`
+    // / `mt-8`→`mt-10` for our `size-6` indicator. Upstream's
+    // `has-[+[data-completed]]:…timeline-separator:bg-primary` (status-tinted
+    // connector) is dropped: our connector is neutral and status-independent — the
+    // separator's own `bg-border` below is the single source of truth.
+    className: cn(
+      "group/timeline-item relative flex flex-1 flex-col gap-0.5 group-data-[orientation=vertical]/timeline:ms-10 group-data-[orientation=horizontal]/timeline:mt-10 group-data-[orientation=horizontal]/timeline:not-last:pe-8 group-data-[orientation=vertical]/timeline:not-last:pb-6",
+      className
+    ),
+    "data-completed": step <= activeStep || undefined,
+    "data-slot": "timeline-item",
+    children,
+  }
+
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: mergeProps<"div">(defaultProps, props),
+  })
+}
+
+// TimelineSeparator
+function TimelineSeparator({
+  className,
+  render,
+  children,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  const defaultProps = {
+    "aria-hidden": true,
+    // DASHBOARD SKIN (re-apply after a ReUI merge): two divergences.
+    // 1. Colour: upstream `bg-primary/10` → `bg-border`. Our timeline connector is
+    //    a neutral rail, not a status-progress bar (LogRail has no status).
+    // 2. Offsets retuned for the `size-6` indicator: the start offset
+    //    `translate-*-4.5`→`-7` (1.125rem→1.75rem) and the length subtrahend
+    //    `1rem`→`1.5rem` both track the indicator's height so the line starts just
+    //    below the disc and ends just above the next one.
+    className: cn(
+      "group-data-[orientation=horizontal]/timeline:-top-6 group-data-[orientation=horizontal]/timeline:-translate-y-1/2 group-data-[orientation=vertical]/timeline:-left-6 group-data-[orientation=vertical]/timeline:-translate-x-1/2 absolute self-start bg-border group-last/timeline-item:hidden group-data-[orientation=horizontal]/timeline:h-0.5 group-data-[orientation=vertical]/timeline:h-[calc(100%-1.5rem-0.25rem)] group-data-[orientation=horizontal]/timeline:w-[calc(100%-1.5rem-0.25rem)] group-data-[orientation=vertical]/timeline:w-0.5 group-data-[orientation=horizontal]/timeline:translate-x-7 group-data-[orientation=vertical]/timeline:translate-y-7",
+      className
+    ),
+    "data-slot": "timeline-separator",
+    children,
+  }
+
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: mergeProps<"div">(defaultProps, props),
+  })
+}
+
+// TimelineTitle
+function TimelineTitle({
+  className,
+  render,
+  children,
+  ...props
+}: useRender.ComponentProps<"h3">) {
+  const defaultProps = {
+    className: cn("font-medium text-sm", className),
+    "data-slot": "timeline-title",
+    children,
+  }
+
+  return useRender({
+    defaultTagName: "h3",
+    render,
+    props: mergeProps<"h3">(defaultProps, props),
+  })
+}
+
+export {
+  Timeline,
+  TimelineContent,
+  TimelineDate,
+  TimelineHeader,
+  TimelineIndicator,
+  TimelineItem,
+  TimelineSeparator,
+  TimelineTitle,
+}


### PR DESCRIPTION
Assignee: @calebpanza ([caleb](https://linear.app/day-moon/profiles/caleb))

## Summary

Vendors ReUI's **Timeline** as a shared structural primitive and proves it by migrating **LogRail** (the post-result operations log) onto it. This is the groundwork for [PFM-999](https://linear.app/day-moon/issue/PFM-999) (webhook deliveries as a timeline).

Closes [PFM-1001](https://linear.app/day-moon/issue/PFM-1001-vendor-the-timeline-primitive-and-migrate-lograil-onto-it).

## What changed

- **`app/ui/timeline.tsx`** — installed via `npx shadcn@latest add @reui/timeline`. Relocated from the CLI's default `components/reui/` into `~/ui/` (where the other primitives live, and the only path reachable via the `~` alias).
- **`LogRail`** now renders through `Timeline` / `TimelineItem` / `TimelineIndicator` / `TimelineSeparator` / `TimelineTitle` / `TimelineContent`. All rail geometry (indicator gutter, connector, drop-on-last) is owned by the primitive — **no** `w-px`/`bg-border` connector, **no** `!last` spacing, and **no** fake `status="complete"` at the call site.
- **Client-side truncation** — renders the first 5 operations with a "Show more" that reveals the rest (no network). Fixes the previously unbounded rail. The two consumers keep separate pagination models: LogRail truncates client-side; deliveries (PFM-999) will page server-side. The primitive bakes in neither.

## Reading the installed source (lesson from PFM-978)

The ticket described the registry timeline as "purely structural, no status vocabulary." The **actually installed** file ships an `activeStep` / `data-completed` progress model with primary-tinted indicators and connectors. Worked from the real source: LogRail passes `value={0}` (no active step) and the two documented **`DASHBOARD SKIN`** divergences neutralize the status model —
1. `size-6` discs (matching `~/ui/steps` `StepIndicator`), with separator offsets retuned to match.
2. A neutral, status-independent `bg-border` connector (LogRail has no status), replacing upstream's `bg-primary/10` + the `has-[+[data-completed]]` tint.

## Testing

- `bun run typecheck` ✅ and `bun run lint` ✅ (from `app/`).
- **Rendered verification** (typecheck proves nothing for a presentation swap): rendered `ResultLogs` with the real `spr_UMag3MCSRzU53LZTc8g5P` seed payload and screenshotted before/after — pixel-equivalent (two nodes, one connector, request + response blocks, same order/icon). Also verified truncation collapsed (5 nodes + "Show 2 more") and expanded (all 7, button gone, drop-on-last correct in both).

## Out of scope
- Webhook deliveries (PFM-999, which this blocks).
- Refactoring `~/ui/steps` to share geometry — `steps.tsx` and `launchpad-checklist.tsx` are untouched.

---
> **Tip:** I will respond to comments that @ mention @cyrus-daymoon on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
