### PR TITLE
fix(api): read LinkedIn posted_at from the modern Posts API fields

### DIFF
--- a/api/src/linkedin/linkedin.service.spec.ts
+++ b/api/src/linkedin/linkedin.service.spec.ts
@@ -1,0 +1,43 @@
+import type { ConfigService } from '@nestjs/config';
+import { LinkedInService } from './linkedin.service';
+import type { SupabaseService } from '../supabase/supabase.service';
+
+type ResolvePostedAt = (post: {
+  publishedAt?: unknown;
+  createdAt?: unknown;
+}) => string | undefined;
+
+describe('LinkedInService#resolvePostedAt', () => {
+  const service = new LinkedInService(
+    {} as SupabaseService,
+    { get: () => undefined } as unknown as ConfigService,
+  );
+  const resolvePostedAt = (
+    service as unknown as { resolvePostedAt: ResolvePostedAt }
+  ).resolvePostedAt.bind(service);
+
+  it('prefers publishedAt when present', () => {
+    expect(
+      resolvePostedAt({ publishedAt: 1634790968774, createdAt: 1634790968743 }),
+    ).toBe(new Date(1634790968774).toISOString());
+  });
+
+  it('falls back to createdAt when publishedAt is absent', () => {
+    expect(resolvePostedAt({ createdAt: 1634790968743 })).toBe(
+      new Date(1634790968743).toISOString(),
+    );
+  });
+
+  it('returns undefined when neither field is present', () => {
+    expect(resolvePostedAt({})).toBeUndefined();
+  });
+
+  it('falls back to createdAt when publishedAt is not a number', () => {
+    expect(
+      resolvePostedAt({
+        publishedAt: 'not-a-number',
+        createdAt: 1634790968743,
+      }),
+    ).toBe(new Date(1634790968743).toISOString());
+  });
+});

--- a/api/src/linkedin/linkedin.service.ts
+++ b/api/src/linkedin/linkedin.service.ts
@@ -66,6 +66,20 @@ export class LinkedInService implements SocialPlatformService {
     };
   }
 
+  private resolvePostedAt(post: {
+    publishedAt?: unknown;
+    createdAt?: unknown;
+  }): string | undefined {
+    let epochMs: number | undefined;
+    if (typeof post.publishedAt === 'number') {
+      epochMs = post.publishedAt;
+    } else if (typeof post.createdAt === 'number') {
+      epochMs = post.createdAt;
+    }
+
+    return epochMs === undefined ? undefined : new Date(epochMs).toISOString();
+  }
+
   private getMediaTypeFromUrn(mediaUrn: string): 'image' | 'video' | undefined {
     const urn = mediaUrn.toLowerCase();
     if (urn.includes(':image:')) {
@@ -475,7 +489,6 @@ export class LinkedInService implements SocialPlatformService {
         async (post) => {
           const postUrn: string = post.id || post.urn;
           const content = post.content;
-          const createdObj = post.created;
 
           const metrics = includeMetrics
             ? await this.getPostMetrics(
@@ -522,7 +535,9 @@ export class LinkedInService implements SocialPlatformService {
             account_id: account.id,
             caption: post.commentary || '',
             url: `https://www.linkedin.com/posts/${postUrn.split(':').pop()}`,
-            posted_at: createdObj?.time,
+            posted_at: this.resolvePostedAt(
+              post as { publishedAt?: unknown; createdAt?: unknown },
+            ),
             media,
             metrics,
           };


### PR DESCRIPTION
## Summary

LinkedIn posts returned from the account feeds endpoint were always missing `posted_at`, unlike every other platform. A customer reported this via Crisp chat (PFM-991) and proposed decoding a timestamp out of the LinkedIn post URN's bits as a workaround.

## Changes

- `api/src/linkedin/linkedin.service.ts`: `getAccountPosts()` was mapping `posted_at` from `post.created?.time`, a field shape from LinkedIn's legacy `v2/ugcPosts` API. The code actually calls LinkedIn's modern REST Posts API (`/rest/posts`), which returns top-level `publishedAt`/`createdAt` (Unix ms) instead — so `post.created` was always `undefined`. Added a `resolvePostedAt()` helper that reads `publishedAt` (preferred) falling back to `createdAt`, converting epoch ms to an ISO string. This matches the ISO-string convention already used by every other platform (Facebook/Instagram/Threads/YouTube pass an ISO string through as-is; TikTok normalizes epoch seconds the same way).
- `api/src/linkedin/linkedin.service.spec.ts` (new): unit test for `resolvePostedAt` covering the `publishedAt` preference, `createdAt` fallback, both-absent, and malformed-value cases.

No DB migration, DTO, or dashboard changes needed — the dashboard already parses `posted_at` generically via `new Date(...)`, so LinkedIn posts will start showing a real date with no further changes.

We did not implement the URN bit-decoding workaround the customer suggested — LinkedIn's own API already returns an explicit, documented publish timestamp on every post we fetch, so it's unnecessary and would be a more fragile source of truth.

## Testing

- `cd api && bun run lint` — passes (no new findings; verified the one remaining lint error is a pre-existing, gitignored local Supabase temp file unrelated to this change)
- `cd api && bunx tsc --noEmit` — passes
- `cd api && bun run test -- linkedin.service.spec.ts` — 4/4 new tests pass
- Verified the field names against LinkedIn's official Posts API documentation (Microsoft Learn), confirming `publishedAt`/`createdAt` as top-level epoch-ms fields in both the Finder and Batch Get response shapes this code path uses

Closes PFM-991

🤖 Generated with AI