### PR TITLE
docs(api): document OAuth callback params and reconnect behavior

### DIFF
--- a/api/src/social-provider-connections/docs/create-auth-url.md.ts
+++ b/api/src/social-provider-connections/docs/create-auth-url.md.ts
@@ -2,4 +2,30 @@ export const createAuthUrlDescription = `
 Generates a URL that initiates the authentication flow for a user's social media account. When visited, the user is redirected to the selected social platform's login/authorization page. Upon successful authentication, they are redirected back to your application.
 
 For Quickstart projects using Post for Me system credentials, \`redirect_url_override\` is not accepted. Configure the project redirect URL in the dashboard instead.
+
+## Callback Redirect
+Once the platform authentication completes (successfully or not), the user is redirected to your configured callback URL (the project's redirect URL, or \`redirect_url_override\` if one was provided) with the result appended as query params:
+
+- \`provider\` - the platform that was authenticated
+- \`projectId\` - the project the account was connected to
+- \`isSuccess\` - \`"true"\` or \`"false"\`
+- \`accountIds\` - comma-separated IDs of accounts that connected successfully (may be empty)
+- \`failedAccountIds\` - comma-separated IDs of accounts that failed to connect; only present if at least one account failed
+- \`error\` - present only if there was at least one error. If multiple errors occurred they are joined with \`|\`
+
+Example success redirect:
+\`\`\`
+https://your-app.com/callback?provider=x&projectId=proj_123&isSuccess=true&accountIds=acc_123,acc_456
+\`\`\`
+
+Example failure redirect:
+\`\`\`
+https://your-app.com/callback?provider=x&projectId=proj_123&isSuccess=false&accountIds=&failedAccountIds=acc_789&error=External+Id+already+exists+for+account+acc_789
+\`\`\`
+
+## Reconnecting an Account
+If \`external_id\` is provided and an account resolved during authentication already has a connection for that provider/project:
+
+- If the existing connection's \`external_id\` matches the one you supplied, the connection is updated in place (fresh tokens are stored) and no error is raised.
+- If the existing connection has a **different** \`external_id\` already set, that account fails to connect - no new token is issued for it, it's included in \`failedAccountIds\`, and \`error\` includes \`External Id already exists for account {id}\`. If this happens for every account in the attempt, the overall result is \`isSuccess=false\` and \`error\` also includes \`No valid accounts found\`.
 `;

--- a/api/src/social-provider-connections/dto/create-provider-auth-url.dto.ts
+++ b/api/src/social-provider-connections/dto/create-provider-auth-url.dto.ts
@@ -207,7 +207,8 @@ export class CreateSocialAccountProviderAuthUrlDto {
   platform_data?: AuthUrlProviderData | null;
 
   @ApiProperty({
-    description: 'Your unique identifier for the social account',
+    description:
+      'Your unique identifier for the social account. If this account already has a connection with a different external_id set, the reconnect attempt will fail for that account - see "Reconnecting an Account" above.',
     required: false,
   })
   external_id?: string;


### PR DESCRIPTION
## Summary

An external integrator (PFM-996) flagged two real gaps in the public API docs at `api.postforme.dev/docs`: the OAuth callback redirect's query-param contract was undocumented, and the `external_id` "reconnect" behavior was undocumented and contradicted guidance previously given (including by the docs AI assistant). This PR extends the existing Swagger description for `POST /social-accounts/auth-url` to cover both, based on the actual behavior verified in the dashboard's callback loaders and connection-upsert logic.

## Changes

- `api/src/social-provider-connections/docs/create-auth-url.md.ts` — added two sections to the endpoint description:
  - **Callback Redirect**: documents the `provider`, `projectId`, `isSuccess`, `accountIds`, `failedAccountIds`, and `error` query params appended to the developer's callback URL after OAuth completes, with success/failure examples.
  - **Reconnecting an Account**: clarifies that reconnecting with the same `external_id` updates the connection in place with no error, but a conflicting `external_id` on an existing connection causes that account to fail silently (excluded from the batch, `error` includes `External Id already exists for account {id}`, can cascade to `No valid accounts found` / `isSuccess=false` if it's the only account in the attempt).
- `api/src/social-provider-connections/dto/create-provider-auth-url.dto.ts` — extended the `external_id` field's Swagger description to point at the new reconnect-conflict behavior.

No code behavior changes — docs only.

## Testing

- Started the API dev server (`bun run start:dev`) and fetched `/swagger-json`, confirming the new sections render correctly in the `POST /social-accounts/auth-url` operation description and the `external_id` field description.
- `bun run lint` in `api/` — passes aside from one pre-existing, unrelated parsing error on a generated Supabase temp file (`supabase/.temp/...`), not touched by this change.

Closes PFM-996

🤖 Generated with AI