### PR TITLE
fix(trigger): stop marking TikTok drafts successful while still processing

### DIFF
--- a/api/src/social-post-results/dto/post-results.dto.ts
+++ b/api/src/social-post-results/dto/post-results.dto.ts
@@ -14,6 +14,11 @@ export class SocialPostResultDto {
   @ApiProperty({ description: 'Indicates if the post was successful' })
   success: boolean;
 
+  @ApiProperty({
+    description: 'Whether the post is still being processed by the platform',
+  })
+  is_processing: boolean;
+
   @ApiProperty({ description: 'Error message if the post failed' })
   error: string | null;
 

--- a/api/src/social-post-results/social-post-results.service.ts
+++ b/api/src/social-post-results/social-post-results.service.ts
@@ -20,6 +20,7 @@ export class PostResultsService {
   ): Promise<{
     data: {
       success: boolean;
+      is_processing: boolean;
       provider_post_id?: string;
       provider_post_url?: string;
       id: string;
@@ -34,7 +35,7 @@ export class PostResultsService {
       await this.supabaseService.supabaseClient
         .from('social_post_results')
         .select(
-          'id, success, provider_post_id, provider_post_url, details, post_id, provider_connection_id, error_message, social_provider_connections(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
+          'id, success, is_processing, provider_post_id, provider_post_url, details, post_id, provider_connection_id, error_message, social_provider_connections(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
         )
         .eq('id', id)
         .eq('social_provider_connections.project_id', projectId)
@@ -47,6 +48,7 @@ export class PostResultsService {
     return {
       data: {
         success: postResult.success,
+        is_processing: postResult.is_processing,
         provider_post_id: postResult?.provider_post_id || undefined,
         provider_post_url: postResult?.provider_post_url || undefined,
         id: postResult?.id,
@@ -125,7 +127,7 @@ export class PostResultsService {
     const query = this.supabaseService.supabaseClient
       .from('social_post_results')
       .select(
-        'id, provider_connection_id, post_id, success, error_message, details, provider_post_id, provider_post_url, created_at, social_provider_connections!inner(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
+        'id, provider_connection_id, post_id, success, is_processing, error_message, details, provider_post_id, provider_post_url, created_at, social_provider_connections!inner(provider, project_id), social_post_result_post_media(social_post_media(url, thumbnail_url, thumbnail_timestamp_ms, tags, skip_processing))',
       )
       .eq('social_provider_connections.project_id', projectId)
       .in(
@@ -197,6 +199,7 @@ export class PostResultsService {
         social_account_id: raw.provider_connection_id,
         post_id: raw.post_id,
         success: raw.success,
+        is_processing: raw.is_processing,
         error: raw.error_message,
         details: raw.details,
         platform_data,
@@ -242,6 +245,7 @@ export class PostResultsService {
       social_account_id: postResults.data.provider_connection_id,
       post_id: postResults.data.post_id,
       success: postResults.data.success,
+      is_processing: postResults.data.is_processing,
       error: postResults.data.error_message || null,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       details: postResults.data.details,

--- a/api/src/webhooks/dto/create-webhook.dto.ts
+++ b/api/src/webhooks/dto/create-webhook.dto.ts
@@ -8,6 +8,7 @@ export const eventValues: EventType[] = [
   'social.post.updated',
   'social.post.deleted',
   'social.post.result.created',
+  'social.post.result.updated',
   'social.account.created',
   'social.account.updated',
 ];

--- a/api/supabase/migrations/20260813120000_add_reconciliation_to_social_post_results.sql
+++ b/api/supabase/migrations/20260813120000_add_reconciliation_to_social_post_results.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.social_post_results
+    ADD COLUMN is_processing boolean NOT NULL DEFAULT false,
+    ADD COLUMN reconciliation_attempts integer NOT NULL DEFAULT 0,
+    ADD COLUMN reconciliation_deadline_at timestamptz NULL;
+
+CREATE INDEX IF NOT EXISTS idx_social_post_results_is_processing
+    ON public.social_post_results(is_processing)
+    WHERE is_processing = true;

--- a/api/supabase/migrations/20260813120100_add_social_post_result_updated_webhook_event.sql
+++ b/api/supabase/migrations/20260813120100_add_social_post_result_updated_webhook_event.sql
@@ -1,0 +1,2 @@
+ALTER TYPE webhook_event_type
+    ADD VALUE IF NOT EXISTS 'social.post.result.updated';

--- a/api/supabase/supabase.types.ts
+++ b/api/supabase/supabase.types.ts
@@ -521,10 +521,13 @@ export type Database = {
           details: Json | null
           error_message: string | null
           id: string
+          is_processing: boolean
           post_id: string
           provider_connection_id: string
           provider_post_id: string | null
           provider_post_url: string | null
+          reconciliation_attempts: number
+          reconciliation_deadline_at: string | null
           success: boolean
           updated_at: string
         }
@@ -533,10 +536,13 @@ export type Database = {
           details?: Json | null
           error_message?: string | null
           id?: string
+          is_processing?: boolean
           post_id: string
           provider_connection_id: string
           provider_post_id?: string | null
           provider_post_url?: string | null
+          reconciliation_attempts?: number
+          reconciliation_deadline_at?: string | null
           success: boolean
           updated_at?: string
         }
@@ -545,10 +551,13 @@ export type Database = {
           details?: Json | null
           error_message?: string | null
           id?: string
+          is_processing?: boolean
           post_id?: string
           provider_connection_id?: string
           provider_post_id?: string | null
           provider_post_url?: string | null
+          reconciliation_attempts?: number
+          reconciliation_deadline_at?: string | null
           success?: boolean
           updated_at?: string
         }
@@ -1325,6 +1334,7 @@ export type Database = {
         | "social.post.result.created"
         | "social.account.created"
         | "social.account.updated"
+        | "social.post.result.updated"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1490,6 +1500,7 @@ export const Constants = {
         "social.post.result.created",
         "social.account.created",
         "social.account.updated",
+        "social.post.result.updated",
       ],
     },
   },

--- a/dashboard/app/lib/.server/database.types.ts
+++ b/dashboard/app/lib/.server/database.types.ts
@@ -278,10 +278,13 @@ export type Database = {
           details: Json | null
           error_message: string | null
           id: string
+          is_processing: boolean
           post_id: string
           provider_connection_id: string
           provider_post_id: string | null
           provider_post_url: string | null
+          reconciliation_attempts: number
+          reconciliation_deadline_at: string | null
           success: boolean
           updated_at: string
         }
@@ -290,10 +293,13 @@ export type Database = {
           details?: Json | null
           error_message?: string | null
           id?: string
+          is_processing?: boolean
           post_id: string
           provider_connection_id: string
           provider_post_id?: string | null
           provider_post_url?: string | null
+          reconciliation_attempts?: number
+          reconciliation_deadline_at?: string | null
           success: boolean
           updated_at?: string
         }
@@ -302,10 +308,13 @@ export type Database = {
           details?: Json | null
           error_message?: string | null
           id?: string
+          is_processing?: boolean
           post_id?: string
           provider_connection_id?: string
           provider_post_id?: string | null
           provider_post_url?: string | null
+          reconciliation_attempts?: number
+          reconciliation_deadline_at?: string | null
           success?: boolean
           updated_at?: string
         }
@@ -1082,6 +1091,7 @@ export type Database = {
         | "social.post.result.created"
         | "social.account.created"
         | "social.account.updated"
+        | "social.post.result.updated"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1244,6 +1254,7 @@ export const Constants = {
         "social.post.result.created",
         "social.account.created",
         "social.account.updated",
+        "social.post.result.updated",
       ],
     },
   },

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts.$postId._index/_post-content-processed.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts.$postId._index/_post-content-processed.tsx
@@ -35,7 +35,7 @@ export function PostContentProcessed() {
   const { results } = useLoaderData<LoaderData>();
 
   const succeeded = results.filter((r) => r.success).length;
-  const failed = results.length - succeeded;
+  const failed = results.filter((r) => !r.success && !r.is_processing).length;
 
   return (
     <div className="space-y-3">
@@ -88,11 +88,12 @@ function ResultRow({ result }: { result: PostResult }) {
     result.platform_data?.username ??
     result.social_account_id;
 
-  const showError = !result.success && Boolean(result.error);
+  const showError = !result.success && !result.is_processing && Boolean(result.error);
+  const showProcessing = !result.success && result.is_processing;
 
   return (
     <>
-      <TableRow className={cn(showError && "border-0")}>
+      <TableRow className={cn((showError || showProcessing) && "border-0")}>
         <TableCell>
           <div className="flex min-w-0 flex-row items-center gap-2">
             <div className="relative shrink-0">
@@ -122,10 +123,14 @@ function ResultRow({ result }: { result: PostResult }) {
             title={!result.success && result.error ? result.error : undefined}
             className={cn(
               "text-sm",
-              result.success ? "text-affirmative" : "text-destructive",
+              result.success
+                ? "text-affirmative"
+                : showProcessing
+                  ? "text-muted-foreground"
+                  : "text-destructive",
             )}
           >
-            {result.success ? "Posted" : "Failed"}
+            {result.success ? "Posted" : showProcessing ? "Processing" : "Failed"}
           </span>
         </TableCell>
 
@@ -150,11 +155,26 @@ function ResultRow({ result }: { result: PostResult }) {
         </TableCell>
       </TableRow>
 
-      {showError ? (
-        <TableRow className="border-destructive/8 bg-destructive/5 hover:bg-destructive/5">
+      {showError || showProcessing ? (
+        <TableRow
+          className={cn(
+            showError && "border-destructive/8 bg-destructive/5 hover:bg-destructive/5",
+            showProcessing && "border-muted bg-muted/40 hover:bg-muted/40",
+          )}
+        >
           <TableCell colSpan={7} className="py-2">
-            <div className="flex flex-row items-start gap-2 text-sm text-destructive pl-2">
-              <ArrowCornerDownRightIcon className="size-4 shrink-0 text-destructive" />
+            <div
+              className={cn(
+                "flex flex-row items-start gap-2 pl-2 text-sm",
+                showError ? "text-destructive" : "text-muted-foreground",
+              )}
+            >
+              <ArrowCornerDownRightIcon
+                className={cn(
+                  "size-4 shrink-0",
+                  showError ? "text-destructive" : "text-muted-foreground",
+                )}
+              />
               <span className="wrap-break-word">{result.error}</span>
             </div>
           </TableCell>
@@ -226,6 +246,9 @@ function RawDataDialog({ result }: { result: PostResult }) {
   const provider = result.account?.provider?.split("_")[0] ?? "";
   const handle = result.account?.username ?? result.social_account_id;
 
+  const showError = !result.success && !result.is_processing && Boolean(result.error);
+  const showProcessing = !result.success && result.is_processing;
+
   const json =
     result.details != null
       ? JSON.stringify(result.details, null, 2)
@@ -256,16 +279,27 @@ function RawDataDialog({ result }: { result: PostResult }) {
             <span
               className={cn(
                 "text-xs font-normal",
-                result.success ? "text-affirmative" : "text-destructive",
+                result.success
+                  ? "text-affirmative"
+                  : showProcessing
+                    ? "text-muted-foreground"
+                    : "text-destructive",
               )}
             >
-              {result.success ? "Posted" : "Failed"}
+              {result.success ? "Posted" : showProcessing ? "Processing" : "Failed"}
             </span>
           </DialogTitle>
         </DialogHeader>
 
-        {!result.success && result.error ? (
-          <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+        {showError || showProcessing ? (
+          <div
+            className={cn(
+              "rounded-md border px-3 py-2 text-sm",
+              showError
+                ? "border-destructive/30 bg-destructive/5 text-destructive"
+                : "border-muted bg-muted/40 text-muted-foreground",
+            )}
+          >
             {result.error}
           </div>
         ) : null}

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts.$postId._index/types.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts.$postId._index/types.ts
@@ -26,6 +26,7 @@ export type PostResult = {
   post_id: string;
   social_account_id: string;
   success: boolean;
+  is_processing: boolean;
   error: string | null;
   /** Raw provider request/response logs + platform-specific metadata. */
   details: unknown;

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_columns.tsx
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_columns.tsx
@@ -160,17 +160,21 @@ export const columns: ColumnDef<PostWithConnections>[] = [
         <div className="flex flex-wrap gap-1">
           {uniqueProviders.map((provider) => {
             const status = providerStatus?.[provider];
+            const StatusIcon =
+              status === "success"
+                ? CheckmarkSmallIcon
+                : status === "processing"
+                  ? LoadingCircleIcon
+                  : status === "failed"
+                    ? TriangleExclamationIcon
+                    : null;
 
             return (
               <Badge
                 key={provider}
                 className={`${providerColors[provider as keyof typeof providerColors] || "bg-gray-500"} text-white text-xs gap-1`}
               >
-                {status === undefined ? null : status ? (
-                  <CheckmarkSmallIcon className="size-3" />
-                ) : (
-                  <TriangleExclamationIcon className="size-3" />
-                )}
+                {StatusIcon ? <StatusIcon className="size-3" /> : null}
                 {provider}
               </Badge>
             );

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_types.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/_types.ts
@@ -35,10 +35,11 @@ export interface PostWithConnections extends Post {
   media: PostMedia[];
   /**
    * Per-platform result status derived from social_post_results.
-   * `true` = every account on that platform succeeded, `false` = at least one
-   * failed (failure is prioritized). Absent when the post has no results yet.
+   * `"failed"` if any account on that platform failed, else `"processing"` if
+   * any account is still processing, else `"success"`. Absent when the post
+   * has no results yet.
    */
-  provider_status?: Record<string, boolean>;
+  provider_status?: Record<string, "success" | "failed" | "processing">;
 }
 
 export interface LoaderData {

--- a/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/route.loader.ts
+++ b/dashboard/app/routes/_protected.$teamId.$projectId.posts._index/route.loader.ts
@@ -100,23 +100,28 @@ export const loader = withSupabase(
       const posts = postsData.data || [];
 
       // Fetch per-account results for the page in a single query and fold them
-      // into a per-platform pass/fail status (failure is prioritized).
+      // into a per-platform status (failed > processing > success priority).
       const postIds = posts.map((p) => p.id);
       if (postIds.length > 0) {
         const { data: resultRows } = await supabase
           .from("social_post_results")
-          .select("post_id, provider_connection_id, success")
+          .select("post_id, provider_connection_id, success, is_processing")
           .in("post_id", postIds);
 
         const resultsByPost = new Map<
           string,
-          { provider_connection_id: string; success: boolean }[]
+          {
+            provider_connection_id: string;
+            success: boolean;
+            is_processing: boolean;
+          }[]
         >();
         for (const r of resultRows ?? []) {
           const arr = resultsByPost.get(r.post_id) ?? [];
           arr.push({
             provider_connection_id: r.provider_connection_id,
             success: r.success,
+            is_processing: r.is_processing,
           });
           resultsByPost.set(r.post_id, arr);
         }
@@ -129,12 +134,23 @@ export const loader = withSupabase(
             (post.social_accounts ?? []).map((a) => [a.id, a.platform]),
           );
 
-          const status: Record<string, boolean> = {};
+          const status: Record<string, "success" | "failed" | "processing"> =
+            {};
           for (const r of rows) {
             const platform = accountPlatform.get(r.provider_connection_id);
             if (!platform) continue;
-            // true && success folds any failure down to false for the platform.
-            status[platform] = (status[platform] ?? true) && r.success;
+            if (status[platform] === "failed") continue;
+
+            const next = r.is_processing
+              ? "processing"
+              : r.success
+                ? "success"
+                : "failed";
+            if (next === "failed" || status[platform] === undefined) {
+              status[platform] = next;
+            } else if (next === "processing" && status[platform] === "success") {
+              status[platform] = next;
+            }
           }
           post.provider_status = status;
         }

--- a/trigger/post-to-platform.ts
+++ b/trigger/post-to-platform.ts
@@ -1,24 +1,13 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@supabase/supabase-js";
 import { idempotencyKeys, logger, task, tags, tasks } from "@trigger.dev/sdk";
-import { PostClient } from "./posting/post-client";
-import { TwitterPostClient } from "./posting/platforms/twitter-post-client";
-import { InstagramPostClient } from "./posting/platforms/instagram-post-client";
-import { FacebookPostClient } from "./posting/platforms/facebook-post-client";
-import { LinkedInPostClient } from "./posting/platforms/linkedin-post-client";
-import { TikTokPostClient } from "./posting/platforms/tiktok-post-client";
-import { BlueskyPostClient } from "./posting/platforms/bluesky-post-client";
-import { ThreadsPostClient } from "./posting/platforms/threads-post-client";
-import { PinterestPostClient } from "./posting/platforms/pinterest-post-client";
-import { YouTubePostClient } from "./posting/platforms/youtube-post-client";
-import { TikTokBusinessPostClient } from "./posting/platforms/tiktok_business-post-client";
+import { createPostClient } from "./posting/create-post-client";
+import { handleTokenRefresh, shouldRefreshToken } from "./posting/token-refresh";
 
 import {
   IndividualPostData,
-  PlatformAppCredentials,
   PostResult,
   SocialAccount,
 } from "./posting/post.types";
-import { differenceInDays } from "date-fns";
 import Stripe from "stripe";
 import { Database } from "./supabase.types";
 
@@ -29,108 +18,6 @@ const supabaseClient = createClient<Database>(
   process.env.SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
-
-const createPostClient = ({
-  supabaseClient,
-  platformName,
-  appCredentials,
-}: {
-  supabaseClient: SupabaseClient;
-  platformName: string;
-  appCredentials: PlatformAppCredentials;
-}): PostClient => {
-  switch (platformName) {
-    case "x":
-      return new TwitterPostClient(supabaseClient, appCredentials);
-    case "instagram":
-      return new InstagramPostClient(supabaseClient, appCredentials);
-    case "facebook":
-      return new FacebookPostClient(supabaseClient, appCredentials);
-    case "linkedin":
-      return new LinkedInPostClient(supabaseClient, appCredentials);
-    case "tiktok":
-      return new TikTokPostClient(supabaseClient, appCredentials);
-    case "bluesky":
-      return new BlueskyPostClient(supabaseClient, appCredentials);
-    case "threads":
-      return new ThreadsPostClient(supabaseClient, appCredentials);
-    case "pinterest":
-      return new PinterestPostClient(supabaseClient, appCredentials);
-    case "youtube":
-      return new YouTubePostClient(supabaseClient, appCredentials);
-    case "tiktok_business":
-      return new TikTokBusinessPostClient(supabaseClient, appCredentials);
-    default:
-      throw Error("Invalid Platform");
-  }
-};
-
-const platformsToAlwaysRefresh = ["youtube", "bluesky"];
-
-const handleTokenRefresh = async ({
-  postClient,
-  account,
-}: {
-  postClient: PostClient;
-  account: SocialAccount;
-}): Promise<{ success: boolean; error?: string }> => {
-  try {
-    const { access_token, expires_at, refresh_token } =
-      await postClient.refreshAccessToken(account);
-
-    if (!access_token) {
-      console.error(
-        `Failed to refresh ${account.provider} token for account ${account.id}`,
-      );
-
-      return {
-        success: false,
-        error: `Failed to refresh ${account.provider} token for account ${account.id}`,
-      };
-    }
-
-    const updateData: {
-      access_token?: string;
-      access_token_expires_at?: string;
-      refresh_token?: string;
-    } = {
-      access_token,
-      access_token_expires_at: expires_at,
-    };
-
-    account.access_token = access_token;
-    account.access_token_expires_at = new Date(expires_at);
-
-    if (refresh_token) {
-      updateData.refresh_token = refresh_token;
-      account.refresh_token = refresh_token;
-    }
-
-    const { error } = await supabaseClient
-      .from("social_provider_connections")
-      .update(updateData)
-      .eq("id", account.id);
-
-    if (error) {
-      console.error(error);
-
-      return {
-        success: false,
-        error: error.message,
-      };
-    }
-  } catch (refreshError) {
-    console.error(refreshError);
-    return {
-      success: false,
-      error: refreshError.message,
-    };
-  }
-
-  return {
-    success: true,
-  };
-};
 
 export const postToPlatform = task({
   id: "post-to-platform",
@@ -168,18 +55,13 @@ export const postToPlatform = task({
         appCredentials,
       });
 
-      if (
-        platformsToAlwaysRefresh.includes(account.provider) ||
-        differenceInDays(
-          account.access_token_expires_at || new Date(),
-          new Date(),
-        ) <= 7
-      ) {
+      if (shouldRefreshToken(account as SocialAccount)) {
         logger.info("Refreshing Token", {
           platform: account.provider,
           account,
         });
         const refreshed = await handleTokenRefresh({
+          supabaseClient,
           postClient,
           account: account as SocialAccount,
         });
@@ -252,7 +134,12 @@ export const postToPlatform = task({
     const { data: insertedPostResult, error: insertResultError } =
       await supabaseClient
         .from("social_post_results")
-        .insert(postResult)
+        .insert({
+          ...postResult,
+          reconciliation_deadline_at: postResult.is_processing
+            ? new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+            : null,
+        })
         .select()
         .single();
 
@@ -301,6 +188,7 @@ export const postToPlatform = task({
           post_id: insertedPostResult.post_id,
           social_account_id: insertedPostResult.provider_connection_id,
           success: insertedPostResult.success,
+          is_processing: insertedPostResult.is_processing,
         },
       });
 

--- a/trigger/posting/create-post-client.ts
+++ b/trigger/posting/create-post-client.ts
@@ -1,0 +1,48 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { PostClient } from "./post-client";
+import { TwitterPostClient } from "./platforms/twitter-post-client";
+import { InstagramPostClient } from "./platforms/instagram-post-client";
+import { FacebookPostClient } from "./platforms/facebook-post-client";
+import { LinkedInPostClient } from "./platforms/linkedin-post-client";
+import { TikTokPostClient } from "./platforms/tiktok-post-client";
+import { BlueskyPostClient } from "./platforms/bluesky-post-client";
+import { ThreadsPostClient } from "./platforms/threads-post-client";
+import { PinterestPostClient } from "./platforms/pinterest-post-client";
+import { YouTubePostClient } from "./platforms/youtube-post-client";
+import { TikTokBusinessPostClient } from "./platforms/tiktok_business-post-client";
+import { PlatformAppCredentials } from "./post.types";
+
+export const createPostClient = ({
+  supabaseClient,
+  platformName,
+  appCredentials,
+}: {
+  supabaseClient: SupabaseClient;
+  platformName: string;
+  appCredentials: PlatformAppCredentials;
+}): PostClient => {
+  switch (platformName) {
+    case "x":
+      return new TwitterPostClient(supabaseClient, appCredentials);
+    case "instagram":
+      return new InstagramPostClient(supabaseClient, appCredentials);
+    case "facebook":
+      return new FacebookPostClient(supabaseClient, appCredentials);
+    case "linkedin":
+      return new LinkedInPostClient(supabaseClient, appCredentials);
+    case "tiktok":
+      return new TikTokPostClient(supabaseClient, appCredentials);
+    case "bluesky":
+      return new BlueskyPostClient(supabaseClient, appCredentials);
+    case "threads":
+      return new ThreadsPostClient(supabaseClient, appCredentials);
+    case "pinterest":
+      return new PinterestPostClient(supabaseClient, appCredentials);
+    case "youtube":
+      return new YouTubePostClient(supabaseClient, appCredentials);
+    case "tiktok_business":
+      return new TikTokBusinessPostClient(supabaseClient, appCredentials);
+    default:
+      throw Error("Invalid Platform");
+  }
+};

--- a/trigger/posting/platforms/tiktok-post-client.ts
+++ b/trigger/posting/platforms/tiktok-post-client.ts
@@ -12,14 +12,11 @@ import {
   SocialAccount,
   TiktokConfiguration,
 } from "../post.types";
+import { TIKTOK_PROCESSING_STATUSES } from "./tiktok-shared";
 
 export class TikTokPostClient extends PostClient {
   #tokenUrl = "https://open.tiktokapis.com/v2/oauth/token/";
-  #processingStatuses = [
-    "PROCESSING",
-    "PROCESSING_DOWNLOAD",
-    "PROCESSING_UPLOAD",
-  ];
+  #processingStatuses = TIKTOK_PROCESSING_STATUSES;
   #processedStatuses = [
     "PUBLISH_COMPLETE",
     "PUBLISH_SUCCESS",

--- a/trigger/posting/platforms/tiktok-post-client.ts
+++ b/trigger/posting/platforms/tiktok-post-client.ts
@@ -145,12 +145,13 @@ export class TikTokPostClient extends PostClient {
 
       if (platformConfig?.is_draft) {
         const { status } = await this.#getPublishStatus({ publishId, account });
+        const isProcessing = this.#processingStatuses.includes(status);
 
         return {
-          success: true,
+          success: !isProcessing,
           post_id: postId,
           provider_connection_id: account.id,
-          error_message: this.#processingStatuses.includes(status)
+          error_message: isProcessing
             ? "TikTok is still processing this draft, post will appear in your inbox once finished processing."
             : undefined,
           details: {

--- a/trigger/posting/platforms/tiktok-post-client.ts
+++ b/trigger/posting/platforms/tiktok-post-client.ts
@@ -149,15 +149,17 @@ export class TikTokPostClient extends PostClient {
 
         return {
           success: !isProcessing,
+          is_processing: isProcessing,
           post_id: postId,
           provider_connection_id: account.id,
           error_message: isProcessing
             ? "TikTok is still processing this draft, post will appear in your inbox once finished processing."
             : undefined,
           details: {
-            status: "Saved as draft",
-            message:
-              "Content saved as draft in TikTok. Check your TikTok inbox notifications to continue editing and publish.",
+            status: isProcessing ? "Processing" : "Saved as draft",
+            message: isProcessing
+              ? "TikTok is still processing this draft. It will be automatically reconciled once TikTok finishes."
+              : "Content saved as draft in TikTok. Check your TikTok inbox notifications to continue editing and publish.",
             addedMedia: this.#addedMedia,
             requests: this.#requests,
             responses: this.#responses,
@@ -228,6 +230,28 @@ export class TikTokPostClient extends PostClient {
     }
   }
 
+  /**
+   * Single, cheap re-check of a draft's publish status for reconciliation.
+   * Unlike #getPublishStatus's internal poll loop (used during post()), this
+   * performs exactly one status check and never waits/retries internally —
+   * the caller (a scheduled reconciliation task) provides the retry cadence.
+   */
+  async checkDraftPublishStatus({
+    publishId,
+    account,
+  }: {
+    publishId: string;
+    account: SocialAccount;
+  }): Promise<{ status: string; failReason?: string }> {
+    const { status, failReason } = await this.#getPublishStatus({
+      publishId,
+      account,
+      maxAttempts: 1,
+    });
+
+    return { status, failReason };
+  }
+
   async #getCreatorInfo(account: SocialAccount) {
     this.#requests.push({
       creatorRequest:
@@ -254,10 +278,12 @@ export class TikTokPostClient extends PostClient {
     publishId,
     account,
     waitForPublicPostId = false,
+    maxAttempts = 15,
   }: {
     publishId: string;
     account: SocialAccount;
     waitForPublicPostId?: boolean;
+    maxAttempts?: number;
   }) {
     let status = "PROCESSING";
     let failReason;
@@ -265,7 +291,6 @@ export class TikTokPostClient extends PostClient {
     let attempts = 0;
     let publicPostIdAttempts = 0;
     const initialDelayMs = 5000;
-    const maxAttempts = 15;
     const maxPublicPostIdAttempts = 3;
 
     while (

--- a/trigger/posting/platforms/tiktok-shared.ts
+++ b/trigger/posting/platforms/tiktok-shared.ts
@@ -1,0 +1,5 @@
+export const TIKTOK_PROCESSING_STATUSES: readonly string[] = [
+  "PROCESSING",
+  "PROCESSING_DOWNLOAD",
+  "PROCESSING_UPLOAD",
+];

--- a/trigger/posting/platforms/tiktok_business-post-client.ts
+++ b/trigger/posting/platforms/tiktok_business-post-client.ts
@@ -11,15 +11,12 @@ import {
   SocialAccount,
   TiktokConfiguration,
 } from "../post.types";
+import { TIKTOK_PROCESSING_STATUSES } from "./tiktok-shared";
 
 export class TikTokBusinessPostClient extends PostClient {
   #tokenUrl =
     "https://business-api.tiktok.com/open_api/v1.3/tt_user/oauth2/refresh_token/";
-  #processingStatuses = [
-    "PROCESSING",
-    "PROCESSING_DOWNLOAD",
-    "PROCESSING_UPLOAD",
-  ];
+  #processingStatuses = TIKTOK_PROCESSING_STATUSES;
   #processedStatuses = [
     "PUBLISH_COMPLETE",
     "PUBLISH_SUCCESS",

--- a/trigger/posting/platforms/tiktok_business-post-client.ts
+++ b/trigger/posting/platforms/tiktok_business-post-client.ts
@@ -170,15 +170,17 @@ export class TikTokBusinessPostClient extends PostClient {
 
         return {
           success: !isProcessing,
+          is_processing: isProcessing,
           post_id: postId,
           provider_connection_id: account.id,
           error_message: isProcessing
             ? "TikTok is still processing this draft, post will appear in your inbox once finished processing."
             : undefined,
           details: {
-            status: "Saved as draft",
-            message:
-              "Content saved as draft in TikTok. Check your TikTok inbox notifications to continue editing and publish.",
+            status: isProcessing ? "Processing" : "Saved as draft",
+            message: isProcessing
+              ? "TikTok is still processing this draft. It will be automatically reconciled once TikTok finishes."
+              : "Content saved as draft in TikTok. Check your TikTok inbox notifications to continue editing and publish.",
             addedMedia: this.#addedMedia,
             requests: this.#requests,
             responses: this.#responses,
@@ -248,6 +250,28 @@ export class TikTokBusinessPostClient extends PostClient {
     }
   }
 
+  /**
+   * Single, cheap re-check of a draft's publish status for reconciliation.
+   * Unlike #getPublishStatus's internal poll loop (used during post()), this
+   * performs exactly one status check and never waits/retries internally —
+   * the caller (a scheduled reconciliation task) provides the retry cadence.
+   */
+  async checkDraftPublishStatus({
+    publishId,
+    account,
+  }: {
+    publishId: string;
+    account: SocialAccount;
+  }): Promise<{ status: string; failReason?: string }> {
+    const { status, failReason } = await this.#getPublishStatus({
+      publishId,
+      account,
+      maxAttempts: 1,
+    });
+
+    return { status, failReason };
+  }
+
   async #getCreatorInfo(account: SocialAccount) {
     const creatorInfoUrl =
       "https://business-api.tiktok.com/open_api/v1.3/business/get/";
@@ -291,10 +315,12 @@ export class TikTokBusinessPostClient extends PostClient {
     publishId,
     account,
     waitForPublicPostId = false,
+    maxAttempts = 15,
   }: {
     publishId: string;
     account: SocialAccount;
     waitForPublicPostId?: boolean;
+    maxAttempts?: number;
   }) {
     let status = "PROCESSING";
     let failReason;
@@ -302,7 +328,6 @@ export class TikTokBusinessPostClient extends PostClient {
     let attempts = 0;
     let publicPostIdAttempts = 0;
     const initialDelayMs = 5000;
-    const maxAttempts = 15;
     const maxPublicPostIdAttempts = 3;
 
     const statusUrl =

--- a/trigger/posting/platforms/tiktok_business-post-client.ts
+++ b/trigger/posting/platforms/tiktok_business-post-client.ts
@@ -166,12 +166,13 @@ export class TikTokBusinessPostClient extends PostClient {
 
       if (platformConfig?.is_draft) {
         const { status } = await this.#getPublishStatus({ publishId, account });
+        const isProcessing = this.#processingStatuses.includes(status);
 
         return {
-          success: true,
+          success: !isProcessing,
           post_id: postId,
           provider_connection_id: account.id,
-          error_message: this.#processingStatuses.includes(status)
+          error_message: isProcessing
             ? "TikTok is still processing this draft, post will appear in your inbox once finished processing."
             : undefined,
           details: {

--- a/trigger/posting/post.types.ts
+++ b/trigger/posting/post.types.ts
@@ -6,6 +6,7 @@ export interface PostResult {
   provider_post_url?: string;
   provider_post_id?: string;
   details?: any;
+  is_processing?: boolean;
 }
 
 export interface UserTag {

--- a/trigger/posting/token-refresh.ts
+++ b/trigger/posting/token-refresh.ts
@@ -1,0 +1,70 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { logger } from "@trigger.dev/sdk";
+import { differenceInDays } from "date-fns";
+import { PostClient } from "./post-client";
+import { SocialAccount } from "./post.types";
+
+const platformsToAlwaysRefresh = ["youtube", "bluesky"];
+
+export const shouldRefreshToken = (account: SocialAccount): boolean =>
+  platformsToAlwaysRefresh.includes(account.provider) ||
+  differenceInDays(
+    account.access_token_expires_at || new Date(),
+    new Date(),
+  ) <= 7;
+
+export const handleTokenRefresh = async ({
+  supabaseClient,
+  postClient,
+  account,
+}: {
+  supabaseClient: SupabaseClient;
+  postClient: PostClient;
+  account: SocialAccount;
+}): Promise<{ success: boolean; error?: string }> => {
+  try {
+    const { access_token, expires_at, refresh_token } =
+      await postClient.refreshAccessToken(account);
+
+    if (!access_token) {
+      const error = `Failed to refresh ${account.provider} token for account ${account.id}`;
+      logger.error(error);
+
+      return { success: false, error };
+    }
+
+    const updateData: {
+      access_token?: string;
+      access_token_expires_at?: string;
+      refresh_token?: string;
+    } = {
+      access_token,
+      access_token_expires_at: expires_at,
+    };
+
+    account.access_token = access_token;
+    account.access_token_expires_at = new Date(expires_at);
+
+    if (refresh_token) {
+      updateData.refresh_token = refresh_token;
+      account.refresh_token = refresh_token;
+    }
+
+    const { error } = await supabaseClient
+      .from("social_provider_connections")
+      .update(updateData)
+      .eq("id", account.id);
+
+    if (error) {
+      logger.error("Failed to persist refreshed token", { error });
+
+      return { success: false, error: error.message };
+    }
+  } catch (refreshError) {
+    logger.error("Token refresh error", { error: refreshError });
+
+    return { success: false, error: refreshError.message };
+  }
+
+  return { success: true };
+};

--- a/trigger/reconcile-tiktok-draft-results.ts
+++ b/trigger/reconcile-tiktok-draft-results.ts
@@ -6,7 +6,11 @@ import { TikTokBusinessPostClient } from "./posting/platforms/tiktok_business-po
 import { TIKTOK_PROCESSING_STATUSES } from "./posting/platforms/tiktok-shared";
 import { handleTokenRefresh, shouldRefreshToken } from "./posting/token-refresh";
 import { PlatformAppCredentials, SocialAccount } from "./posting/post.types";
+import Stripe from "stripe";
 import { Database } from "./supabase.types";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+const STRIPE_METER_EVENT = process.env.STRIPE_METER_EVENT || "successful_post";
 
 const supabaseClient = createClient<Database>(
   process.env.SUPABASE_URL!,
@@ -103,6 +107,27 @@ const resolveRow = async ({
   }
 
   if (success && teamId && stripeCustomerId) {
+    try {
+      logger.info("Increasing stripe meter", {
+        meter: STRIPE_METER_EVENT,
+        stripe_customer_id: stripeCustomerId,
+      });
+      const meterEvent = await stripe.billing.meterEvents.create({
+        event_name: STRIPE_METER_EVENT,
+        payload: {
+          stripe_customer_id: stripeCustomerId,
+        },
+      });
+
+      logger.info("Created meter event", { meterEvent });
+    } catch (error) {
+      logger.error("Failed to increase stripe meter", {
+        meter: STRIPE_METER_EVENT,
+        stripe_customer_id: stripeCustomerId,
+        error,
+      });
+    }
+
     void idempotencyKeys
       .create(["increment-team-usage", updated.id], { scope: "global" })
       .then((idempotencyKey) =>
@@ -222,11 +247,38 @@ const reconcileRow = async ({
     });
   } catch (statusError) {
     if (axios.isAxiosError(statusError)) {
-      logger.error("Transient error checking TikTok draft status, will retry", {
+      const status = statusError.response?.status;
+      const isTransient =
+        !statusError.response ||
+        status === 429 ||
+        status === 408 ||
+        (status !== undefined && status >= 500);
+
+      if (isTransient) {
+        logger.error("Transient error checking TikTok draft status, will retry", {
+          id: row.id,
+          error: statusError.message,
+        });
+        await bumpAttempts(row.id, row.reconciliation_attempts);
+        return;
+      }
+
+      logger.error("Permanent error checking TikTok draft status, giving up", {
         id: row.id,
+        status,
         error: statusError.message,
       });
-      await bumpAttempts(row.id, row.reconciliation_attempts);
+      await resolveRow({
+        row,
+        success: false,
+        errorMessage: statusError.message,
+        details: {
+          ...row.details,
+          status: "Processing failed",
+          message: statusError.message,
+          reconciled_at: new Date().toISOString(),
+        },
+      });
       return;
     }
 
@@ -260,9 +312,10 @@ export const reconcileTikTokDraftResults = schedules.task({
     const { data: expiredRows, error: expiredFetchError } = await supabaseClient
       .from("social_post_results")
       .select(
-        `id, post_id, details, reconciliation_attempts, social_provider_connections!inner(project_id)`,
+        `id, post_id, details, reconciliation_attempts, social_provider_connections!inner(provider, project_id)`,
       )
       .eq("is_processing", true)
+      .in("social_provider_connections.provider", ["tiktok", "tiktok_business"])
       .or(
         `reconciliation_deadline_at.lte.${now},reconciliation_attempts.gte.${MAX_RECONCILIATION_ATTEMPTS}`,
       );
@@ -350,8 +403,8 @@ export const reconcileTikTokDraftResults = schedules.task({
       groups.set(key, groupRows);
     }
 
-    await Promise.allSettled(
-      Array.from(groups.values()).map(async (groupRows) => {
+    const groupResults = await Promise.allSettled(
+      Array.from(groups.entries()).map(async ([, groupRows]) => {
         const { provider, project_id: projectId } =
           groupRows[0].social_provider_connections;
 
@@ -373,11 +426,27 @@ export const reconcileTikTokDraftResults = schedules.task({
           app_secret: credentialRow.app_secret || "",
         });
 
-        await Promise.allSettled(
+        const rowResults = await Promise.allSettled(
           groupRows.map((row) => reconcileRow({ row, client })),
         );
+        rowResults.forEach((result, i) => {
+          if (result.status === "rejected") {
+            logger.error("Unhandled error reconciling TikTok draft row", {
+              id: groupRows[i].id,
+              error: result.reason,
+            });
+          }
+        });
       }),
     );
+    groupResults.forEach((result, i) => {
+      if (result.status === "rejected") {
+        logger.error("Unhandled error reconciling TikTok draft group", {
+          key: Array.from(groups.keys())[i],
+          error: result.reason,
+        });
+      }
+    });
 
     logger.info("TikTok draft result reconciliation complete");
   },

--- a/trigger/reconcile-tiktok-draft-results.ts
+++ b/trigger/reconcile-tiktok-draft-results.ts
@@ -1,7 +1,9 @@
+import axios from "axios";
 import { createClient } from "@supabase/supabase-js";
 import { idempotencyKeys, logger, schedules, tasks } from "@trigger.dev/sdk";
 import { TikTokPostClient } from "./posting/platforms/tiktok-post-client";
 import { TikTokBusinessPostClient } from "./posting/platforms/tiktok_business-post-client";
+import { TIKTOK_PROCESSING_STATUSES } from "./posting/platforms/tiktok-shared";
 import { handleTokenRefresh, shouldRefreshToken } from "./posting/token-refresh";
 import { PlatformAppCredentials, SocialAccount } from "./posting/post.types";
 import { Database } from "./supabase.types";
@@ -12,11 +14,6 @@ const supabaseClient = createClient<Database>(
 );
 
 const MAX_RECONCILIATION_ATTEMPTS = 50;
-const PROCESSING_STATUSES = [
-  "PROCESSING",
-  "PROCESSING_DOWNLOAD",
-  "PROCESSING_UPLOAD",
-];
 
 type ReconcilableClient = TikTokPostClient | TikTokBusinessPostClient;
 
@@ -51,6 +48,16 @@ type PendingResultRow = {
   };
 };
 
+type ResolvableRow = Pick<
+  PendingResultRow,
+  "id" | "post_id" | "details" | "reconciliation_attempts"
+> & {
+  social_provider_connections: Pick<
+    PendingResultRow["social_provider_connections"],
+    "project_id"
+  >;
+};
+
 const bumpAttempts = async (id: string, currentAttempts: number) => {
   const { error } = await supabaseClient
     .from("social_post_results")
@@ -70,7 +77,7 @@ const resolveRow = async ({
   teamId,
   stripeCustomerId,
 }: {
-  row: PendingResultRow;
+  row: ResolvableRow;
   success: boolean;
   errorMessage: string | null;
   details: any;
@@ -194,7 +201,7 @@ const reconcileRow = async ({
       account,
     });
 
-    if (PROCESSING_STATUSES.includes(status)) {
+    if (TIKTOK_PROCESSING_STATUSES.includes(status)) {
       await bumpAttempts(row.id, row.reconciliation_attempts);
       return;
     }
@@ -214,6 +221,15 @@ const reconcileRow = async ({
       stripeCustomerId: connection.projects?.teams?.stripe_customer_id,
     });
   } catch (statusError) {
+    if (axios.isAxiosError(statusError)) {
+      logger.error("Transient error checking TikTok draft status, will retry", {
+        id: row.id,
+        error: statusError.message,
+      });
+      await bumpAttempts(row.id, row.reconciliation_attempts);
+      return;
+    }
+
     logger.error("TikTok draft reconciliation resolved to failure", {
       id: row.id,
       error: statusError,
@@ -237,21 +253,41 @@ export const reconcileTikTokDraftResults = schedules.task({
   id: "reconcile-tiktok-draft-results",
   maxDuration: 3600,
   retry: { maxAttempts: 1 },
+  queue: { concurrencyLimit: 1 },
   run: async () => {
     const now = new Date().toISOString();
 
-    const { error: expireError } = await supabaseClient
+    const { data: expiredRows, error: expiredFetchError } = await supabaseClient
       .from("social_post_results")
-      .update({ is_processing: false })
+      .select(
+        `id, post_id, details, reconciliation_attempts, social_provider_connections!inner(project_id)`,
+      )
       .eq("is_processing", true)
       .or(
         `reconciliation_deadline_at.lte.${now},reconciliation_attempts.gte.${MAX_RECONCILIATION_ATTEMPTS}`,
       );
 
-    if (expireError) {
-      logger.error("Failed to expire stale reconciliation rows", {
-        error: expireError,
+    if (expiredFetchError) {
+      logger.error("Failed to fetch expired reconciliation rows", {
+        error: expiredFetchError,
       });
+    } else if (expiredRows?.length) {
+      logger.info(`Giving up on ${expiredRows.length} expired reconciliation row(s)`);
+      await Promise.allSettled(
+        (expiredRows as unknown as ResolvableRow[]).map((row) =>
+          resolveRow({
+            row,
+            success: false,
+            errorMessage:
+              "Reconciliation for this TikTok draft did not complete within the allotted time or attempt limit.",
+            details: {
+              ...row.details,
+              status: "Reconciliation abandoned",
+              reconciled_at: new Date().toISOString(),
+            },
+          }),
+        ),
+      );
     }
 
     const { data: rows, error } = await supabaseClient
@@ -337,9 +373,9 @@ export const reconcileTikTokDraftResults = schedules.task({
           app_secret: credentialRow.app_secret || "",
         });
 
-        for (const row of groupRows) {
-          await reconcileRow({ row, client });
-        }
+        await Promise.allSettled(
+          groupRows.map((row) => reconcileRow({ row, client })),
+        );
       }),
     );
 

--- a/trigger/reconcile-tiktok-draft-results.ts
+++ b/trigger/reconcile-tiktok-draft-results.ts
@@ -1,0 +1,348 @@
+import { createClient } from "@supabase/supabase-js";
+import { idempotencyKeys, logger, schedules, tasks } from "@trigger.dev/sdk";
+import { TikTokPostClient } from "./posting/platforms/tiktok-post-client";
+import { TikTokBusinessPostClient } from "./posting/platforms/tiktok_business-post-client";
+import { handleTokenRefresh, shouldRefreshToken } from "./posting/token-refresh";
+import { PlatformAppCredentials, SocialAccount } from "./posting/post.types";
+import { Database } from "./supabase.types";
+
+const supabaseClient = createClient<Database>(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+const MAX_RECONCILIATION_ATTEMPTS = 50;
+const PROCESSING_STATUSES = [
+  "PROCESSING",
+  "PROCESSING_DOWNLOAD",
+  "PROCESSING_UPLOAD",
+];
+
+type ReconcilableClient = TikTokPostClient | TikTokBusinessPostClient;
+
+const createTikTokClient = (
+  provider: "tiktok" | "tiktok_business",
+  appCredentials: PlatformAppCredentials,
+): ReconcilableClient =>
+  provider === "tiktok_business"
+    ? new TikTokBusinessPostClient(supabaseClient, appCredentials)
+    : new TikTokPostClient(supabaseClient, appCredentials);
+
+type PendingResultRow = {
+  id: string;
+  post_id: string;
+  details: any;
+  reconciliation_attempts: number;
+  social_provider_connections: {
+    id: string;
+    provider: "tiktok" | "tiktok_business";
+    project_id: string;
+    access_token: string;
+    refresh_token: string | null;
+    access_token_expires_at: string | null;
+    refresh_token_expires_at: string | null;
+    social_provider_user_id: string;
+    social_provider_user_name: string | null;
+    social_provider_metadata: any;
+    projects: {
+      team_id: string;
+      teams: { stripe_customer_id: string | null } | null;
+    } | null;
+  };
+};
+
+const bumpAttempts = async (id: string, currentAttempts: number) => {
+  const { error } = await supabaseClient
+    .from("social_post_results")
+    .update({ reconciliation_attempts: currentAttempts + 1 })
+    .eq("id", id);
+
+  if (error) {
+    logger.error("Failed to bump reconciliation attempts", { id, error });
+  }
+};
+
+const resolveRow = async ({
+  row,
+  success,
+  errorMessage,
+  details,
+  teamId,
+  stripeCustomerId,
+}: {
+  row: PendingResultRow;
+  success: boolean;
+  errorMessage: string | null;
+  details: any;
+  teamId?: string | null;
+  stripeCustomerId?: string | null;
+}) => {
+  const { data: updated, error } = await supabaseClient
+    .from("social_post_results")
+    .update({
+      success,
+      is_processing: false,
+      error_message: errorMessage,
+      details,
+      reconciliation_attempts: row.reconciliation_attempts + 1,
+    })
+    .eq("id", row.id)
+    .select()
+    .single();
+
+  if (error || !updated) {
+    logger.error("Failed to update reconciled post result", { id: row.id, error });
+    return;
+  }
+
+  if (success && teamId && stripeCustomerId) {
+    void idempotencyKeys
+      .create(["increment-team-usage", updated.id], { scope: "global" })
+      .then((idempotencyKey) =>
+        tasks.trigger(
+          "increment-team-usage",
+          { stripe_customer_id: stripeCustomerId, team_id: teamId },
+          { idempotencyKey, idempotencyKeyTTL: "1h" },
+        ),
+      )
+      .catch((error) => {
+        logger.error("Failed to trigger increment team usage during reconciliation", {
+          social_post_result_id: updated.id,
+          error,
+        });
+      });
+  }
+
+  await tasks.trigger("process-webhooks", {
+    projectId: row.social_provider_connections.project_id,
+    eventType: "social.post.result.updated",
+    eventData: {
+      details: updated.details,
+      id: updated.id,
+      error: updated.error_message,
+      platform_data: {
+        id: updated.provider_post_id,
+        url: updated.provider_post_url,
+      },
+      post_id: updated.post_id,
+      social_account_id: updated.provider_connection_id,
+      success: updated.success,
+      is_processing: updated.is_processing,
+    },
+  });
+};
+
+const reconcileRow = async ({
+  row,
+  client,
+}: {
+  row: PendingResultRow;
+  client: ReconcilableClient;
+}) => {
+  const connection = row.social_provider_connections;
+  const account: SocialAccount = {
+    id: connection.id,
+    provider: connection.provider as SocialAccount["provider"],
+    social_provider_user_name: connection.social_provider_user_name,
+    access_token: connection.access_token,
+    refresh_token: connection.refresh_token,
+    access_token_expires_at: connection.access_token_expires_at
+      ? new Date(connection.access_token_expires_at)
+      : null,
+    refresh_token_expires_at: connection.refresh_token_expires_at
+      ? new Date(connection.refresh_token_expires_at)
+      : null,
+    social_provider_user_id: connection.social_provider_user_id,
+    social_provider_metadata: connection.social_provider_metadata,
+  };
+
+  if (shouldRefreshToken(account)) {
+    const refreshed = await handleTokenRefresh({
+      supabaseClient,
+      postClient: client,
+      account,
+    });
+
+    if (!refreshed.success) {
+      logger.error("Failed to refresh token during reconciliation", {
+        social_post_result_id: row.id,
+        accountId: account.id,
+        error: refreshed.error,
+      });
+      await bumpAttempts(row.id, row.reconciliation_attempts);
+      return;
+    }
+  }
+
+  const publishId = row.details?.publish_id;
+  if (!publishId) {
+    logger.error("Reconciliation row missing publish_id, giving up", {
+      id: row.id,
+    });
+    await resolveRow({
+      row,
+      success: false,
+      errorMessage: "Unable to reconcile: missing publish_id",
+      details: row.details,
+    });
+    return;
+  }
+
+  try {
+    const { status } = await client.checkDraftPublishStatus({
+      publishId,
+      account,
+    });
+
+    if (PROCESSING_STATUSES.includes(status)) {
+      await bumpAttempts(row.id, row.reconciliation_attempts);
+      return;
+    }
+
+    await resolveRow({
+      row,
+      success: true,
+      errorMessage: null,
+      details: {
+        ...row.details,
+        status: "Saved as draft",
+        message:
+          "Content saved as draft in TikTok. Check your TikTok inbox notifications to continue editing and publish.",
+        reconciled_at: new Date().toISOString(),
+      },
+      teamId: connection.projects?.team_id,
+      stripeCustomerId: connection.projects?.teams?.stripe_customer_id,
+    });
+  } catch (statusError) {
+    logger.error("TikTok draft reconciliation resolved to failure", {
+      id: row.id,
+      error: statusError,
+    });
+    await resolveRow({
+      row,
+      success: false,
+      errorMessage: statusError.message,
+      details: {
+        ...row.details,
+        status: "Processing failed",
+        message: statusError.message,
+        reconciled_at: new Date().toISOString(),
+      },
+    });
+  }
+};
+
+export const reconcileTikTokDraftResults = schedules.task({
+  cron: { pattern: "*/10 * * * *", environments: ["PRODUCTION"] },
+  id: "reconcile-tiktok-draft-results",
+  maxDuration: 3600,
+  retry: { maxAttempts: 1 },
+  run: async () => {
+    const now = new Date().toISOString();
+
+    const { error: expireError } = await supabaseClient
+      .from("social_post_results")
+      .update({ is_processing: false })
+      .eq("is_processing", true)
+      .or(
+        `reconciliation_deadline_at.lte.${now},reconciliation_attempts.gte.${MAX_RECONCILIATION_ATTEMPTS}`,
+      );
+
+    if (expireError) {
+      logger.error("Failed to expire stale reconciliation rows", {
+        error: expireError,
+      });
+    }
+
+    const { data: rows, error } = await supabaseClient
+      .from("social_post_results")
+      .select(
+        `
+        id, post_id, details, reconciliation_attempts,
+        social_provider_connections!inner(
+          id, provider, project_id, access_token, refresh_token,
+          access_token_expires_at, refresh_token_expires_at,
+          social_provider_user_id, social_provider_user_name, social_provider_metadata,
+          projects( team_id, teams(stripe_customer_id) )
+        )
+        `,
+      )
+      .eq("is_processing", true)
+      .in("social_provider_connections.provider", ["tiktok", "tiktok_business"])
+      .lt("reconciliation_attempts", MAX_RECONCILIATION_ATTEMPTS)
+      .gt("reconciliation_deadline_at", now)
+      .order("created_at", { ascending: true })
+      .limit(100);
+
+    if (error) {
+      logger.error("Failed to fetch processing TikTok draft results", { error });
+      throw new Error(`Failed to fetch processing results: ${error.message}`);
+    }
+
+    if (!rows || rows.length === 0) {
+      logger.info("No TikTok draft results pending reconciliation");
+      return;
+    }
+
+    logger.info(`Reconciling ${rows.length} TikTok draft result(s)`);
+
+    const pendingRows = rows as unknown as PendingResultRow[];
+    const projectIds = [
+      ...new Set(pendingRows.map((row) => row.social_provider_connections.project_id)),
+    ];
+
+    const { data: appCredentialsRows, error: credentialsError } =
+      await supabaseClient
+        .from("social_provider_app_credentials")
+        .select("*")
+        .in("project_id", projectIds);
+
+    if (credentialsError) {
+      logger.error("Failed to fetch app credentials", {
+        error: credentialsError,
+      });
+      throw new Error(
+        `Failed to fetch app credentials: ${credentialsError.message}`,
+      );
+    }
+
+    const groups = new Map<string, PendingResultRow[]>();
+    for (const row of pendingRows) {
+      const key = `${row.social_provider_connections.provider}:${row.social_provider_connections.project_id}`;
+      const groupRows = groups.get(key) ?? [];
+      groupRows.push(row);
+      groups.set(key, groupRows);
+    }
+
+    await Promise.allSettled(
+      Array.from(groups.values()).map(async (groupRows) => {
+        const { provider, project_id: projectId } =
+          groupRows[0].social_provider_connections;
+
+        const credentialRow = (appCredentialsRows ?? []).find(
+          (credential) =>
+            credential.provider === provider && credential.project_id === projectId,
+        );
+
+        if (!credentialRow) {
+          logger.error("No app credentials found for provider", {
+            provider,
+            projectId,
+          });
+          return;
+        }
+
+        const client = createTikTokClient(provider, {
+          app_id: credentialRow.app_id || "",
+          app_secret: credentialRow.app_secret || "",
+        });
+
+        for (const row of groupRows) {
+          await reconcileRow({ row, client });
+        }
+      }),
+    );
+
+    logger.info("TikTok draft result reconciliation complete");
+  },
+});

--- a/trigger/refresh-account-tokens.ts
+++ b/trigger/refresh-account-tokens.ts
@@ -1,16 +1,7 @@
 import { logger, schedules } from "@trigger.dev/sdk";
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
-import { PostClient } from "./posting/post-client";
-import { TwitterPostClient } from "./posting/platforms/twitter-post-client";
-import { InstagramPostClient } from "./posting/platforms/instagram-post-client";
-import { FacebookPostClient } from "./posting/platforms/facebook-post-client";
-import { LinkedInPostClient } from "./posting/platforms/linkedin-post-client";
-import { TikTokPostClient } from "./posting/platforms/tiktok-post-client";
-import { BlueskyPostClient } from "./posting/platforms/bluesky-post-client";
-import { ThreadsPostClient } from "./posting/platforms/threads-post-client";
-import { PinterestPostClient } from "./posting/platforms/pinterest-post-client";
-import { YouTubePostClient } from "./posting/platforms/youtube-post-client";
-import { TikTokBusinessPostClient } from "./posting/platforms/tiktok_business-post-client";
+import { createClient } from "@supabase/supabase-js";
+import { createPostClient } from "./posting/create-post-client";
+import { handleTokenRefresh as sharedHandleTokenRefresh } from "./posting/token-refresh";
 import { PlatformAppCredentials, SocialAccount } from "./posting/post.types";
 
 import { Database } from "./supabase.types";
@@ -20,113 +11,34 @@ const supabaseClient = createClient<Database>(
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
-const createPostClient = ({
-  supabaseClient,
-  platformName,
-  appCredentials,
-}: {
-  supabaseClient: SupabaseClient;
-  platformName: string;
-  appCredentials: PlatformAppCredentials;
-}): PostClient => {
-  switch (platformName) {
-    case "x":
-      return new TwitterPostClient(supabaseClient, appCredentials);
-    case "instagram":
-      return new InstagramPostClient(supabaseClient, appCredentials);
-    case "facebook":
-      return new FacebookPostClient(supabaseClient, appCredentials);
-    case "linkedin":
-      return new LinkedInPostClient(supabaseClient, appCredentials);
-    case "tiktok":
-      return new TikTokPostClient(supabaseClient, appCredentials);
-    case "bluesky":
-      return new BlueskyPostClient(supabaseClient, appCredentials);
-    case "threads":
-      return new ThreadsPostClient(supabaseClient, appCredentials);
-    case "pinterest":
-      return new PinterestPostClient(supabaseClient, appCredentials);
-    case "youtube":
-      return new YouTubePostClient(supabaseClient, appCredentials);
-    case "tiktok_business":
-      return new TikTokBusinessPostClient(supabaseClient, appCredentials);
-    default:
-      throw Error("Invalid Platform");
-  }
-};
-
 const handleTokenRefresh = async ({
   postClient,
   account,
 }: {
-  postClient: PostClient;
+  postClient: ReturnType<typeof createPostClient>;
   account: SocialAccount;
 }): Promise<{ success: boolean; error?: string; accountId: string }> => {
-  try {
-    logger.info(
-      `Refreshing token for ${account.provider} account ${account.id}`,
-    );
+  logger.info(
+    `Refreshing token for ${account.provider} account ${account.id}`,
+  );
 
-    const { access_token, expires_at, refresh_token } =
-      await postClient.refreshAccessToken(account);
+  const result = await sharedHandleTokenRefresh({
+    supabaseClient,
+    postClient,
+    account,
+  });
 
-    if (!access_token) {
-      const error = `Failed to refresh ${account.provider} token for account ${account.id}`;
-      logger.error(error);
-      return {
-        success: false,
-        error,
-        accountId: account.id,
-      };
-    }
-
-    const updateData: {
-      access_token?: string;
-      access_token_expires_at?: string;
-      refresh_token?: string;
-    } = {
-      access_token,
-      access_token_expires_at: expires_at,
-    };
-
-    if (refresh_token) {
-      updateData.refresh_token = refresh_token;
-    }
-
-    const { error: updateError } = await supabaseClient
-      .from("social_provider_connections")
-      .update(updateData)
-      .eq("id", account.id);
-
-    if (updateError) {
-      logger.error(`Database update error for account ${account.id}:`, {
-        error: updateError,
-      });
-      return {
-        success: false,
-        error: updateError.message,
-        accountId: account.id,
-      };
-    }
-
+  if (!result.success) {
+    logger.error(`Token refresh failed for account ${account.id}:`, {
+      error: result.error,
+    });
+  } else {
     logger.info(
       `Successfully refreshed token for ${account.provider} account ${account.id}`,
     );
-    return {
-      success: true,
-      accountId: account.id,
-    };
-  } catch (refreshError) {
-    logger.error(
-      `Token refresh error for account ${account.id}:`,
-      refreshError,
-    );
-    return {
-      success: false,
-      error: refreshError.message,
-      accountId: account.id,
-    };
   }
+
+  return { ...result, accountId: account.id };
 };
 
 const refreshAccountsByProviderAndProject = async ({

--- a/trigger/supabase.types.ts
+++ b/trigger/supabase.types.ts
@@ -278,10 +278,13 @@ export type Database = {
           details: Json | null
           error_message: string | null
           id: string
+          is_processing: boolean
           post_id: string
           provider_connection_id: string
           provider_post_id: string | null
           provider_post_url: string | null
+          reconciliation_attempts: number
+          reconciliation_deadline_at: string | null
           success: boolean
           updated_at: string
         }
@@ -290,10 +293,13 @@ export type Database = {
           details?: Json | null
           error_message?: string | null
           id?: string
+          is_processing?: boolean
           post_id: string
           provider_connection_id: string
           provider_post_id?: string | null
           provider_post_url?: string | null
+          reconciliation_attempts?: number
+          reconciliation_deadline_at?: string | null
           success: boolean
           updated_at?: string
         }
@@ -302,10 +308,13 @@ export type Database = {
           details?: Json | null
           error_message?: string | null
           id?: string
+          is_processing?: boolean
           post_id?: string
           provider_connection_id?: string
           provider_post_id?: string | null
           provider_post_url?: string | null
+          reconciliation_attempts?: number
+          reconciliation_deadline_at?: string | null
           success?: boolean
           updated_at?: string
         }
@@ -1082,6 +1091,7 @@ export type Database = {
         | "social.post.result.created"
         | "social.account.created"
         | "social.account.updated"
+        | "social.post.result.updated"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1244,6 +1254,7 @@ export const Constants = {
         "social.post.result.created",
         "social.account.created",
         "social.account.updated",
+        "social.post.result.updated",
       ],
     },
   },


### PR DESCRIPTION
## Summary

TikTok draft posts were being recorded as successful even when TikTok's own publish-status check reported the post was still processing (`PROCESSING`, `PROCESSING_DOWNLOAD`, `PROCESSING_UPLOAD`). This produced a self-contradictory result row — `success: true` alongside an `error_message` admitting the draft wasn't actually done — matching the customer-reported symptom of "showing a failed post while also marking it as successful," and caused Stripe usage billing and success webhooks to fire before TikTok had actually finished processing the draft.

Since a still-processing draft has no final status at post time, this PR also adds a scheduled reconciliation job that polls TikTok for the real outcome afterward and updates the result once it's known, plus the plumbing (webhook event, API field, dashboard UI) needed to expose that in-between "still processing" state to customers instead of just success/failure.

## Changes

**Original fix**
- `trigger/posting/platforms/tiktok-post-client.ts` / `tiktok_business-post-client.ts`: draft branch of `post()` now returns `success: false, is_processing: true` (not `success: true`) when the polled publish status is still processing, instead of prematurely marking it successful.

**Reconciliation**
- `trigger/reconcile-tiktok-draft-results.ts`: new scheduled job (every 10 min) that re-polls TikTok for drafts left `is_processing: true`, resolves them via a shared `resolveRow` helper (updates the result row, fires `social.post.result.updated`, and triggers usage billing on eventual success), and retries via `reconciliation_attempts` up to a cap or a 24h deadline.
- `api/supabase/migrations/...add_reconciliation_to_social_post_results.sql`: adds `is_processing`, `reconciliation_attempts`, `reconciliation_deadline_at` to `social_post_results`.
- `api/supabase/migrations/...add_social_post_result_updated_webhook_event.sql`: adds the `social.post.result.updated` webhook event type.
- `api/src/webhooks/dto/create-webhook.dto.ts`: registers `social.post.result.updated` in the webhook subscription allowlist.
- `api/src/social-post-results/`: surfaces `is_processing` on the customer-facing `GET /social-post-results` endpoints.
- `dashboard/.../posts._index/`: posts list now shows a 3-state (`success` / `processing` / `failed`) badge per platform instead of a boolean, so an in-flight TikTok draft no longer renders as "failed".

**Review fixes (round 1, from `/code-review 329`)**
- Retry transient status-check errors (network blips, TikTok 429/5xx) via `bumpAttempts` instead of immediately resolving the row as a permanent failure.
- Route the "give up" sweep (deadline passed / max attempts hit) through `resolveRow` so it also fires the webhook and records a real outcome, instead of a silent bulk `is_processing: false` update.
- Added a `queue: { concurrencyLimit: 1 }` guard on the schedule so a slow run can't overlap the next cron fire and double-process rows.
- De-duplicated the `PROCESSING_STATUSES` list (was hand-copied in 3 places) into `trigger/posting/platforms/tiktok-shared.ts`.
- Parallelized per-row reconciliation within a provider/project group via `Promise.allSettled`, mirroring `refresh-account-tokens.ts`.

**Review fixes (round 2, from a second `/code-review 329` pass)**
- `resolveRow` now fires the Stripe `meterEvents.create` event on reconciled success (matching the synchronous `post-to-platform.ts` path) — previously deferred TikTok drafts were silently undercounted for metered billing even though they counted against plan usage limits.
- TikTok status-check `AxiosError`s are now classified by HTTP status instead of always treated as transient: no response / 5xx / 429 / 408 still retry, but other 4xx errors (revoked token, invalid `publish_id`, etc.) now fail fast with the real error message instead of retrying silently for up to 24h/50 attempts.
- The expiry ("give up") query is now scoped to `tiktok`/`tiktok_business`, matching the main pending-rows query, so it can no longer sweep up and permanently fail another provider's rows if `is_processing` is ever set outside this job.
- Both `Promise.allSettled` calls (per-row and per-group) now log any rejected promises with row/group context instead of silently dropping unexpected reconciliation errors.
- Dashboard: `PostResult` now includes `is_processing`; the post-detail results table and "View Logs" raw-data dialog render a still-processing TikTok draft as a neutral "Processing" state instead of a red "Failed" error (this component was missed when the posts-list page got its 3-state treatment).

## Testing

- `cd trigger && bun run typecheck && bun run lint` — passes clean.
- `cd api && bun run typecheck` — passes clean (`lint` has one pre-existing, unrelated parse error on a local untracked Supabase temp file).
- `cd dashboard && bun run typecheck && bun run lint` — passes clean.
- No existing test suite covers any of the touched files; not adding new test infra as part of this fix.
- Not manually exercised against a live TikTok draft post in this pass — recommend a manual check via `bun run dev` against a test TikTok account before merging, or monitoring the next real draft post + reconciliation run after deploy.

Closes PFM-988

🤖 Generated with AI
