### PR TITLE
fix(dashboard): surface OAuth error params on failed account connections

### DIFF
--- a/api/src/facebook/facebook.service.ts
+++ b/api/src/facebook/facebook.service.ts
@@ -19,10 +19,10 @@ import type {
 } from './facebook.types';
 import { FacebookPostMetricsDto } from './dto/facebook-post-metrics.dto';
 import { mapWithConcurrency } from '../lib/async.utils';
+import { getFacebookApiVersion } from '../lib/graph-api-version.util';
 
 const FACEBOOK_METRICS_POST_CONCURRENCY = 3;
 const FACEBOOK_INSIGHTS_INTERVAL_CONCURRENCY = 2;
-const DEFAULT_FACEBOOK_API_VERSION = 'v25.0';
 
 type FacebookInsightsInterval = { since: string; until: string };
 
@@ -36,11 +36,7 @@ export class FacebookService implements SocialPlatformService {
   ) {}
 
   private get graphApiBaseUrl(): string {
-    const facebookApiVersion =
-      this.configService.get<string>('FACEBOOK_API_VERSION') ||
-      DEFAULT_FACEBOOK_API_VERSION;
-
-    return `https://graph.facebook.com/${facebookApiVersion}`;
+    return `https://graph.facebook.com/${getFacebookApiVersion(this.configService)}`;
   }
 
   private logFacebookInsightsError(error: unknown, groupName?: string): void {

--- a/api/src/instagram/instagram.service.ts
+++ b/api/src/instagram/instagram.service.ts
@@ -20,10 +20,13 @@ import type {
   InstagramInsight,
 } from './instagram.types';
 import { mapWithConcurrency } from '../lib/async.utils';
+import {
+  getFacebookApiVersion,
+  getInstagramApiVersion,
+} from '../lib/graph-api-version.util';
 
 const INSTAGRAM_METRICS_CONCURRENCY = 3;
-const DEFAULT_FACEBOOK_API_VERSION = 'v25.0';
-const DEFAULT_INSTAGRAM_API_VERSION = 'v23.0';
+const GRAPH_INSTAGRAM_DOMAIN = 'https://graph.instagram.com';
 
 @Injectable({ scope: Scope.REQUEST })
 export class InstagramService implements SocialPlatformService {
@@ -35,17 +38,11 @@ export class InstagramService implements SocialPlatformService {
   ) {}
 
   private get facebookApiVersion(): string {
-    return (
-      this.configService.get<string>('FACEBOOK_API_VERSION') ||
-      DEFAULT_FACEBOOK_API_VERSION
-    );
+    return getFacebookApiVersion(this.configService);
   }
 
   private get instagramApiVersion(): string {
-    return (
-      this.configService.get<string>('INSTAGRAM_API_VERSION') ||
-      DEFAULT_INSTAGRAM_API_VERSION
-    );
+    return getInstagramApiVersion(this.configService);
   }
 
   getApiBaseUrl(account: SocialAccount) {
@@ -57,7 +54,7 @@ export class InstagramService implements SocialPlatformService {
       accountMetaData?.connection_type === 'instagram' ||
       (account.access_token && account.access_token.startsWith('IG'))
     ) {
-      return `https://graph.instagram.com/${this.instagramApiVersion}`;
+      return `${GRAPH_INSTAGRAM_DOMAIN}/${this.instagramApiVersion}`;
     }
     return `https://graph.facebook.com/${this.facebookApiVersion}`;
   }
@@ -113,7 +110,7 @@ export class InstagramService implements SocialPlatformService {
 
       if (accountMetaData?.connection_type === 'instagram') {
         const response = await axios.get<InstagramRefreshTokenResponse>(
-          'https://graph.instagram.com/refresh_access_token',
+          `${GRAPH_INSTAGRAM_DOMAIN}/refresh_access_token`,
           {
             params: {
               grant_type: 'ig_refresh_token',

--- a/api/src/lib/graph-api-version.util.ts
+++ b/api/src/lib/graph-api-version.util.ts
@@ -1,0 +1,18 @@
+import type { ConfigService } from '@nestjs/config';
+
+export const DEFAULT_FACEBOOK_API_VERSION = 'v25.0';
+export const DEFAULT_INSTAGRAM_API_VERSION = 'v23.0';
+
+export function getFacebookApiVersion(configService: ConfigService): string {
+  return (
+    configService.get<string>('FACEBOOK_API_VERSION') ||
+    DEFAULT_FACEBOOK_API_VERSION
+  );
+}
+
+export function getInstagramApiVersion(configService: ConfigService): string {
+  return (
+    configService.get<string>('INSTAGRAM_API_VERSION') ||
+    DEFAULT_INSTAGRAM_API_VERSION
+  );
+}

--- a/api/src/social-provider-connections/helper/auth-url.helper.ts
+++ b/api/src/social-provider-connections/helper/auth-url.helper.ts
@@ -6,6 +6,7 @@ import { google } from 'googleapis';
 import type { SupabaseService } from '../../supabase/supabase.service';
 import type { AuthUrlProviderData } from '../dto/create-provider-auth-url.dto';
 import type { Database } from '../../../supabase';
+import { getFacebookApiVersion } from '../../lib/graph-api-version.util';
 
 type SocialProviderEnum = Database['public']['Enums']['social_provider'];
 
@@ -113,8 +114,7 @@ export async function generateAuthUrl({
         }
       }
 
-      const facebookVersion =
-        configService.get<string>('FACEBOOK_API_VERSION') || 'v23.0';
+      const facebookVersion = getFacebookApiVersion(configService);
       const authParams = new URLSearchParams([
         ['client_id', appId],
         ['redirect_uri', callbackUrl],
@@ -161,8 +161,7 @@ export async function generateAuthUrl({
         }
       }
 
-      const facebookVersion =
-        configService.get<string>('FACEBOOK_API_VERSION') || 'v23.0';
+      const facebookVersion = getFacebookApiVersion(configService);
       const authParams = new URLSearchParams([
         ['client_id', appId],
         ['redirect_uri', callbackUrl],

--- a/dashboard/app/lib/.server/social-accounts/oauth-callback-response.ts
+++ b/dashboard/app/lib/.server/social-accounts/oauth-callback-response.ts
@@ -1,0 +1,82 @@
+import { redirect } from "react-router";
+
+export function parseOauthCallbackError(url: URL, provider: string | undefined) {
+  const oauthError = url.searchParams.get("error");
+  const oauthErrorReason = url.searchParams.get("error_reason");
+  const oauthErrorDescription = url.searchParams.get("error_description");
+  const oauthErrorMessage = oauthError
+    ? (oauthErrorDescription || oauthErrorReason || oauthError).replace(
+        /\|/g,
+        " ",
+      )
+    : null;
+
+  if (oauthError) {
+    console.error(
+      "OAuth provider returned an error during account connection",
+      {
+        provider,
+        error: oauthError,
+        error_reason: oauthErrorReason,
+        error_description: oauthErrorDescription,
+      },
+    );
+  }
+
+  return { oauthError, oauthErrorReason, oauthErrorDescription, oauthErrorMessage };
+}
+
+//Either return to component or redirect to project callback url
+export const createOauthCallbackResponse = ({
+  teamId,
+  projectId,
+  provider,
+  isSuccess,
+  callbackUrl,
+  accountIds,
+  failedAccountIds,
+  errors,
+  isLoggedIn,
+}: {
+  teamId?: string;
+  projectId?: string;
+  provider?: string;
+  isSuccess: boolean;
+  accountIds?: string[];
+  failedAccountIds?: string[];
+  errors?: string[];
+  callbackUrl?: string | null | undefined;
+  isLoggedIn?: boolean;
+}) => {
+  const error = errors && errors.length > 0 ? errors.join("|") : null;
+
+  if (callbackUrl) {
+    const authParams = new URLSearchParams([
+      ["provider", provider || ""],
+      ["projectId", projectId || ""],
+      ["isSuccess", isSuccess ? "true" : "false"],
+      ["accountIds", accountIds?.join(",") || ""],
+    ]);
+
+    if (failedAccountIds && failedAccountIds.length > 0) {
+      authParams.append("failedAccountIds", failedAccountIds?.join(","));
+    }
+
+    if (error) {
+      authParams.append("error", error);
+    }
+
+    return redirect(`${callbackUrl}?${authParams.toString()}`);
+  }
+
+  return {
+    teamId,
+    projectId,
+    provider,
+    isSuccess,
+    accountIds,
+    failedAccountIds,
+    error,
+    isLoggedIn,
+  };
+};

--- a/dashboard/app/lib/.server/social-accounts/social-account.constants.ts
+++ b/dashboard/app/lib/.server/social-accounts/social-account.constants.ts
@@ -1,11 +1,13 @@
 export const SOCIAL_ACCOUNT_PHOTO_BUCKET_NAME = "social-account-photos";
 export const REDIRECT_APP_URL = process.env.APP_URL || "http://localhost:5173";
 
-export const FACEBOOK_GRAPH_API_URL =
-  process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com";
+export const FACEBOOK_GRAPH_API_URL = (
+  process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com"
+).replace(/\/+$/, "");
 export const FACEBOOK_API_VERSION =
   process.env.FACEBOOK_API_VERSION || "v25.0";
-export const INSTAGRAM_GRAPH_API_URL =
-  process.env.INSTAGRAM_GRAPH_API_URL || "https://graph.instagram.com";
+export const INSTAGRAM_GRAPH_API_URL = (
+  process.env.INSTAGRAM_GRAPH_API_URL || "https://graph.instagram.com"
+).replace(/\/+$/, "");
 export const INSTAGRAM_API_VERSION =
   process.env.INSTAGRAM_API_VERSION || "v23.0";

--- a/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
@@ -18,10 +18,29 @@ export const loader = withSupabase(async function ({
 
   let { provider } = params;
 
+  const oauthError = url.searchParams.get("error");
+  const oauthErrorReason = url.searchParams.get("error_reason");
+  const oauthErrorDescription = url.searchParams.get("error_description");
+  const oauthErrorMessage = oauthError
+    ? oauthErrorDescription || oauthErrorReason || oauthError
+    : null;
+
+  if (oauthError) {
+    console.error(
+      "OAuth provider returned an error during account connection",
+      {
+        provider,
+        error: oauthError,
+        error_reason: oauthErrorReason,
+        error_description: oauthErrorDescription,
+      },
+    );
+  }
+
   if (!projectId || !provider) {
     return createResponse({
       isSuccess: false,
-      errors: ["Project Id or Provider not found"],
+      errors: [oauthErrorMessage || "Project Id or Provider not found"],
       isLoggedIn,
     });
   }
@@ -33,7 +52,7 @@ export const loader = withSupabase(async function ({
   if (!key) {
     return createResponse({
       isSuccess: false,
-      errors: ["Auth state not set"],
+      errors: [oauthErrorMessage || "Auth state not set"],
       isLoggedIn,
     });
   }
@@ -59,7 +78,7 @@ export const loader = withSupabase(async function ({
     console.error("Project not found");
     return createResponse({
       isSuccess: false,
-      errors: ["Project not found"],
+      errors: [oauthErrorMessage || "Project not found"],
       projectId,
       provider,
       isLoggedIn,
@@ -109,26 +128,14 @@ export const loader = withSupabase(async function ({
         ? "x"
         : provider;
 
-  const oauthError = url.searchParams.get("error");
-  if (oauthError) {
-    const errorReason = url.searchParams.get("error_reason");
-    const errorDescription = url.searchParams.get("error_description");
-    console.error(
-      "OAuth provider returned an error during account connection",
-      {
-        provider: normalizedProvider,
-        error: oauthError,
-        error_reason: errorReason,
-        error_description: errorDescription,
-      },
-    );
+  if (oauthErrorMessage) {
     return createResponse({
       isSuccess: false,
       teamId: project.team_id,
       projectId,
       provider: normalizedProvider,
       callbackUrl: project.auth_callback_url,
-      errors: [errorDescription || errorReason || oauthError],
+      errors: [oauthErrorMessage],
       isLoggedIn,
     });
   }

--- a/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
@@ -109,6 +109,30 @@ export const loader = withSupabase(async function ({
         ? "x"
         : provider;
 
+  const oauthError = url.searchParams.get("error");
+  if (oauthError) {
+    const errorReason = url.searchParams.get("error_reason");
+    const errorDescription = url.searchParams.get("error_description");
+    console.error(
+      "OAuth provider returned an error during account connection",
+      {
+        provider: normalizedProvider,
+        error: oauthError,
+        error_reason: errorReason,
+        error_description: errorDescription,
+      },
+    );
+    return createResponse({
+      isSuccess: false,
+      teamId: project.team_id,
+      projectId,
+      provider: normalizedProvider,
+      callbackUrl: project.auth_callback_url,
+      errors: [errorDescription || errorReason || oauthError],
+      isLoggedIn,
+    });
+  }
+
   if (!providerAppCredentials && provider !== "bluesky") {
     console.error("Provider app credentials not found for project");
     return createResponse({

--- a/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts
@@ -1,7 +1,10 @@
 import type { Database } from "~/lib/.server/database.types";
-import { redirect } from "react-router";
 import { addSocialAccountConnections } from "~/lib/.server/social-accounts/social-account";
 import { withSupabase } from "~/lib/.server/supabase";
+import {
+  parseOauthCallbackError,
+  createOauthCallbackResponse,
+} from "~/lib/.server/social-accounts/oauth-callback-response";
 
 type SocialProviderEnum = Database["public"]["Enums"]["social_provider"];
 
@@ -18,27 +21,10 @@ export const loader = withSupabase(async function ({
 
   let { provider } = params;
 
-  const oauthError = url.searchParams.get("error");
-  const oauthErrorReason = url.searchParams.get("error_reason");
-  const oauthErrorDescription = url.searchParams.get("error_description");
-  const oauthErrorMessage = oauthError
-    ? oauthErrorDescription || oauthErrorReason || oauthError
-    : null;
-
-  if (oauthError) {
-    console.error(
-      "OAuth provider returned an error during account connection",
-      {
-        provider,
-        error: oauthError,
-        error_reason: oauthErrorReason,
-        error_description: oauthErrorDescription,
-      },
-    );
-  }
+  const { oauthErrorMessage } = parseOauthCallbackError(url, provider);
 
   if (!projectId || !provider) {
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       errors: [oauthErrorMessage || "Project Id or Provider not found"],
       isLoggedIn,
@@ -50,7 +36,7 @@ export const loader = withSupabase(async function ({
     (url.searchParams.get("state") as string);
 
   if (!key) {
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       errors: [oauthErrorMessage || "Auth state not set"],
       isLoggedIn,
@@ -76,11 +62,30 @@ export const loader = withSupabase(async function ({
 
   if (projectError || !project) {
     console.error("Project not found");
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       errors: [oauthErrorMessage || "Project not found"],
       projectId,
       provider,
+      isLoggedIn,
+    });
+  }
+
+  const normalizedProvider =
+    provider === "instagram_w_facebook"
+      ? "instagram"
+      : provider === "x_oauth2"
+        ? "x"
+        : provider;
+
+  if (oauthErrorMessage) {
+    return createOauthCallbackResponse({
+      isSuccess: false,
+      teamId: project.team_id,
+      projectId,
+      provider: normalizedProvider,
+      callbackUrl: project.auth_callback_url,
+      errors: [oauthErrorMessage],
       isLoggedIn,
     });
   }
@@ -121,28 +126,9 @@ export const loader = withSupabase(async function ({
     (appCredential) => appCredential.provider === provider,
   );
 
-  const normalizedProvider =
-    provider === "instagram_w_facebook"
-      ? "instagram"
-      : provider === "x_oauth2"
-        ? "x"
-        : provider;
-
-  if (oauthErrorMessage) {
-    return createResponse({
-      isSuccess: false,
-      teamId: project.team_id,
-      projectId,
-      provider: normalizedProvider,
-      callbackUrl: project.auth_callback_url,
-      errors: [oauthErrorMessage],
-      isLoggedIn,
-    });
-  }
-
   if (!providerAppCredentials && provider !== "bluesky") {
     console.error("Provider app credentials not found for project");
-    return createResponse({
+    return createOauthCallbackResponse({
       projectId,
       provider: normalizedProvider,
       teamId: project.team_id,
@@ -173,7 +159,7 @@ export const loader = withSupabase(async function ({
 
     if (successConnections.length === 0) {
       errors.push("No valid accounts found");
-      return createResponse({
+      return createOauthCallbackResponse({
         isSuccess: false,
         teamId: project.team_id,
         projectId,
@@ -185,7 +171,7 @@ export const loader = withSupabase(async function ({
       });
     }
 
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: true,
       teamId: project.team_id,
       projectId,
@@ -198,7 +184,7 @@ export const loader = withSupabase(async function ({
     });
   } catch (error) {
     console.error(error);
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       errors: [
         (error as { message?: string })?.message ||
@@ -212,58 +198,3 @@ export const loader = withSupabase(async function ({
     });
   }
 });
-
-//Either return to component or redirect to project callback url
-const createResponse = ({
-  teamId,
-  projectId,
-  provider,
-  isSuccess,
-  callbackUrl,
-  accountIds,
-  failedAccountIds,
-  errors,
-  isLoggedIn,
-}: {
-  teamId?: string;
-  projectId?: string;
-  provider?: string;
-  isSuccess: boolean;
-  accountIds?: string[];
-  failedAccountIds?: string[];
-  errors?: string[];
-  callbackUrl?: string | null | undefined;
-  isLoggedIn?: boolean;
-}) => {
-  const error = errors && errors.length > 0 ? errors.join("|") : null;
-
-  if (callbackUrl) {
-    const authParams = new URLSearchParams([
-      ["provider", provider || ""],
-      ["projectId", projectId || ""],
-      ["isSuccess", isSuccess ? "true" : "false"],
-      ["accountIds", accountIds?.join(",") || ""],
-    ]);
-
-    if (failedAccountIds && failedAccountIds.length > 0) {
-      authParams.append("failedAccountIds", failedAccountIds?.join(","));
-    }
-
-    if (error) {
-      authParams.append("error", error);
-    }
-
-    return redirect(`${callbackUrl}?${authParams.toString()}`);
-  }
-
-  return {
-    teamId,
-    projectId,
-    provider,
-    isSuccess,
-    accountIds,
-    failedAccountIds,
-    error,
-    isLoggedIn,
-  };
-};

--- a/dashboard/app/routes/callback.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$provider.account/route.loader.ts
@@ -1,7 +1,10 @@
-import { redirect } from "react-router";
 import { addSocialAccountConnections } from "~/lib/.server/social-accounts/social-account";
 import { withSupabase } from "~/lib/.server/supabase";
 import type { Database } from "~/lib/.server/database.types";
+import {
+  parseOauthCallbackError,
+  createOauthCallbackResponse,
+} from "~/lib/.server/social-accounts/oauth-callback-response";
 
 type SocialProviderEnum = Database["public"]["Enums"]["social_provider"];
 
@@ -17,31 +20,14 @@ export const loader = withSupabase(async function ({
 
   let { provider } = params;
 
-  const oauthError = url.searchParams.get("error");
-  const oauthErrorReason = url.searchParams.get("error_reason");
-  const oauthErrorDescription = url.searchParams.get("error_description");
-  const oauthErrorMessage = oauthError
-    ? oauthErrorDescription || oauthErrorReason || oauthError
-    : null;
-
-  if (oauthError) {
-    console.error(
-      "OAuth provider returned an error during account connection",
-      {
-        provider,
-        error: oauthError,
-        error_reason: oauthErrorReason,
-        error_description: oauthErrorDescription,
-      },
-    );
-  }
+  const { oauthErrorMessage } = parseOauthCallbackError(url, provider);
 
   const key =
     (url.searchParams.get("oauth_token") as string) ||
     (url.searchParams.get("state") as string);
 
   if (!key) {
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       errors: [oauthErrorMessage || "Auth state not set"],
       isLoggedIn,
@@ -68,26 +54,11 @@ export const loader = withSupabase(async function ({
   )?.value;
 
   if (!projectId || !provider) {
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       errors: [oauthErrorMessage || "Project Id or Provider not found"],
       isLoggedIn,
     });
-  }
-
-  const connectionType = oauthData.data?.find(
-    (d) => d.key === "connection_type",
-  )?.value;
-  if (
-    connectionType &&
-    provider === "instagram" &&
-    connectionType === "facebook"
-  ) {
-    provider = "instagram_w_facebook";
-  }
-
-  if (provider === "x" && connectionType === "oauth2") {
-    provider = "x_oauth2";
   }
 
   const normalizedProvider =
@@ -116,7 +87,7 @@ export const loader = withSupabase(async function ({
 
   if (projectError || !project) {
     console.error("Project not found");
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       errors: [oauthErrorMessage || "Project not found"],
       projectId,
@@ -125,12 +96,8 @@ export const loader = withSupabase(async function ({
     });
   }
 
-  const providerAppCredentials = project.social_provider_app_credentials.find(
-    (appCredential) => appCredential.provider === provider,
-  );
-
   if (oauthErrorMessage) {
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       teamId: project.team_id,
       projectId,
@@ -141,9 +108,28 @@ export const loader = withSupabase(async function ({
     });
   }
 
+  const connectionType = oauthData.data?.find(
+    (d) => d.key === "connection_type",
+  )?.value;
+  if (
+    connectionType &&
+    provider === "instagram" &&
+    connectionType === "facebook"
+  ) {
+    provider = "instagram_w_facebook";
+  }
+
+  if (provider === "x" && connectionType === "oauth2") {
+    provider = "x_oauth2";
+  }
+
+  const providerAppCredentials = project.social_provider_app_credentials.find(
+    (appCredential) => appCredential.provider === provider,
+  );
+
   if (!providerAppCredentials && provider !== "bluesky") {
     console.error("Provider app credentials not found for project");
-    return createResponse({
+    return createOauthCallbackResponse({
       projectId,
       provider: normalizedProvider,
       teamId: project.team_id,
@@ -174,7 +160,7 @@ export const loader = withSupabase(async function ({
 
     if (successConnections.length === 0) {
       errors.push("No valid accounts found");
-      return createResponse({
+      return createOauthCallbackResponse({
         isSuccess: false,
         teamId: project.team_id,
         projectId,
@@ -186,7 +172,7 @@ export const loader = withSupabase(async function ({
       });
     }
 
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: true,
       teamId: project.team_id,
       projectId,
@@ -199,7 +185,7 @@ export const loader = withSupabase(async function ({
     });
   } catch (error) {
     console.error(error);
-    return createResponse({
+    return createOauthCallbackResponse({
       isSuccess: false,
       errors: [
         (error as { message?: string })?.message ||
@@ -213,57 +199,3 @@ export const loader = withSupabase(async function ({
     });
   }
 });
-
-//Either return to component or redirect to project callback url
-const createResponse = ({
-  teamId,
-  projectId,
-  provider,
-  isSuccess,
-  callbackUrl,
-  accountIds,
-  failedAccountIds,
-  errors,
-  isLoggedIn,
-}: {
-  teamId?: string;
-  projectId?: string;
-  provider?: string;
-  isSuccess: boolean;
-  accountIds?: string[];
-  failedAccountIds?: string[];
-  errors?: string[];
-  callbackUrl?: string | null | undefined;
-  isLoggedIn?: boolean;
-}) => {
-  const error = errors && errors.length > 0 ? errors.join("|") : null;
-
-  if (callbackUrl) {
-    const authParams = new URLSearchParams([
-      ["provider", provider || ""],
-      ["projectId", projectId || ""],
-      ["isSuccess", isSuccess ? "true" : "false"],
-      ["accountIds", accountIds?.join(",") || ""],
-    ]);
-
-    if (failedAccountIds && failedAccountIds.length > 0) {
-      authParams.append("failedAccountIds", failedAccountIds?.join(","));
-    }
-    if (error) {
-      authParams.append("error", error);
-    }
-
-    return redirect(`${callbackUrl}?${authParams.toString()}`);
-  }
-
-  return {
-    teamId,
-    projectId,
-    provider,
-    isSuccess,
-    accountIds,
-    failedAccountIds,
-    error,
-    isLoggedIn,
-  };
-};

--- a/dashboard/app/routes/callback.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$provider.account/route.loader.ts
@@ -110,6 +110,30 @@ export const loader = withSupabase(async function ({
     (appCredential) => appCredential.provider === provider,
   );
 
+  const oauthError = url.searchParams.get("error");
+  if (oauthError) {
+    const errorReason = url.searchParams.get("error_reason");
+    const errorDescription = url.searchParams.get("error_description");
+    console.error(
+      "OAuth provider returned an error during account connection",
+      {
+        provider: normalizedProvider,
+        error: oauthError,
+        error_reason: errorReason,
+        error_description: errorDescription,
+      },
+    );
+    return createResponse({
+      isSuccess: false,
+      teamId: project.team_id,
+      projectId,
+      provider: normalizedProvider,
+      callbackUrl: project.auth_callback_url,
+      errors: [errorDescription || errorReason || oauthError],
+      isLoggedIn,
+    });
+  }
+
   if (!providerAppCredentials && provider !== "bluesky") {
     console.error("Provider app credentials not found for project");
     return createResponse({

--- a/dashboard/app/routes/callback.$provider.account/route.loader.ts
+++ b/dashboard/app/routes/callback.$provider.account/route.loader.ts
@@ -17,6 +17,25 @@ export const loader = withSupabase(async function ({
 
   let { provider } = params;
 
+  const oauthError = url.searchParams.get("error");
+  const oauthErrorReason = url.searchParams.get("error_reason");
+  const oauthErrorDescription = url.searchParams.get("error_description");
+  const oauthErrorMessage = oauthError
+    ? oauthErrorDescription || oauthErrorReason || oauthError
+    : null;
+
+  if (oauthError) {
+    console.error(
+      "OAuth provider returned an error during account connection",
+      {
+        provider,
+        error: oauthError,
+        error_reason: oauthErrorReason,
+        error_description: oauthErrorDescription,
+      },
+    );
+  }
+
   const key =
     (url.searchParams.get("oauth_token") as string) ||
     (url.searchParams.get("state") as string);
@@ -24,7 +43,7 @@ export const loader = withSupabase(async function ({
   if (!key) {
     return createResponse({
       isSuccess: false,
-      errors: ["Auth state not set"],
+      errors: [oauthErrorMessage || "Auth state not set"],
       isLoggedIn,
     });
   }
@@ -51,7 +70,7 @@ export const loader = withSupabase(async function ({
   if (!projectId || !provider) {
     return createResponse({
       isSuccess: false,
-      errors: ["Project Id or Provider not found"],
+      errors: [oauthErrorMessage || "Project Id or Provider not found"],
       isLoggedIn,
     });
   }
@@ -99,7 +118,7 @@ export const loader = withSupabase(async function ({
     console.error("Project not found");
     return createResponse({
       isSuccess: false,
-      errors: ["Project not found"],
+      errors: [oauthErrorMessage || "Project not found"],
       projectId,
       provider: normalizedProvider,
       isLoggedIn,
@@ -110,26 +129,14 @@ export const loader = withSupabase(async function ({
     (appCredential) => appCredential.provider === provider,
   );
 
-  const oauthError = url.searchParams.get("error");
-  if (oauthError) {
-    const errorReason = url.searchParams.get("error_reason");
-    const errorDescription = url.searchParams.get("error_description");
-    console.error(
-      "OAuth provider returned an error during account connection",
-      {
-        provider: normalizedProvider,
-        error: oauthError,
-        error_reason: errorReason,
-        error_description: errorDescription,
-      },
-    );
+  if (oauthErrorMessage) {
     return createResponse({
       isSuccess: false,
       teamId: project.team_id,
       projectId,
       provider: normalizedProvider,
       callbackUrl: project.auth_callback_url,
-      errors: [errorDescription || errorReason || oauthError],
+      errors: [oauthErrorMessage],
       isLoggedIn,
     });
   }

--- a/trigger/posting/platforms/facebook-post-client.ts
+++ b/trigger/posting/platforms/facebook-post-client.ts
@@ -25,11 +25,13 @@ export class FacebookPostClient extends PostClient {
     "upload_complete",
   ];
 
-  #graphApiUrl =
-    process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com";
-  #graphVideoApiUrl =
+  #graphApiUrl = (
+    process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com"
+  ).replace(/\/+$/, "");
+  #graphVideoApiUrl = (
     process.env.FACEBOOK_GRAPH_VIDEO_API_URL ||
-    "https://graph-video.facebook.com";
+    "https://graph-video.facebook.com"
+  ).replace(/\/+$/, "");
   #apiVersion = process.env.FACEBOOK_API_VERSION || "v25.0";
   #oauthApiVersion = process.env.FACEBOOK_OAUTH_API_VERSION || "v20.0";
 

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -33,10 +33,12 @@ export class InstagramPostClient extends PostClient {
   #bucket: string = "post-media";
   #appCredentials: PlatformAppCredentials;
 
-  #graphApiUrl =
-    process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com";
-  #graphInstagramApiUrl =
-    process.env.INSTAGRAM_GRAPH_API_URL || "https://graph.instagram.com";
+  #graphApiUrl = (
+    process.env.FACEBOOK_GRAPH_API_URL || "https://graph.facebook.com"
+  ).replace(/\/+$/, "");
+  #graphInstagramApiUrl = (
+    process.env.INSTAGRAM_GRAPH_API_URL || "https://graph.instagram.com"
+  ).replace(/\/+$/, "");
   #apiVersion = process.env.FACEBOOK_API_VERSION || "v25.0";
   #instagramApiVersion = process.env.INSTAGRAM_API_VERSION || "v23.0";
   #oauthApiVersion = process.env.FACEBOOK_OAUTH_API_VERSION || "v20.0";


### PR DESCRIPTION
## Summary

Investigating PFM-1047 ("Feature Unavailable" on Facebook connect) found the dashboard's OAuth callback flow silently drops Facebook's (and every other standard-OAuth2 provider's) `error`/`error_reason`/`error_description` query params on a denied or blocked connection attempt. Both callback loaders only ever checked for `code`, so any such failure surfaced as a generic, useless `"No code provided"` — both to the user and in logs.

This doesn't retroactively explain PFM-1047 itself (if Facebook's "Feature Unavailable" interstitial is a true dead-end at facebook.com with no redirect back, nothing reaches our server at all — that's a separate, unconfirmed App Review/Business Verification question, out of scope here). But it closes a real observability gap: any OAuth failure that *does* redirect back (explicit user denial, invalid scope, etc.) now surfaces the provider's actual reason instead of a meaningless message, making the next ticket like this one diagnosable from logs alone.

Stacked on `feat/update-facebook-graph-api` (#312) since both are part of the same Facebook OAuth reliability push.

## Changes

- `dashboard/app/routes/callback.$projectId.$provider.account/route.loader.ts` — project-scoped callback: check `error` before the "No App Credentials" guard, log the full `error`/`error_reason`/`error_description` triple, surface `error_description || error_reason || error` to the user.
- `dashboard/app/routes/callback.$provider.account/route.loader.ts` — same fix for the system/quickstart-scoped callback.
- Loader-level fix (not per-provider `.social-account.ts` files) so it covers every provider sharing the same bare `code` check — facebook, instagram_w_facebook, linkedin, pinterest, threads, tiktok, tiktok_business — in 2 files instead of 7+. Confirmed no interference with `x` (OAuth1, uses `?denied=` not `?error=`) or `bluesky` (not a redirect-based flow).

**Follow-up fix (code review):** the OAuth error check originally ran after the `state`/key guard and the project-lookup guard in both loaders. That meant a denied/blocked redirect that lacked a valid `state` (or whose `oauth_data` row had already expired/been cleaned up) still fell through to the generic pre-existing "Auth state not set" / "Project not found" message instead of the provider's real error — exactly the failure mode this PR set out to fix. Both loaders now extract the OAuth error params up front and prefer that message in every early-return guard branch, while still preferring the full project-aware response (with `callbackUrl`/`teamId` for redirecting back to the customer's own callback URL) when project info is available.

**Follow-up fix (`/code-review 331`):** because this branch had merged `main` (which had already merged `feat/update-facebook-graph-api`), the reviewed diff also surfaced 10 findings spanning Graph API version-handling inconsistencies left behind by that version bump, plus further cleanup in the two callback loaders above:

- Added `api/src/lib/graph-api-version.util.ts` as the single source of truth for the `FACEBOOK_API_VERSION`/`INSTAGRAM_API_VERSION` defaults (v25.0/v23.0), used by `facebook.service.ts`, `instagram.service.ts`, and `auth-url.helper.ts` — this fixes `auth-url.helper.ts`'s OAuth-authorize-dialog URL, which had silently diverged to a v23.0 default while every other reader of the same env var defaulted to v25.0.
- Deduped `instagram.service.ts`'s `refreshAccessToken` direct-Instagram branch, which hardcoded a second copy of the `graph.instagram.com` domain literal instead of sharing it with `getApiBaseUrl`.
- Added trailing-slash stripping on the operator-configurable Graph API base URLs (`FACEBOOK_GRAPH_API_URL`, `FACEBOOK_GRAPH_VIDEO_API_URL`, `INSTAGRAM_GRAPH_API_URL`) in `trigger/posting/platforms/facebook-post-client.ts`, `instagram-post-client.ts`, and `dashboard/.../social-account.constants.ts`, so a trailing-slash override doesn't double-slash the resulting URL.
- Extracted the two callback loaders' duplicated 18-line OAuth-error-parsing block and identical `createResponse` helper into a shared `dashboard/app/lib/.server/social-accounts/oauth-callback-response.ts`, which also now sanitizes literal `|` characters out of provider-supplied error text (it previously could collide with the `errors.join("|")` delimiter used to pack multiple errors into one redirect query param).
- Reordered both loaders so the OAuth-error early return happens as soon as the minimum data needed for the error redirect is available, skipping DB work that's only needed on the success path (`callback.$projectId.$provider.account` now skips an entire `social_provider_connection_oauth_data` query on failed OAuth attempts).
- Scope decisions made explicitly and left as-is: `api/`'s Facebook token-refresh call stays on the general v25.0 default rather than being pinned to `trigger/`'s dedicated v20.0 OAuth-version override, and the v25.0 default itself for live posting/data endpoints needed no change — it's already operator-overridable and documented in each sibling's `.env.example`.

Non-goals: no change to the `business_management` OAuth scope, no DB schema change.

## Testing

- `cd dashboard && bun run typecheck` and `bun run lint` — both clean
- `cd trigger && bun run typecheck` and `bun run lint` — both clean
- `cd api && bun run lint` (scoped to touched files — the sibling-wide script hits an unrelated pre-existing local-Supabase temp-file parsing error) — clean
- Manual end-to-end repro against local Supabase + dashboard dev server for both routes: hit each callback with a synthetic `?state=<valid-pending-state>&error=access_denied&error_reason=user_denied&error_description=...`, confirmed the rendered page shows the description text instead of "No code provided", and confirmed the structured error appears in server logs. Test data cleaned up afterward.

## Notes

Caveat worth flagging to reviewers: this doesn't guarantee a fix for the original PFM-1047 report specifically, since Facebook's "Feature Unavailable" screen may never redirect back at all. Root-cause theory for that (unverified, no code change proposed): the default Facebook scope list requests `business_management`, which requires App Review/Business Verification — until then, only users with a role on the connecting Meta app can grant it, matching "works on my account, fails for my client."

Part of PFM-1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)
