### PR TITLE
fix(trigger): surface TikTok's reached_active_user_cap as a clear, attributed error

### DIFF
--- a/trigger/posting/platforms/tiktok-post-client.ts
+++ b/trigger/posting/platforms/tiktok-post-client.ts
@@ -212,12 +212,18 @@ export class TikTokPostClient extends PostClient {
     } catch (error) {
       console.error("Error in postToTikTok:", error.message);
       const errorDetails = await this.#getErrorDetails(error);
+      const tiktokErrorCode = error.response?.data?.error?.code;
+
+      const errorMessage =
+        tiktokErrorCode === "reached_active_user_cap"
+          ? "TikTok has temporarily reached its daily cap on new active users for our app (this is a limit TikTok imposes until our app completes their review — it is not a Post for Me limit). This resets automatically within 24 hours; please try posting again after that."
+          : "Failed to post to TikTok";
 
       return {
         success: false,
         post_id: postId,
         provider_connection_id: account.id,
-        error_message: "Failed to post to TikTok",
+        error_message: errorMessage,
         details: {
           error: errorDetails,
           requests: this.#requests,


### PR DESCRIPTION
## Summary

TikTok's Content Posting API returns a 403 `reached_active_user_cap` when our
app's daily cap on new active users is hit — a limit TikTok imposes on apps
still pending its app review, not something Post for Me controls. The
`TikTokPostClient` catch block collapsed every publish failure into a
generic `"Failed to post to TikTok"`, burying the real reason in the raw
logs dialog. A paying customer (PFM-1051) hit this exact error, assumed we
were the ones capping them, and escalated as urgent since they'd migrated
from another tool specifically to get away from this error. This PR makes
the cause visible and correctly attributed so it's self-explanatory instead
of a support ticket.

## Changes

- `trigger/posting/platforms/tiktok-post-client.ts`: in `post()`'s catch
  block, detect `error.response?.data?.error?.code === "reached_active_user_cap"`
  and return a specific `error_message` explaining it's TikTok's own
  temporary, app-wide limit (tied to app review status, resets ~24h) rather
  than a Post for Me restriction. Any other error still falls back to the
  previous generic message. Raw error details are still stashed under
  `details` for the dashboard's "View Logs" dialog, unchanged.
- No other layers needed changes — `error_message` flows through
  `post-to-platform.ts` → `social_post_results.error_message` → the API's
  `error` DTO field → the dashboard's post-detail error row verbatim, so the
  new message reaches the user with this one change.
- Scoped to the personal Content Posting API client only (the endpoint in
  the report, `/v2/post/publish/video/init/`). Verified the TikTok Business
  client (`tiktok_business-post-client.ts`) doesn't share this error
  code/mechanism — TikTok's Business API uses a different numeric
  error-code scheme tied to verified business accounts, not the "unaudited
  client" review gate that produces `reached_active_user_cap` — so it's
  intentionally left unchanged.

## Testing

- `cd trigger && bun run typecheck && bun run lint` — both pass clean.
- No test harness exists in `trigger/` (no `*.test.ts` files, no `test`
  script) to add coverage to.
- Manually traced the call path: `/v2/post/publish/video/init/` is called
  from `#getPublishId` inside `#processVideo`, which has no intermediate
  catch block (only a `try/finally` for temp-file cleanup), so an error
  there propagates unmodified into `post()`'s single catch block where the
  new detection lives.
- Could not reproduce the live TikTok cap itself (no unaudited/capped app
  available in this environment); confirmed the error shape
  (`{ error: { code: "reached_active_user_cap" } }` on a 403) against
  TikTok's Content Posting API docs and third-party integration reports of
  this exact error.

## Notes

- Also investigated the customer's second ask (bring-your-own TikTok
  developer credentials to avoid the shared app's cap entirely) — that
  capability already exists in production (`social_provider_app_credentials`
  is project-scoped, and the dashboard has a dedicated
  `.../setup/tiktok/` credentials form). No code change needed there; it's
  a support/docs answer for this customer.

Closes PFM-1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)