### PR TITLE
fix(trigger): use X weighted character counting for caption truncation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Typecheck
         id: typecheck
         run: bun run typecheck
+      - name: Test
+        id: test
+        run: bun run test
 
   dashboard:
     name: Dashboard

--- a/api/src/social-posts/social-posts.service.ts
+++ b/api/src/social-posts/social-posts.service.ts
@@ -214,24 +214,6 @@ export class SocialPostsService {
     return [];
   }
 
-  validatePostCaptionLength({
-    caption,
-    platform,
-  }: {
-    caption: string;
-    platform: string;
-  }): { isValid: boolean; error: string } {
-    const maxCaptionLength = 2200;
-
-    switch (platform) {
-      default:
-        return {
-          isValid: caption.length <= maxCaptionLength,
-          error: `caption must be less than ${maxCaptionLength} characters`,
-        };
-    }
-  }
-
   async createPost({
     post,
     projectId,

--- a/trigger/bun.lock
+++ b/trigger/bun.lock
@@ -22,14 +22,17 @@
         "stripe": "^18.1.1",
         "tus-js-client": "^4.3.1",
         "twitter-api-v2": "^1.22.0",
+        "twitter-text": "^3.1.0",
         "uuid": "^11.1.0",
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
         "@trigger.dev/build": "4.4.4",
+        "@types/bun": "^1.4.0",
         "@types/fluent-ffmpeg": "^2.1.27",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.10.7",
+        "@types/twitter-text": "^3.1.10",
         "@types/uuid": "^10.0.0",
         "eslint": "^9.18.0",
         "supabase": "^2.30.4",
@@ -54,6 +57,8 @@
     "@atproto/syntax": ["@atproto/syntax@0.4.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA=="],
 
     "@atproto/xrpc": ["@atproto/xrpc@0.6.12", "", { "dependencies": { "@atproto/lexicon": "^0.4.10", "zod": "^3.23.8" } }, "sha512-Ut3iISNLujlmY9Gu8sNU+SPDJDvqlVzWddU8qUr0Yae5oD4SguaUFjjhireMGhQ3M5E0KljQgDbTmnBo1kIZ3w=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@bugsnag/cuid": ["@bugsnag/cuid@3.2.2", "", {}, "sha512-7onuYLTMqMmHE9BBPG0YER4nFsU1rB+me1/YIeMusqcLbVbKKuG9u9+BDVDpje5e0llkkrVNOKYwmzM9DRIo7A=="],
 
@@ -247,6 +252,8 @@
 
     "@trigger.dev/sdk": ["@trigger.dev/sdk@4.4.4", "", { "dependencies": { "@opentelemetry/api": "1.9.0", "@opentelemetry/semantic-conventions": "1.36.0", "@trigger.dev/core": "4.4.4", "chalk": "^5.2.0", "cronstrue": "^2.21.0", "debug": "^4.3.4", "evt": "^2.4.13", "slug": "^6.0.0", "ulid": "^2.3.0", "uncrypto": "^0.1.3", "uuid": "^9.0.0", "ws": "^8.11.0" }, "peerDependencies": { "ai": "^4.2.0 || ^5.0.0 || ^6.0.0", "zod": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["ai"] }, "sha512-X2R1BCZlptxJw2oT6SJAU8bDKO8pgfNIFrNdo7p6XUjW7gha9s1oNZEicL7cmvJF8rO35MO70vO/Wqo8tjQjPQ=="],
 
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
     "@types/cookie": ["@types/cookie@0.4.1", "", {}, "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="],
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
@@ -262,6 +269,8 @@
     "@types/node": ["@types/node@22.19.18", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ=="],
 
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "@types/twitter-text": ["@types/twitter-text@3.1.10", "", {}, "sha512-+wF6TYQtvokyCc42VKF9OAvEgro0JIAEMor+A7eZsZtkgD/LPAIJx5+g7529nQUzRpas2hlmJEPfZgkzxr0xnA=="],
 
     "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
@@ -329,6 +338,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
     "c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -364,6 +375,8 @@
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "cookie": ["cookie@0.4.2", "", {}, "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="],
+
+    "core-js": ["core-js@2.6.12", "", {}, "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
@@ -699,7 +712,7 @@
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
-    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+    "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
@@ -807,7 +820,11 @@
 
     "tus-js-client": ["tus-js-client@4.3.1", "", { "dependencies": { "buffer-from": "^1.1.2", "combine-errors": "^3.0.3", "is-stream": "^2.0.0", "js-base64": "^3.7.2", "lodash.throttle": "^4.1.1", "proper-lockfile": "^4.1.2", "url-parse": "^1.5.7" } }, "sha512-ZLeYmjrkaU1fUsKbIi8JML52uAocjEZtBx4DKjRrqzrZa0O4MYwT6db+oqePlspV+FxXJAyFBc/L5gwUi2OFsg=="],
 
+    "twemoji-parser": ["twemoji-parser@11.0.2", "", {}, "sha512-5kO2XCcpAql6zjdLwRwJjYvAZyDy3+Uj7v1ipBzLthQmDL7Ce19bEqHr3ImSNeoSW2OA8u02XmARbXHaNO8GhA=="],
+
     "twitter-api-v2": ["twitter-api-v2@1.29.0", "", {}, "sha512-v473q5bwme4N+DWSg6qY+JCvfg1nSJRWwui3HUALafxfqCvVkKiYmS/5x/pVeJwTmyeBxexMbzHwnzrH4h6oYQ=="],
+
+    "twitter-text": ["twitter-text@3.1.0", "", { "dependencies": { "@babel/runtime": "^7.3.1", "core-js": "^2.5.0", "punycode": "1.4.1", "twemoji-parser": "^11.0.2" } }, "sha512-nulfUi3FN6z0LUjYipJid+eiwXvOLb8Ass7Jy/6zsXmZK3URte043m8fL3FyDzrK+WLpyqhHuR/TcARTN/iuGQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -924,6 +941,10 @@
     "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "socket.io-client/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
+
+    "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "uri-js/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 

--- a/trigger/package.json
+++ b/trigger/package.json
@@ -10,7 +10,8 @@
     "typegen": "bun run supabase:typegen",
     "supabase:typegen": "supabase gen types typescript --local > supabase.types.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
+    "test": "bun test"
   },
   "dependencies": {
     "@atproto/api": "^0.14.20",
@@ -30,14 +31,17 @@
     "stripe": "^18.1.1",
     "tus-js-client": "^4.3.1",
     "twitter-api-v2": "^1.22.0",
+    "twitter-text": "^3.1.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@trigger.dev/build": "4.4.4",
     "@types/fluent-ffmpeg": "^2.1.27",
+    "@types/bun": "^1.4.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.10.7",
+    "@types/twitter-text": "^3.1.10",
     "@types/uuid": "^10.0.0",
     "eslint": "^9.18.0",
     "supabase": "^2.30.4",

--- a/trigger/posting/platforms/twitter-post-client.test.ts
+++ b/trigger/posting/platforms/twitter-post-client.test.ts
@@ -1,26 +1,20 @@
 import { describe, expect, it } from "bun:test";
-import { parseTweet } from "twitter-text";
+import * as twitterText from "twitter-text";
+import type { ParseTweetOptions } from "twitter-text";
 import { getAllowedCaption } from "./twitter-post-client";
+
+const { parseTweet } = twitterText;
 
 const STANDARD_LIMIT = 280;
 const PREMIUM_LIMIT = 2200;
 
-// Mirrors the v3 config `getAllowedCaption` uses internally — see the
-// comment in twitter-post-client.ts for why this can't be imported from
-// twitter-text directly.
-const TWITTER_TEXT_V3_CONFIG = {
-  version: 3,
-  scale: 100,
-  defaultWeight: 200,
-  emojiParsingEnabled: true,
-  transformedURLLength: 23,
-  ranges: [
-    { start: 0, end: 4351, weight: 100 },
-    { start: 8192, end: 8205, weight: 100 },
-    { start: 8208, end: 8223, weight: 100 },
-    { start: 8242, end: 8247, weight: 100 },
-  ],
-};
+// Same runtime-sourced config `getAllowedCaption` uses internally — see the
+// comment in twitter-post-client.ts for why this isn't in the typed API.
+const TWITTER_TEXT_V3_CONFIG = (
+  twitterText as unknown as {
+    configs: { version3: ParseTweetOptions };
+  }
+).configs.version3;
 
 function weightedLength(text: string, limit: number): number {
   return parseTweet(text, {
@@ -110,5 +104,27 @@ describe("getAllowedCaption", () => {
 
     expect(trimmed).toBe(false);
     expect(allowedCaption).toBe("");
+  });
+
+  it("trims to near the weighted limit even when an invalid character appears early", () => {
+    // twitter-text freezes `validRangeEnd` at the first character it
+    // considers invalid (e.g. a BOM) and never advances it again, even
+    // though weightedLength keeps growing past the limit. Truncation must
+    // not key off validRangeEnd or this collapses to a handful of chars.
+    const caption = "Hello﻿" + "a".repeat(400);
+    expect(weightedLength(caption, STANDARD_LIMIT)).toBeGreaterThan(
+      STANDARD_LIMIT,
+    );
+
+    const { allowedCaption, trimmed } = getAllowedCaption(
+      caption,
+      STANDARD_LIMIT,
+    );
+
+    expect(trimmed).toBe(true);
+    expect(allowedCaption.length).toBeGreaterThan(200);
+    expect(weightedLength(allowedCaption, STANDARD_LIMIT)).toBeLessThanOrEqual(
+      STANDARD_LIMIT,
+    );
   });
 });

--- a/trigger/posting/platforms/twitter-post-client.test.ts
+++ b/trigger/posting/platforms/twitter-post-client.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import { parseTweet } from "twitter-text";
+import { getAllowedCaption } from "./twitter-post-client";
+
+const STANDARD_LIMIT = 280;
+const PREMIUM_LIMIT = 2200;
+
+// Mirrors the v3 config `getAllowedCaption` uses internally — see the
+// comment in twitter-post-client.ts for why this can't be imported from
+// twitter-text directly.
+const TWITTER_TEXT_V3_CONFIG = {
+  version: 3,
+  scale: 100,
+  defaultWeight: 200,
+  emojiParsingEnabled: true,
+  transformedURLLength: 23,
+  ranges: [
+    { start: 0, end: 4351, weight: 100 },
+    { start: 8192, end: 8205, weight: 100 },
+    { start: 8208, end: 8223, weight: 100 },
+    { start: 8242, end: 8247, weight: 100 },
+  ],
+};
+
+function weightedLength(text: string, limit: number): number {
+  return parseTweet(text, {
+    ...TWITTER_TEXT_V3_CONFIG,
+    maxWeightedTweetLength: limit,
+  }).weightedLength;
+}
+
+describe("getAllowedCaption", () => {
+  it("does not trim an all-CJK caption exactly at the weighted limit", () => {
+    // Each CJK char is weighted 2, so 140 chars = 280 weighted.
+    const caption = "あ".repeat(140);
+    expect(weightedLength(caption, STANDARD_LIMIT)).toBe(280);
+
+    const { allowedCaption, trimmed } = getAllowedCaption(
+      caption,
+      STANDARD_LIMIT,
+    );
+
+    expect(trimmed).toBe(false);
+    expect(allowedCaption).toBe(caption);
+  });
+
+  it("trims an all-CJK caption one character past the weighted limit", () => {
+    // 141 chars = 282 weighted, over the 280 limit.
+    const caption = "あ".repeat(141);
+    expect(weightedLength(caption, STANDARD_LIMIT)).toBe(282);
+
+    const { allowedCaption, trimmed } = getAllowedCaption(
+      caption,
+      STANDARD_LIMIT,
+    );
+
+    expect(trimmed).toBe(true);
+    expect(allowedCaption.length).toBeLessThan(caption.length);
+    expect(weightedLength(allowedCaption, STANDARD_LIMIT)).toBeLessThanOrEqual(
+      STANDARD_LIMIT,
+    );
+  });
+
+  it("trims an emoji/newline-heavy caption cleanly, without splitting surrogate pairs", () => {
+    const emoji = "😀"; // surrogate pair, weighted 2
+    const caption = (emoji + "\n").repeat(100); // well over the weighted limit
+
+    const { allowedCaption, trimmed } = getAllowedCaption(
+      caption,
+      STANDARD_LIMIT,
+    );
+
+    expect(trimmed).toBe(true);
+    expect(weightedLength(allowedCaption, STANDARD_LIMIT)).toBeLessThanOrEqual(
+      STANDARD_LIMIT,
+    );
+
+    // A cleanly-truncated string re-parses without lone surrogate issues:
+    // spreading by code point should round-trip to the same string.
+    expect([...allowedCaption].join("")).toBe(allowedCaption);
+  });
+
+  it("does not trim a plain ASCII caption well under the limit", () => {
+    const caption = "Just a normal, short tweet about nothing in particular.";
+
+    const { allowedCaption, trimmed } = getAllowedCaption(
+      caption,
+      STANDARD_LIMIT,
+    );
+
+    expect(trimmed).toBe(false);
+    expect(allowedCaption).toBe(caption);
+  });
+
+  it("honors the premium limit instead of the standard limit", () => {
+    // 200 CJK chars = 400 weighted: over standard (280), under premium (2200).
+    const caption = "あ".repeat(200);
+    expect(weightedLength(caption, PREMIUM_LIMIT)).toBe(400);
+
+    const standardResult = getAllowedCaption(caption, STANDARD_LIMIT);
+    expect(standardResult.trimmed).toBe(true);
+
+    const premiumResult = getAllowedCaption(caption, PREMIUM_LIMIT);
+    expect(premiumResult.trimmed).toBe(false);
+    expect(premiumResult.allowedCaption).toBe(caption);
+  });
+
+  it("leaves an empty caption untouched", () => {
+    const { allowedCaption, trimmed } = getAllowedCaption("", STANDARD_LIMIT);
+
+    expect(trimmed).toBe(false);
+    expect(allowedCaption).toBe("");
+  });
+});

--- a/trigger/posting/platforms/twitter-post-client.ts
+++ b/trigger/posting/platforms/twitter-post-client.ts
@@ -9,7 +9,8 @@ import sharp from "sharp";
 import { readFile } from "fs/promises";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
-import { parseTweet } from "twitter-text";
+import * as twitterText from "twitter-text";
+import type { ParseTweetOptions } from "twitter-text";
 import {
   PlatformAppCredentials,
   PostMedia,
@@ -18,25 +19,18 @@ import {
   TwitterConfiguration,
 } from "../post.types";
 
-// twitter-text's weighting config ("configs.defaults") isn't part of its
-// public API surface (no `configs` export), and `parseTweet` replaces
-// rather than merges a partial options object — so overriding just
-// `maxWeightedTweetLength` requires supplying the full v3 config below
-// (mirrors twitter-text/dist/configs.js `defaults`) or weight calculation
-// silently breaks.
-const TWITTER_TEXT_V3_CONFIG = {
-  version: 3,
-  scale: 100,
-  defaultWeight: 200,
-  emojiParsingEnabled: true,
-  transformedURLLength: 23,
-  ranges: [
-    { start: 0, end: 4351, weight: 100 },
-    { start: 8192, end: 8205, weight: 100 },
-    { start: 8208, end: 8223, weight: 100 },
-    { start: 8242, end: 8247, weight: 100 },
-  ],
-};
+const { parseTweet } = twitterText;
+
+// `configs` isn't part of twitter-text's typed public API
+// (@types/twitter-text doesn't declare it), but the package does export it
+// at runtime alongside `parseTweet`. Sourcing the v3 weighting config
+// directly from the installed package - instead of hand-copying its ranges -
+// keeps our weighting in sync with whatever version of twitter-text we ship.
+const TWITTER_TEXT_V3_CONFIG = (
+  twitterText as unknown as {
+    configs: { version3: ParseTweetOptions };
+  }
+).configs.version3;
 
 export function getAllowedCaption(
   caption: string,
@@ -44,17 +38,40 @@ export function getAllowedCaption(
 ): { allowedCaption: string; trimmed: boolean } {
   if (!caption) return { allowedCaption: caption, trimmed: false };
 
-  const parsed = parseTweet(caption, {
+  const parseOptions = {
     ...TWITTER_TEXT_V3_CONFIG,
     maxWeightedTweetLength: characterLimit,
-  });
+  };
+
+  const parsed = parseTweet(caption, parseOptions);
 
   if (parsed.weightedLength <= characterLimit) {
     return { allowedCaption: caption, trimmed: false };
   }
 
+  // Binary search for the longest prefix (by Unicode code point, so we
+  // never split a surrogate pair) whose weighted length fits the limit.
+  // We can't use `validRangeEnd` here: twitter-text freezes it at the first
+  // character it considers "invalid" (e.g. a stray BOM) and never advances
+  // it again even as weightedLength keeps growing past the limit, which
+  // can collapse a caption down to just a few characters.
+  const codePoints = Array.from(caption);
+  let low = 0;
+  let high = codePoints.length;
+
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const candidate = codePoints.slice(0, mid).join("");
+
+    if (parseTweet(candidate, parseOptions).weightedLength <= characterLimit) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
   return {
-    allowedCaption: caption.slice(0, parsed.validRangeEnd + 1),
+    allowedCaption: codePoints.slice(0, low).join(""),
     trimmed: true,
   };
 }

--- a/trigger/posting/platforms/twitter-post-client.ts
+++ b/trigger/posting/platforms/twitter-post-client.ts
@@ -9,6 +9,7 @@ import sharp from "sharp";
 import { readFile } from "fs/promises";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
+import { parseTweet } from "twitter-text";
 import {
   PlatformAppCredentials,
   PostMedia,
@@ -16,6 +17,47 @@ import {
   SocialAccount,
   TwitterConfiguration,
 } from "../post.types";
+
+// twitter-text's weighting config ("configs.defaults") isn't part of its
+// public API surface (no `configs` export), and `parseTweet` replaces
+// rather than merges a partial options object — so overriding just
+// `maxWeightedTweetLength` requires supplying the full v3 config below
+// (mirrors twitter-text/dist/configs.js `defaults`) or weight calculation
+// silently breaks.
+const TWITTER_TEXT_V3_CONFIG = {
+  version: 3,
+  scale: 100,
+  defaultWeight: 200,
+  emojiParsingEnabled: true,
+  transformedURLLength: 23,
+  ranges: [
+    { start: 0, end: 4351, weight: 100 },
+    { start: 8192, end: 8205, weight: 100 },
+    { start: 8208, end: 8223, weight: 100 },
+    { start: 8242, end: 8247, weight: 100 },
+  ],
+};
+
+export function getAllowedCaption(
+  caption: string,
+  characterLimit: number,
+): { allowedCaption: string; trimmed: boolean } {
+  if (!caption) return { allowedCaption: caption, trimmed: false };
+
+  const parsed = parseTweet(caption, {
+    ...TWITTER_TEXT_V3_CONFIG,
+    maxWeightedTweetLength: characterLimit,
+  });
+
+  if (parsed.weightedLength <= characterLimit) {
+    return { allowedCaption: caption, trimmed: false };
+  }
+
+  return {
+    allowedCaption: caption.slice(0, parsed.validRangeEnd + 1),
+    trimmed: true,
+  };
+}
 
 export class TwitterPostClient extends PostClient {
   #IMAGE_LIMIT = 4;
@@ -102,11 +144,13 @@ export class TwitterPostClient extends PostClient {
         isOAuth2,
       });
 
-      const allowedCaption = caption.slice(
-        0,
-        account.social_provider_metadata?.has_platform_premium
-          ? this.#PREMIUM_CHARACTER_LIMIT
-          : this.#CHARACTER_LIMIT,
+      const characterLimit = account.social_provider_metadata?.has_platform_premium
+        ? this.#PREMIUM_CHARACTER_LIMIT
+        : this.#CHARACTER_LIMIT;
+
+      const { allowedCaption, trimmed } = getAllowedCaption(
+        caption,
+        characterLimit,
       );
 
       const postPayload: SendTweetV2Params = {
@@ -159,7 +203,7 @@ export class TwitterPostClient extends PostClient {
         provider_post_id: tweet.data.id,
         provider_post_url: `https://twitter.com/user/status/${tweet.data.id}`,
         details: {
-          trimmed: caption.length > allowedCaption.length,
+          trimmed,
           requests: this.#requests,
           responses: this.#responses,
         },


### PR DESCRIPTION
## Summary

X (Twitter) posts with CJK characters, emoji, or newlines could get rejected by X's API with a misleading 403. A customer diagnosed the root cause: X counts CJK characters, emoji, and newlines as **2 weighted characters** each, but our caption truncation used plain `.slice()`/`.length`, which only counts UTF-16 code units. A caption that looked under the 280-char limit by JS string length could be far over X's real weighted limit.

## Changes

- `trigger/posting/platforms/twitter-post-client.ts`: extracted a new `getAllowedCaption()` helper that uses `twitter-text`'s `parseTweet()` for weighted-aware truncation, and wired it into `post()`. Also fixed the `details.trimmed` result flag, which compared the same flawed UTF-16-based metric.
  - Truncation binary-searches for the longest Unicode-code-point-safe prefix under the weighted limit, rather than trusting `parseTweet`'s `validRangeEnd`. `validRangeEnd` freezes at the first character `twitter-text` considers "invalid" (e.g. a stray BOM/`U+FEFF`) and never advances again even as the real weighted length keeps growing past the limit — that could collapse a long caption down to just a handful of characters.
  - The v3 weighting config (`TWITTER_TEXT_V3_CONFIG`) is now sourced from `twitter-text`'s runtime `configs.version3` export (not part of its typed public API, but present at runtime) instead of a hand-copied literal, so it tracks whatever version of the package is actually installed instead of silently drifting from it.
- `trigger/package.json`: added `twitter-text` + `@types/twitter-text` (new runtime dependency), and `@types/bun` (dev-only, needed for `bun:test` types). Added a `test` script (`bun test`) — `trigger/` previously had no test runner configured; Bun's built-in one needed no new tooling.
- `.github/workflows/ci.yml`: wired the `trigger` CI job to actually run `bun run test`, alongside its existing lint/typecheck steps.
- `trigger/posting/platforms/twitter-post-client.test.ts`: unit tests for `getAllowedCaption` covering the CJK weighted boundary (140 vs 141 chars), emoji/newline truncation safety (no split surrogate pairs), a plain-ASCII regression case, premium-vs-standard limit selection, empty captions, and the invalid-character (BOM) over-truncation edge case.
- `api/src/social-posts/social-posts.service.ts`: removed the unused `validatePostCaptionLength()` — flat 2200-char limit, zero callers anywhere in the repo, and misleading to leave in place as dead code.

Deliberately out of scope: Bluesky/Threads/Pinterest/Instagram have similar naive `.slice()` truncation, but none of those platforms use weighted counting the way X does, so it's lower priority — worth a separate follow-up if desired. Also not touching the `#PREMIUM_CHARACTER_LIMIT = 2200` constant, even though X's real long-form limit is 25,000 — that's a separate product/tier question.

## Testing

- `cd trigger && bun test` — 7/7 pass.
- `cd trigger && bun run typecheck && bun run lint` — clean.
- `cd api && bun run typecheck` — clean after removing the dead method; confirmed no remaining references via repo-wide grep.
- `bun run build` (trigger.dev dry-run deploy) requires an interactive cloud login not available in this environment — **not run**, should be verified before merge.
- E2E (posting a real CJK caption near the limit through the trigger flow with live X credentials to confirm no 403) — **not run**, deferred to local verification with Twitter credentials per the linked issue.

Closes PFM-570

🤖 Generated with AI
