### PR TITLE
feat(trigger): add timestamps to social post result logs

### DIFF
--- a/trigger/bun.lock
+++ b/trigger/bun.lock
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@eslint/js": "^9.18.0",
         "@trigger.dev/build": "4.4.4",
+        "@types/bun": "^1.4.0",
         "@types/fluent-ffmpeg": "^2.1.27",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.10.7",
@@ -247,6 +248,8 @@
 
     "@trigger.dev/sdk": ["@trigger.dev/sdk@4.4.4", "", { "dependencies": { "@opentelemetry/api": "1.9.0", "@opentelemetry/semantic-conventions": "1.36.0", "@trigger.dev/core": "4.4.4", "chalk": "^5.2.0", "cronstrue": "^2.21.0", "debug": "^4.3.4", "evt": "^2.4.13", "slug": "^6.0.0", "ulid": "^2.3.0", "uncrypto": "^0.1.3", "uuid": "^9.0.0", "ws": "^8.11.0" }, "peerDependencies": { "ai": "^4.2.0 || ^5.0.0 || ^6.0.0", "zod": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["ai"] }, "sha512-X2R1BCZlptxJw2oT6SJAU8bDKO8pgfNIFrNdo7p6XUjW7gha9s1oNZEicL7cmvJF8rO35MO70vO/Wqo8tjQjPQ=="],
 
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
     "@types/cookie": ["@types/cookie@0.4.1", "", {}, "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="],
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
@@ -328,6 +331,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
 

--- a/trigger/package.json
+++ b/trigger/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@trigger.dev/build": "4.4.4",
+    "@types/bun": "^1.4.0",
     "@types/fluent-ffmpeg": "^2.1.27",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.10.7",

--- a/trigger/package.json
+++ b/trigger/package.json
@@ -10,7 +10,8 @@
     "typegen": "bun run supabase:typegen",
     "supabase:typegen": "supabase gen types typescript --local > supabase.types.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
+    "test": "bun test"
   },
   "dependencies": {
     "@atproto/api": "^0.14.20",

--- a/trigger/posting/platforms/bluesky-post-client.ts
+++ b/trigger/posting/platforms/bluesky-post-client.ts
@@ -1,4 +1,5 @@
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import { BlobRef, AtpAgent, RichText, AppBskyVideoDefs } from "@atproto/api";
 import sharp from "sharp";
 import { JSDOM } from "jsdom";
@@ -26,8 +27,8 @@ export class BlueskyPostClient extends PostClient {
   #videoStatusInitialDelayMs = 5000;
   #videoStatusRetryBackoffMultiplier = 1.5;
   #maxRetryDelayMs = 60000;
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
 
   constructor(
     supabaseClient: SupabaseClient,

--- a/trigger/posting/platforms/bluesky-post-client.ts
+++ b/trigger/posting/platforms/bluesky-post-client.ts
@@ -1,5 +1,4 @@
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import { BlobRef, AtpAgent, RichText, AppBskyVideoDefs } from "@atproto/api";
 import sharp from "sharp";
 import { JSDOM } from "jsdom";
@@ -27,8 +26,6 @@ export class BlueskyPostClient extends PostClient {
   #videoStatusInitialDelayMs = 5000;
   #videoStatusRetryBackoffMultiplier = 1.5;
   #maxRetryDelayMs = 60000;
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
 
   constructor(
     supabaseClient: SupabaseClient,
@@ -44,7 +41,7 @@ export class BlueskyPostClient extends PostClient {
     account: SocialAccount,
   ): Promise<RefreshTokenResult> {
     try {
-      this.#requests.push({ refreshRequest: "Resuming Session" });
+      this.requests.push({ refreshRequest: "Resuming Session" });
       await this.#agent.resumeSession({
         accessJwt: account.access_token,
         refreshJwt: account.refresh_token!,
@@ -53,7 +50,7 @@ export class BlueskyPostClient extends PostClient {
         active: true,
       });
 
-      this.#responses.push({ refreshResponse: "Resumed Session" });
+      this.responses.push({ refreshResponse: "Resumed Session" });
       return {
         access_token: account.access_token,
         refresh_token: account.refresh_token,
@@ -66,7 +63,7 @@ export class BlueskyPostClient extends PostClient {
         password: account.social_provider_metadata.bluesky_app_password!,
       });
 
-      this.#responses.push({ refreshResponse: "New Session Created" });
+      this.responses.push({ refreshResponse: "New Session Created" });
       return {
         access_token: this.#agent.session?.accessJwt,
         refresh_token: this.#agent.session?.refreshJwt,
@@ -190,11 +187,11 @@ export class BlueskyPostClient extends PostClient {
         postPayload.embed = embed;
       }
 
-      this.#requests.push({ postRequest: postPayload });
+      this.requests.push({ postRequest: postPayload });
 
       const response = await this.#agent.post(postPayload);
 
-      this.#responses.push({ postResponse: response });
+      this.responses.push({ postResponse: response });
       return {
         post_id: postId,
         provider_connection_id: account.id,
@@ -205,8 +202,8 @@ export class BlueskyPostClient extends PostClient {
         }/post/${response.uri.split("/").pop()}`,
         details: {
           trimmed: caption.length > trimmedCaption.length,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } catch (error) {
@@ -218,8 +215,8 @@ export class BlueskyPostClient extends PostClient {
         error_message: error.message,
         details: {
           error,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     }
@@ -284,7 +281,7 @@ export class BlueskyPostClient extends PostClient {
       uploadUrl.searchParams.append("did", this.#agent.session!.did);
       uploadUrl.searchParams.append("name", remoteName);
 
-      this.#requests.push({ uploadVideoRequest: uploadUrl });
+      this.requests.push({ uploadVideoRequest: uploadUrl });
       const uploadResponse = await fetch(uploadUrl, {
         method: "POST",
         headers: {
@@ -300,7 +297,7 @@ export class BlueskyPostClient extends PostClient {
       await this.unlinkQuiet(inputPath);
     }
 
-    this.#responses.push({ uploadVideoResponse: uploadResponseData });
+    this.responses.push({ uploadVideoResponse: uploadResponseData });
 
     const jobStatus = uploadResponseData as AppBskyVideoDefs.JobStatus;
 
@@ -325,7 +322,7 @@ export class BlueskyPostClient extends PostClient {
         `Checking Bluesky video status, attempt ${attempt}/${this.#videoStatusMaxAttempts}`,
       );
 
-      this.#requests.push({
+      this.requests.push({
         videoStatusRequest: {
           jobId: jobStatus.jobId,
           attempt,
@@ -338,7 +335,7 @@ export class BlueskyPostClient extends PostClient {
 
       lastJobStatus = status.jobStatus;
 
-      this.#responses.push({
+      this.responses.push({
         videoStatusResponse: status.jobStatus,
         attempt,
       });

--- a/trigger/posting/platforms/facebook-post-client.ts
+++ b/trigger/posting/platforms/facebook-post-client.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import fetch from "node-fetch";
 import {
@@ -14,8 +15,8 @@ import { logger, wait } from "@trigger.dev/sdk";
 import FormData from "form-data";
 
 export class FacebookPostClient extends PostClient {
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
   #appCredentials: PlatformAppCredentials;
   #completeStatuses = [
     "error",

--- a/trigger/posting/platforms/facebook-post-client.ts
+++ b/trigger/posting/platforms/facebook-post-client.ts
@@ -1,6 +1,5 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import fetch from "node-fetch";
 import {
@@ -15,8 +14,6 @@ import { logger, wait } from "@trigger.dev/sdk";
 import FormData from "form-data";
 
 export class FacebookPostClient extends PostClient {
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
   #appCredentials: PlatformAppCredentials;
   #completeStatuses = [
     "error",
@@ -44,7 +41,7 @@ export class FacebookPostClient extends PostClient {
         client_secret: this.#appCredentials.app_secret,
         fb_exchange_token: account.access_token,
       };
-      this.#requests.push({
+      this.requests.push({
         refreshRequest: "https://graph.facebook.com/v20.0/oauth/access_token",
         params: refreshParams,
       });
@@ -54,7 +51,7 @@ export class FacebookPostClient extends PostClient {
           params: refreshParams,
         },
       );
-      this.#responses.push({ refreshResponse: response.data });
+      this.responses.push({ refreshResponse: response.data });
 
       if (!response.data.access_token) {
         console.error("Failed to refresh Facebook token", response.data);
@@ -187,7 +184,7 @@ export class FacebookPostClient extends PostClient {
       }
 
       if (!platformUrl) {
-        this.#requests.push({
+        this.requests.push({
           postRequest: {
             url: `https://graph.facebook.com/v20.0/${platformId}`,
             params: {
@@ -207,7 +204,7 @@ export class FacebookPostClient extends PostClient {
           },
         );
 
-        this.#responses.push({ postResponse: postResponse.data });
+        this.responses.push({ postResponse: postResponse.data });
         platformUrl = postResponse.data.permalink_url;
       }
 
@@ -218,8 +215,8 @@ export class FacebookPostClient extends PostClient {
         provider_post_id: platformId,
         provider_post_url: platformUrl ?? "https://www.facebook.com/profile",
         details: {
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } catch (error) {
@@ -233,8 +230,8 @@ export class FacebookPostClient extends PostClient {
         provider_connection_id: account.id,
         details: {
           error,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
         error_message: `Failed to post to Facebook ${
           error.response?.data?.error?.message || error.message
@@ -272,7 +269,7 @@ export class FacebookPostClient extends PostClient {
       postData.link = link;
     }
 
-    this.#requests.push({
+    this.requests.push({
       createTextRequest: {
         url: `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/feed`,
         body: postData,
@@ -284,7 +281,7 @@ export class FacebookPostClient extends PostClient {
       postData,
     );
 
-    this.#responses.push({ createTextResponse: response.data });
+    this.responses.push({ createTextResponse: response.data });
 
     if (response.data.error) {
       throw new Error(`Failed to post: ${response.data.error.message}`);
@@ -332,7 +329,7 @@ export class FacebookPostClient extends PostClient {
       payload.place = platformConfig.location;
     }
 
-    this.#requests.push({
+    this.requests.push({
       photoRequest: {
         url: `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
         data: payload,
@@ -343,7 +340,7 @@ export class FacebookPostClient extends PostClient {
       payload,
     );
 
-    this.#responses.push({ photoResponse: photoResponse.data });
+    this.responses.push({ photoResponse: photoResponse.data });
 
     if (photoResponse.data.error) {
       throw new Error(
@@ -401,7 +398,7 @@ export class FacebookPostClient extends PostClient {
           }));
       }
 
-      this.#requests.push({
+      this.requests.push({
         photoRequest: {
           url: `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
           data: payload,
@@ -412,7 +409,7 @@ export class FacebookPostClient extends PostClient {
         payload,
       );
 
-      this.#responses.push({ photoResponse: photoResponse.data });
+      this.responses.push({ photoResponse: photoResponse.data });
       if (photoResponse.data.error) {
         throw new Error(
           `Failed to upload image: ${photoResponse.data.error.message}`,
@@ -421,7 +418,7 @@ export class FacebookPostClient extends PostClient {
       mediaIds.push({ media_fbid: photoResponse.data.id });
     }
 
-    this.#requests.push({
+    this.requests.push({
       createCarouselPostRequest: {
         url: `https://graph.facebook.com/v20.0/${account.social_provider_user_id}/feed`,
         body: {
@@ -454,7 +451,7 @@ export class FacebookPostClient extends PostClient {
       carouselBody,
     );
 
-    this.#responses.push({ createCarouselPostResponse: response.data });
+    this.responses.push({ createCarouselPostResponse: response.data });
 
     if (response.data.error) {
       throw new Error(
@@ -475,7 +472,7 @@ export class FacebookPostClient extends PostClient {
     medium: PostMedia;
   }): Promise<string> {
     const fileUrl = await this.getSignedUrlForFile(medium);
-    this.#requests.push({
+    this.requests.push({
       videoRequest: {
         url: `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/videos`,
         data: {
@@ -496,7 +493,7 @@ export class FacebookPostClient extends PostClient {
 
     const videoResponseData = videoResponse.data;
 
-    this.#responses.push({ videoResponse: videoResponseData });
+    this.responses.push({ videoResponse: videoResponseData });
 
     if (videoResponseData?.error) {
       console.error(videoResponseData);
@@ -512,7 +509,7 @@ export class FacebookPostClient extends PostClient {
     const maxAttempts = 48;
 
     while (status === "processing" && attempts < maxAttempts) {
-      this.#requests.push({
+      this.requests.push({
         statusRequest: {
           url: `https://graph.facebook.com/${videoResponseData.id}?fields=status`,
         },
@@ -527,7 +524,7 @@ export class FacebookPostClient extends PostClient {
         },
       );
 
-      this.#responses.push({ statusResponse: statusResponse.data });
+      this.responses.push({ statusResponse: statusResponse.data });
 
       status = statusResponse.data?.status?.video_status;
       attempts++;
@@ -736,7 +733,7 @@ export class FacebookPostClient extends PostClient {
       payload.place = platformConfig.location;
     }
 
-    this.#requests.push({
+    this.requests.push({
       photoRequest: {
         url: `https://graph-video.facebook.com/v20.0/${account.social_provider_user_id}/photos`,
         data: payload,
@@ -747,7 +744,7 @@ export class FacebookPostClient extends PostClient {
       payload,
     );
 
-    this.#responses.push({ photoResponse: photoResponse.data });
+    this.responses.push({ photoResponse: photoResponse.data });
     if (photoResponse.data.error) {
       throw new Error(
         `Failed to upload image: ${photoResponse.data.error.message}`,

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -1,7 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import sharp from "sharp";
 import {
@@ -29,8 +28,6 @@ export class InstagramPostClient extends PostClient {
   #postStartedAtMs: number | null = null;
   #localSupabaseClient;
   #addedMedia: any[] = [];
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
   #bucket: string = "post-media";
   #appCredentials: PlatformAppCredentials;
 
@@ -63,7 +60,7 @@ export class InstagramPostClient extends PostClient {
         console.log(
           `Refreshing direct Instagram token (via connection_type) for account: ${account.id}`,
         );
-        this.#requests.push({
+        this.requests.push({
           refreshRequest: "https://graph.instagram.com/refresh_access_token",
           params: {
             grant_type: "ig_refresh_token",
@@ -80,7 +77,7 @@ export class InstagramPostClient extends PostClient {
           },
         );
 
-        this.#responses.push({ refreshResponse: response.data });
+        this.responses.push({ refreshResponse: response.data });
 
         if (response.data && response.data.access_token) {
           const newAccessToken = response.data.access_token;
@@ -106,7 +103,7 @@ export class InstagramPostClient extends PostClient {
           fb_exchange_token: account.access_token,
         };
 
-        this.#requests.push({
+        this.requests.push({
           refreshRequest: "https://graph.facebook.com/v20.0/oauth/access_token",
           params: refreshTokenParams,
         });
@@ -117,7 +114,7 @@ export class InstagramPostClient extends PostClient {
           },
         );
 
-        this.#responses.push({ refreshResponse: response.data });
+        this.responses.push({ refreshResponse: response.data });
 
         if (response.data && response.data.access_token) {
           const newAccessToken = response.data.access_token;
@@ -203,7 +200,7 @@ export class InstagramPostClient extends PostClient {
 
         try {
           console.log(`Publish attempt #${publishAttempts + 1}`);
-          this.#requests.push({
+          this.requests.push({
             publishRequest: {
               creation_id: containerId,
               access_token: account.access_token,
@@ -222,7 +219,7 @@ export class InstagramPostClient extends PostClient {
             );
           }
 
-          this.#responses.push({ publishResponse: publishResponse.data });
+          this.responses.push({ publishResponse: publishResponse.data });
 
           platformId = publishResponse.data.id;
         } catch (error) {
@@ -272,8 +269,8 @@ export class InstagramPostClient extends PostClient {
               ? `Only first ${this.#maxItems} items were posted`
               : null,
           addedMedia: this.#addedMedia,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } catch (error) {
@@ -288,8 +285,8 @@ export class InstagramPostClient extends PostClient {
             "Account needs to be reconnected, Access token has expired",
           details: {
             error,
-            requests: this.#requests,
-            responses: this.#responses,
+            requests: this.requests,
+            responses: this.responses,
           },
         };
       }
@@ -303,8 +300,8 @@ export class InstagramPostClient extends PostClient {
         provider_connection_id: account.id,
         details: {
           error,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } finally {
@@ -555,7 +552,7 @@ export class InstagramPostClient extends PostClient {
       carouselPayload.location_id = platformConfig.location;
     }
 
-    this.#requests.push({
+    this.requests.push({
       createCarouselRequest: carouselPayload,
     });
     const carouselResponse = await axios.post(
@@ -563,7 +560,7 @@ export class InstagramPostClient extends PostClient {
       carouselPayload,
     );
 
-    this.#responses.push({ createCarouselResponse: carouselResponse.data });
+    this.responses.push({ createCarouselResponse: carouselResponse.data });
 
     if (carouselResponse.data.error) {
       throw new Error(
@@ -599,7 +596,7 @@ export class InstagramPostClient extends PostClient {
           `Creating ${mediaLabel}, attempt ${attempt}/${this.#mediaRetryAttempts}`,
         );
 
-        this.#requests.push({
+        this.requests.push({
           [requestLogKey]: payload,
           attempt,
         });
@@ -609,7 +606,7 @@ export class InstagramPostClient extends PostClient {
           payload,
         );
 
-        this.#responses.push({
+        this.responses.push({
           [responseLogKey]: createMediaResponse.data,
           attempt,
         });
@@ -629,7 +626,7 @@ export class InstagramPostClient extends PostClient {
         return containerId;
       } catch (error) {
         if (error?.response?.data) {
-          this.#responses.push({
+          this.responses.push({
             [responseLogKey]: error.response.data,
             attempt,
             failed: true,
@@ -687,7 +684,7 @@ export class InstagramPostClient extends PostClient {
         `Checking ${mediaLabel} status, attempt ${attempt}/${this.#mediaStatusMaxAttempts}`,
       );
 
-      this.#requests.push({
+      this.requests.push({
         statusRequest: {
           url: `${this.getApiBaseUrl(account)}/${containerId}`,
           mediaLabel,
@@ -704,7 +701,7 @@ export class InstagramPostClient extends PostClient {
         },
       );
 
-      this.#responses.push({ statusResponse: statusResponse.data });
+      this.responses.push({ statusResponse: statusResponse.data });
 
       statusData = statusResponse.data;
       console.log(`${mediaLabel} status:`, statusData);
@@ -818,7 +815,7 @@ export class InstagramPostClient extends PostClient {
       }
 
       try {
-        this.#requests.push({
+        this.requests.push({
           getPostUrlRequest: {
             url: `${this.getApiBaseUrl(account)}/${postId}`,
             attempt,
@@ -836,7 +833,7 @@ export class InstagramPostClient extends PostClient {
           },
         );
 
-        this.#responses.push({
+        this.responses.push({
           getPostUrlResponse: mediaResponse.data,
           attempt,
         });
@@ -861,7 +858,7 @@ export class InstagramPostClient extends PostClient {
         }
 
         if (error?.response?.data) {
-          this.#responses.push({
+          this.responses.push({
             getPostUrlResponse: error.response.data,
             attempt,
             failed: true,

--- a/trigger/posting/platforms/instagram-post-client.ts
+++ b/trigger/posting/platforms/instagram-post-client.ts
@@ -1,6 +1,7 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import sharp from "sharp";
 import {
@@ -28,8 +29,8 @@ export class InstagramPostClient extends PostClient {
   #postStartedAtMs: number | null = null;
   #localSupabaseClient;
   #addedMedia: any[] = [];
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
   #bucket: string = "post-media";
   #appCredentials: PlatformAppCredentials;
 

--- a/trigger/posting/platforms/linkedin-post-client.ts
+++ b/trigger/posting/platforms/linkedin-post-client.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import {
   LinkedinConfiguration,
   PlatformAppCredentials,
@@ -13,8 +14,8 @@ export class LinkedInPostClient extends PostClient {
   #clientId: string;
   #clientSecret: string;
   #maxImages = 20;
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
 
   constructor(
     supabaseClient: SupabaseClient,

--- a/trigger/posting/platforms/linkedin-post-client.ts
+++ b/trigger/posting/platforms/linkedin-post-client.ts
@@ -1,6 +1,5 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import {
   LinkedinConfiguration,
   PlatformAppCredentials,
@@ -14,8 +13,6 @@ export class LinkedInPostClient extends PostClient {
   #clientId: string;
   #clientSecret: string;
   #maxImages = 20;
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
 
   constructor(
     supabaseClient: SupabaseClient,
@@ -30,7 +27,7 @@ export class LinkedInPostClient extends PostClient {
     account: SocialAccount,
   ): Promise<RefreshTokenResult> {
     const tokenUrl = "https://www.linkedin.com/oauth/v2/accessToken";
-    this.#requests.push({ refreshRequest: tokenUrl });
+    this.requests.push({ refreshRequest: tokenUrl });
     const response = await fetch(tokenUrl, {
       method: "POST",
       headers: {
@@ -46,7 +43,7 @@ export class LinkedInPostClient extends PostClient {
 
     const data = await response.json();
 
-    this.#responses.push({ refreshResponse: data });
+    this.responses.push({ refreshResponse: data });
 
     if (!response.ok) {
       throw new Error(
@@ -125,7 +122,7 @@ export class LinkedInPostClient extends PostClient {
         }
       }
 
-      this.#requests.push({ postRequest: postBody });
+      this.requests.push({ postRequest: postBody });
       const response = await fetch(`https://api.linkedin.com/v2/ugcPosts`, {
         method: "POST",
         headers: {
@@ -147,7 +144,7 @@ export class LinkedInPostClient extends PostClient {
       const providerPostId =
         result.id || response.headers.get("x-restli-id") || undefined;
 
-      this.#responses.push({ postResponse: result });
+      this.responses.push({ postResponse: result });
       return {
         success: true,
         provider_connection_id: account.id,
@@ -157,8 +154,8 @@ export class LinkedInPostClient extends PostClient {
           ? `https://www.linkedin.com/feed/update/${providerPostId}`
           : undefined,
         details: {
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } catch (error) {
@@ -173,8 +170,8 @@ export class LinkedInPostClient extends PostClient {
         error_message: `Failed to post to LinkedIn: ${error.message}`,
         details: {
           error,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     }
@@ -213,7 +210,7 @@ export class LinkedInPostClient extends PostClient {
   }): Promise<any> {
     const isVideo = medium.type === "video";
 
-    this.#requests.push({
+    this.requests.push({
       registerRequest: {
         registerUploadRequest: {
           recipes: [
@@ -261,7 +258,7 @@ export class LinkedInPostClient extends PostClient {
 
     const registerData = await registerResponse.json();
 
-    this.#responses.push({ registerResponse: registerData });
+    this.responses.push({ registerResponse: registerData });
 
     const uploadUrl =
       registerData.value.uploadMechanism[
@@ -300,7 +297,7 @@ export class LinkedInPostClient extends PostClient {
       );
     }
 
-    this.#responses.push({ uploadResponse: uploadResponse.status });
+    this.responses.push({ uploadResponse: uploadResponse.status });
 
     const mediaObject: any = {
       status: "READY",
@@ -344,7 +341,7 @@ export class LinkedInPostClient extends PostClient {
         mediaCategory = "IMAGE";
         for (let i = 0; i < allowedMedia.length; i++) {
           const medium = allowedMedia[i];
-          this.#requests.push({ processMedia: medium });
+          this.requests.push({ processMedia: medium });
           uploadedMedia.push(
             await this.#createMedia({
               medium,

--- a/trigger/posting/platforms/pinterest-post-client.ts
+++ b/trigger/posting/platforms/pinterest-post-client.ts
@@ -1,5 +1,4 @@
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import FormData from "form-data";
 import { wait } from "@trigger.dev/sdk";
@@ -14,8 +13,6 @@ import {
 import { SupabaseClient } from "@supabase/supabase-js";
 
 export class PinterestPostClient extends PostClient {
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
   #appCredentials: PlatformAppCredentials;
   constructor(
     supabaseClient: SupabaseClient,
@@ -43,7 +40,7 @@ export class PinterestPostClient extends PostClient {
       requestUrl = "https://api-sandbox.pinterest.com/v5/oauth/token";
     }
 
-    this.#requests.push({
+    this.requests.push({
       refreshRequest: requestUrl,
       params,
     });
@@ -55,7 +52,7 @@ export class PinterestPostClient extends PostClient {
       },
     });
 
-    this.#responses.push({ refreshResponse: refreshResponse.data });
+    this.responses.push({ refreshResponse: refreshResponse.data });
 
     const { access_token, expires_in, refresh_token } = refreshResponse.data;
     const newExpirationDate = new Date(Date.now() + expires_in * 1000);
@@ -117,7 +114,7 @@ export class PinterestPostClient extends PostClient {
         media_source: mediaSource,
       };
 
-      this.#requests.push({ postRequest: pinData });
+      this.requests.push({ postRequest: pinData });
 
       let publishUrl = "https://api.pinterest.com/v5/pins";
       if (account.social_provider_metadata?.is_sandbox) {
@@ -131,7 +128,7 @@ export class PinterestPostClient extends PostClient {
         },
       });
 
-      this.#responses.push({ postResponse: response.data });
+      this.responses.push({ postResponse: response.data });
 
       return {
         success: true,
@@ -140,8 +137,8 @@ export class PinterestPostClient extends PostClient {
         provider_post_id: response.data.id,
         provider_post_url: `https://pinterest.com/pin/${response.data.id}`,
         details: {
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } catch (error) {
@@ -154,8 +151,8 @@ export class PinterestPostClient extends PostClient {
         error_message: "Failed to post to Pinterest",
         details: {
           error: error.response?.data || error.message,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     }
@@ -167,7 +164,7 @@ export class PinterestPostClient extends PostClient {
       boardsUrl = "https://api-sandbox.pinterest.com/v5/boards";
     }
 
-    this.#requests.push({
+    this.requests.push({
       getBoardsRequest: boardsUrl,
     });
     const boardsResponse = await axios.get(boardsUrl, {
@@ -176,7 +173,7 @@ export class PinterestPostClient extends PostClient {
         "Content-Type": "application/json",
       },
     });
-    this.#responses.push({ getBoardsResponse: boardsResponse.data });
+    this.responses.push({ getBoardsResponse: boardsResponse.data });
 
     if (boardsResponse.data.items && boardsResponse.data.items.length > 0) {
       return boardsResponse.data.items[0].id;
@@ -186,7 +183,7 @@ export class PinterestPostClient extends PostClient {
       name: "Post For Me",
       description: "Posts from Post For Me",
     };
-    this.#requests.push({
+    this.requests.push({
       createBoardRequest: {
         url: boardsUrl,
         params: createBoardParams,
@@ -199,7 +196,7 @@ export class PinterestPostClient extends PostClient {
       },
     });
 
-    this.#responses.push({ createBoardResponse: createBoardResponse.data });
+    this.responses.push({ createBoardResponse: createBoardResponse.data });
 
     return createBoardResponse.data.id;
   }
@@ -218,7 +215,7 @@ export class PinterestPostClient extends PostClient {
       mediaUrl = "https://api-sandbox.pinterest.com/v5/media";
     }
 
-    this.#requests.push({
+    this.requests.push({
       registerMediaRequest: mediaUrl,
     });
     // Step 1: Register media with Pinterest
@@ -235,7 +232,7 @@ export class PinterestPostClient extends PostClient {
       },
     );
 
-    this.#responses.push({ registerMediaResponse: registerMediaResponse.data });
+    this.responses.push({ registerMediaResponse: registerMediaResponse.data });
 
     const mediaId = registerMediaResponse.data.media_id;
     const { upload_url, upload_parameters } = registerMediaResponse.data;
@@ -276,7 +273,7 @@ export class PinterestPostClient extends PostClient {
         : {}),
     });
 
-    this.#requests.push({ uploadRequest: { file: medium } });
+    this.requests.push({ uploadRequest: { file: medium } });
 
     const headers: Record<string, string> = {
       ...(form.getHeaders() as Record<string, string>),
@@ -301,7 +298,7 @@ export class PinterestPostClient extends PostClient {
       maxBodyLength: Infinity,
     });
 
-    this.#responses.push({ uploadResponse: uploadResponse.status });
+    this.responses.push({ uploadResponse: uploadResponse.status });
 
     if (uploadResponse.status !== 204) {
       throw new Error(`Upload failed with status: ${uploadResponse.status}`);
@@ -314,7 +311,7 @@ export class PinterestPostClient extends PostClient {
     let delay = 4000;
 
     while (attempts < maxAttempts) {
-      this.#requests.push({
+      this.requests.push({
         checkMediaStatusRequest: `${mediaUrl}/${mediaId}`,
       });
       const statusResponse = await axios.get(`${mediaUrl}/${mediaId}`, {
@@ -323,7 +320,7 @@ export class PinterestPostClient extends PostClient {
         },
       });
 
-      this.#responses.push({ checkMediaStatusResponse: statusResponse.data });
+      this.responses.push({ checkMediaStatusResponse: statusResponse.data });
 
       mediaStatus = statusResponse.data.status;
 

--- a/trigger/posting/platforms/pinterest-post-client.ts
+++ b/trigger/posting/platforms/pinterest-post-client.ts
@@ -1,4 +1,5 @@
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import FormData from "form-data";
 import { wait } from "@trigger.dev/sdk";
@@ -13,8 +14,8 @@ import {
 import { SupabaseClient } from "@supabase/supabase-js";
 
 export class PinterestPostClient extends PostClient {
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
   #appCredentials: PlatformAppCredentials;
   constructor(
     supabaseClient: SupabaseClient,

--- a/trigger/posting/platforms/threads-post-client.ts
+++ b/trigger/posting/platforms/threads-post-client.ts
@@ -1,5 +1,4 @@
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import axios, { AxiosResponse } from "axios";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
@@ -32,8 +31,6 @@ interface ThreadsPostParams {
 export class ThreadsPostClient extends PostClient {
   #maxItems = 4;
   #containerUrl = "https://graph.threads.net/v1.0/me/threads";
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
 
   constructor(
     supabaseClient: SupabaseClient,
@@ -45,7 +42,7 @@ export class ThreadsPostClient extends PostClient {
   async refreshAccessToken(
     account: SocialAccount,
   ): Promise<TokenRefreshResult> {
-    this.#requests.push({
+    this.requests.push({
       refreshRequest: "https://graph.threads.net/refresh_access_token",
     });
 
@@ -59,7 +56,7 @@ export class ThreadsPostClient extends PostClient {
       },
     });
 
-    this.#responses.push({ refreshResponse: refreshResponse.data });
+    this.responses.push({ refreshResponse: refreshResponse.data });
 
     const { access_token, expires_in } = refreshResponse.data;
     const newExpirationDate = new Date(Date.now() + expires_in * 1000);
@@ -118,7 +115,7 @@ export class ThreadsPostClient extends PostClient {
       while (!platformId && publishAttempts < maxPublishAttempts) {
         try {
           console.log(`Publish attempt #${publishAttempts + 1}`);
-          this.#requests.push({
+          this.requests.push({
             postRequest: {
               url: `https://graph.threads.net/v1.0/me/threads_publish`,
               params: {
@@ -140,7 +137,7 @@ export class ThreadsPostClient extends PostClient {
               },
             );
 
-          this.#responses.push({ publishResponse: publishResponse.data });
+          this.responses.push({ publishResponse: publishResponse.data });
 
           platformId = publishResponse.data.id;
         } catch (error: any) {
@@ -173,8 +170,8 @@ export class ThreadsPostClient extends PostClient {
         provider_post_id: platformId,
         provider_post_url: platformUrl,
         details: {
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } catch (error: any) {
@@ -189,8 +186,8 @@ export class ThreadsPostClient extends PostClient {
           error_message: "Account needs to be reconnected",
           details: {
             error,
-            requests: this.#requests,
-            responses: this.#responses,
+            requests: this.requests,
+            responses: this.responses,
           },
         };
       }
@@ -202,8 +199,8 @@ export class ThreadsPostClient extends PostClient {
         error_message: "Failed to post to Threads",
         details: {
           error: error.response?.data || error.message,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     }
@@ -213,7 +210,7 @@ export class ThreadsPostClient extends PostClient {
     account: SocialAccount,
     caption: string,
   ): Promise<string | null> {
-    this.#requests.push({
+    this.requests.push({
       createContainerRequest: {
         url: this.#containerUrl,
         params: {
@@ -237,7 +234,7 @@ export class ThreadsPostClient extends PostClient {
         },
       );
 
-    this.#responses.push({
+    this.responses.push({
       createContainerResponse: createContainerResponse.data,
     });
 
@@ -259,7 +256,7 @@ export class ThreadsPostClient extends PostClient {
     const signedUrl = await this.getSignedUrlForFile(medium);
     const isVideo = medium.type === "video";
 
-    this.#requests.push({
+    this.requests.push({
       createContainerRequest: {
         url: this.#containerUrl,
         params: {
@@ -295,7 +292,7 @@ export class ThreadsPostClient extends PostClient {
         },
       );
 
-    this.#responses.push({
+    this.responses.push({
       createContainerResponse: createContainerResponse.data,
     });
 
@@ -308,7 +305,7 @@ export class ThreadsPostClient extends PostClient {
 
     while (attempts < maxStatusChecks) {
       try {
-        this.#requests.push({
+        this.requests.push({
           checkContainerStatusRequest: {
             url: `https://graph.threads.net/v1.0/${containerId}`,
             params: {
@@ -326,7 +323,7 @@ export class ThreadsPostClient extends PostClient {
             },
           });
 
-        this.#responses.push({
+        this.responses.push({
           checkContainerStatusResponse: statusResponse.data,
         });
 
@@ -377,7 +374,7 @@ export class ThreadsPostClient extends PostClient {
       const signedUrl = await this.getSignedUrlForFile(medium);
       const isVideo = medium.type === "video";
 
-      this.#requests.push({
+      this.requests.push({
         carouselItemRequest: {
           url: this.#containerUrl,
           params: {
@@ -403,7 +400,7 @@ export class ThreadsPostClient extends PostClient {
         },
       );
 
-      this.#responses.push({
+      this.responses.push({
         carouselItemResponse: itemResponse.data,
       });
 
@@ -414,7 +411,7 @@ export class ThreadsPostClient extends PostClient {
       await wait.for({ seconds: 2 });
     }
 
-    this.#requests.push({
+    this.requests.push({
       createCarouselRequest: {
         url: this.#containerUrl,
         params: {
@@ -440,7 +437,7 @@ export class ThreadsPostClient extends PostClient {
       },
     );
 
-    this.#responses.push({
+    this.responses.push({
       createCarouselResponse: carouselResponse.data,
     });
 
@@ -454,7 +451,7 @@ export class ThreadsPostClient extends PostClient {
 
   async #getPostUrl(account: SocialAccount, postId: string): Promise<string> {
     // After successful publish, fetch the media object to get the permalink
-    this.#requests.push({
+    this.requests.push({
       getPostUrlRequest: { url: `https://graph.threads.net/v1.0/${postId}` },
     });
 
@@ -468,7 +465,7 @@ export class ThreadsPostClient extends PostClient {
       },
     });
 
-    this.#responses.push({ getPostUrlResponse: mediaResponse.data });
+    this.responses.push({ getPostUrlResponse: mediaResponse.data });
 
     if (mediaResponse.data.error) {
       throw new Error(

--- a/trigger/posting/platforms/threads-post-client.ts
+++ b/trigger/posting/platforms/threads-post-client.ts
@@ -1,4 +1,5 @@
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import axios, { AxiosResponse } from "axios";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
@@ -31,8 +32,8 @@ interface ThreadsPostParams {
 export class ThreadsPostClient extends PostClient {
   #maxItems = 4;
   #containerUrl = "https://graph.threads.net/v1.0/me/threads";
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
 
   constructor(
     supabaseClient: SupabaseClient,

--- a/trigger/posting/platforms/tiktok-post-client.ts
+++ b/trigger/posting/platforms/tiktok-post-client.ts
@@ -2,6 +2,7 @@ import { createReadStream } from "fs";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import sharp from "sharp";
 import {
@@ -38,8 +39,8 @@ export class TikTokPostClient extends PostClient {
     { ratio: 16 / 9, width: 1920, height: 1080 },
   ];
   #addedMedia: any[] = [];
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
   #bucket: string = "post-media";
 
   constructor(

--- a/trigger/posting/platforms/tiktok-post-client.ts
+++ b/trigger/posting/platforms/tiktok-post-client.ts
@@ -2,7 +2,6 @@ import { createReadStream } from "fs";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import sharp from "sharp";
 import {
@@ -39,8 +38,6 @@ export class TikTokPostClient extends PostClient {
     { ratio: 16 / 9, width: 1920, height: 1080 },
   ];
   #addedMedia: any[] = [];
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
   #bucket: string = "post-media";
 
   constructor(
@@ -64,7 +61,7 @@ export class TikTokPostClient extends PostClient {
     formData.append("grant_type", "refresh_token");
     formData.append("refresh_token", account.refresh_token!);
 
-    this.#requests.push({ refreshRequest: { url: this.#tokenUrl } });
+    this.requests.push({ refreshRequest: { url: this.#tokenUrl } });
     const refreshResponse = await axios.post(this.#tokenUrl, formData, {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -72,7 +69,7 @@ export class TikTokPostClient extends PostClient {
       },
     });
 
-    this.#responses.push({ refreshResponse: refreshResponse.data });
+    this.responses.push({ refreshResponse: refreshResponse.data });
 
     if (refreshResponse.data.error) {
       throw new Error(
@@ -159,8 +156,8 @@ export class TikTokPostClient extends PostClient {
             message:
               "Content saved as draft in TikTok. Check your TikTok inbox notifications to continue editing and publish.",
             addedMedia: this.#addedMedia,
-            requests: this.#requests,
-            responses: this.#responses,
+            requests: this.requests,
+            responses: this.responses,
             username: creatorInfoResponse.data.data.creator_username,
             publish_id: publishId,
           },
@@ -185,8 +182,8 @@ export class TikTokPostClient extends PostClient {
             message:
               "Still Proccessing, check TikTok account to confirm status",
             addedMedia: this.#addedMedia,
-            requests: this.#requests,
-            responses: this.#responses,
+            requests: this.requests,
+            responses: this.responses,
             username: creatorInfoResponse.data.data.creator_username,
             publish_id: publishId,
           },
@@ -203,8 +200,8 @@ export class TikTokPostClient extends PostClient {
         details: {
           status: "Published successfully",
           addedMedia: this.#addedMedia,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
           username: creatorInfoResponse.data.data.creator_username,
           publish_id: publishId,
         },
@@ -221,15 +218,15 @@ export class TikTokPostClient extends PostClient {
         error_message: "Failed to post to TikTok",
         details: {
           error: errorDetails,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     }
   }
 
   async #getCreatorInfo(account: SocialAccount) {
-    this.#requests.push({
+    this.requests.push({
       creatorRequest:
         "https://open.tiktokapis.com/v2/post/publish/creator_info/query/",
     });
@@ -245,7 +242,7 @@ export class TikTokPostClient extends PostClient {
       },
     );
 
-    this.#responses.push({ creatorResponse: response.data });
+    this.responses.push({ creatorResponse: response.data });
 
     return response;
   }
@@ -276,7 +273,7 @@ export class TikTokPostClient extends PostClient {
           publicPostIdAttempts < maxPublicPostIdAttempts)) &&
       attempts < maxAttempts
     ) {
-      this.#requests.push({
+      this.requests.push({
         statusRequest: {
           url: "https://open.tiktokapis.com/v2/post/publish/status/fetch/",
           params: {
@@ -302,7 +299,7 @@ export class TikTokPostClient extends PostClient {
         statusResponse.data,
       );
 
-      this.#responses.push({ statusResponse: parsedStatusResponse.data });
+      this.responses.push({ statusResponse: parsedStatusResponse.data });
 
       status = parsedStatusResponse.data.data.status;
       failReason = parsedStatusResponse.data.data.fail_reason;
@@ -389,7 +386,7 @@ export class TikTokPostClient extends PostClient {
     payload: any;
     account: SocialAccount;
   }): Promise<{ publishId: string; uploadUrl?: string }> {
-    this.#requests.push({
+    this.requests.push({
       publishIdRequest: {
         postUrl: postUrl,
         payload: payload,
@@ -403,7 +400,7 @@ export class TikTokPostClient extends PostClient {
       },
     });
 
-    this.#responses.push({
+    this.responses.push({
       publishIdResponse: initResponse.data,
     });
 
@@ -498,7 +495,7 @@ export class TikTokPostClient extends PostClient {
       const end = isLastChunk ? size - 1 : start + chunkSize - 1;
       const contentRange = `bytes ${start}-${end}/${size}`;
 
-      this.#requests.push({
+      this.requests.push({
         videoUploadRequest: { chunkIndex, totalChunkCount, contentRange },
       });
 
@@ -516,7 +513,7 @@ export class TikTokPostClient extends PostClient {
         },
       );
 
-      this.#responses.push({
+      this.responses.push({
         videoUploadResponse: { chunkIndex, status: uploadResponse.status },
       });
     }

--- a/trigger/posting/platforms/tiktok_business-post-client.ts
+++ b/trigger/posting/platforms/tiktok_business-post-client.ts
@@ -1,7 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import sharp from "sharp";
 import {
@@ -39,8 +38,6 @@ export class TikTokBusinessPostClient extends PostClient {
     { ratio: 16 / 9, width: 1920, height: 1080 },
   ];
   #addedMedia: any[] = [];
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
   #bucket: string = "post-media";
   #maxRequestRetries = 3;
   #requestRetryInitialDelayMs = 2000;
@@ -71,7 +68,7 @@ export class TikTokBusinessPostClient extends PostClient {
     const refreshData = await this.#withTikTokRetry({
       operation: "refreshing business access token",
       run: async (attempt) => {
-        this.#requests.push({
+        this.requests.push({
           refreshRequest: { url: this.#tokenUrl },
           attempt,
         });
@@ -86,7 +83,7 @@ export class TikTokBusinessPostClient extends PostClient {
           },
         );
 
-        this.#responses.push({ refreshResponse: refreshResponse.data, attempt });
+        this.responses.push({ refreshResponse: refreshResponse.data, attempt });
 
         if (refreshResponse.data.code !== 0) {
           const refreshError = new Error(
@@ -180,8 +177,8 @@ export class TikTokBusinessPostClient extends PostClient {
             message:
               "Content saved as draft in TikTok. Check your TikTok inbox notifications to continue editing and publish.",
             addedMedia: this.#addedMedia,
-            requests: this.#requests,
-            responses: this.#responses,
+            requests: this.requests,
+            responses: this.responses,
             username: creatorInfoResponse.data.data.username,
             publish_id: publishId,
           },
@@ -205,8 +202,8 @@ export class TikTokBusinessPostClient extends PostClient {
             status: "Processing",
             message: "Still Proccessing, check TikTok account to confirm status",
             addedMedia: this.#addedMedia,
-            requests: this.#requests,
-            responses: this.#responses,
+            requests: this.requests,
+            responses: this.responses,
             username: creatorInfoResponse.data.data.username,
             publish_id: publishId,
           },
@@ -223,8 +220,8 @@ export class TikTokBusinessPostClient extends PostClient {
         details: {
           status: "Published successfully",
           addedMedia: this.#addedMedia,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
           username: creatorInfoResponse.data.data.username,
           publish_id: publishId,
         },
@@ -241,8 +238,8 @@ export class TikTokBusinessPostClient extends PostClient {
         error_message: "Failed to post to TikTok",
         details: {
           error: errorDetails,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     }
@@ -255,7 +252,7 @@ export class TikTokBusinessPostClient extends PostClient {
     return await this.#withTikTokRetry({
       operation: "fetching business creator info",
       run: async (attempt) => {
-        this.#requests.push({
+        this.requests.push({
           creatorRequest: creatorInfoUrl,
           attempt,
         });
@@ -269,7 +266,7 @@ export class TikTokBusinessPostClient extends PostClient {
           },
         );
 
-        this.#responses.push({ creatorResponse: response.data, attempt });
+        this.responses.push({ creatorResponse: response.data, attempt });
 
         if (response.data.code !== 0) {
           const creatorInfoError = new Error(
@@ -318,7 +315,7 @@ export class TikTokBusinessPostClient extends PostClient {
       const parsedStatusResponse = await this.#withTikTokRetry({
         operation: "fetching publish status",
         run: async (requestAttempt) => {
-          this.#requests.push({
+          this.requests.push({
             statusRequest: {
               url: statusUrl,
               params: {
@@ -341,7 +338,7 @@ export class TikTokBusinessPostClient extends PostClient {
 
           const parsedResponse = JSON.parse(statusResponse.data);
 
-          this.#responses.push({
+          this.responses.push({
             statusResponse: parsedResponse,
             attempt: attempts + 1,
             requestAttempt,
@@ -439,7 +436,7 @@ export class TikTokBusinessPostClient extends PostClient {
     return await this.#withTikTokRetry({
       operation: "publishing media",
       run: async (attempt) => {
-        this.#requests.push({
+        this.requests.push({
           publishIdRequest: {
             postUrl: postUrl,
             payload: payload,
@@ -454,7 +451,7 @@ export class TikTokBusinessPostClient extends PostClient {
           },
         });
 
-        this.#responses.push({
+        this.responses.push({
           publishIdResponse: initResponse.data,
           attempt,
         });

--- a/trigger/posting/platforms/tiktok_business-post-client.ts
+++ b/trigger/posting/platforms/tiktok_business-post-client.ts
@@ -1,6 +1,7 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { wait } from "@trigger.dev/sdk";
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import axios from "axios";
 import sharp from "sharp";
 import {
@@ -38,8 +39,8 @@ export class TikTokBusinessPostClient extends PostClient {
     { ratio: 16 / 9, width: 1920, height: 1080 },
   ];
   #addedMedia: any[] = [];
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
   #bucket: string = "post-media";
   #maxRequestRetries = 3;
   #requestRetryInitialDelayMs = 2000;

--- a/trigger/posting/platforms/twitter-post-client.ts
+++ b/trigger/posting/platforms/twitter-post-client.ts
@@ -1,4 +1,5 @@
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import {
   EUploadMimeType,
   SendTweetV2Params,
@@ -23,8 +24,8 @@ export class TwitterPostClient extends PostClient {
   #CHARACTER_LIMIT = 280;
   #appKey;
   #appSecret;
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
   #maxFileSize = 5 * 1024 * 1024;
   #uploadChunkSize = 5 * 1024 * 1024;
 

--- a/trigger/posting/platforms/twitter-post-client.ts
+++ b/trigger/posting/platforms/twitter-post-client.ts
@@ -1,5 +1,4 @@
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import {
   EUploadMimeType,
   SendTweetV2Params,
@@ -24,8 +23,6 @@ export class TwitterPostClient extends PostClient {
   #CHARACTER_LIMIT = 280;
   #appKey;
   #appSecret;
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
   #maxFileSize = 5 * 1024 * 1024;
   #uploadChunkSize = 5 * 1024 * 1024;
 
@@ -143,13 +140,13 @@ export class TwitterPostClient extends PostClient {
         postPayload.quote_tweet_id = platformConfig.quote_tweet_id;
       }
 
-      this.#requests.push({
+      this.requests.push({
         postRequest: postPayload,
       });
 
       const tweet = await twitterClient.v2.tweet(postPayload);
 
-      this.#responses.push({
+      this.responses.push({
         postResponse: tweet,
       });
 
@@ -161,8 +158,8 @@ export class TwitterPostClient extends PostClient {
         provider_post_url: `https://twitter.com/user/status/${tweet.data.id}`,
         details: {
           trimmed: caption.length > allowedCaption.length,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } catch (error) {
@@ -183,8 +180,8 @@ export class TwitterPostClient extends PostClient {
         error_message: `Failed to post to Twitter: ${error.message}`,
         details: {
           error,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     }
@@ -202,7 +199,7 @@ export class TwitterPostClient extends PostClient {
     const mediaIds: string[] = [];
     if (media.length == 1) {
       const medium = media[0];
-      this.#requests.push({ uploadRequest: { file: medium } });
+      this.requests.push({ uploadRequest: { file: medium } });
       const isVideo = medium.type === "video";
 
       let mediaId: string;
@@ -232,7 +229,7 @@ export class TwitterPostClient extends PostClient {
         });
       }
 
-      this.#responses.push({ uploadResponse: { mediaId } });
+      this.responses.push({ uploadResponse: { mediaId } });
       mediaIds.push(mediaId);
       // Add a small delay after successful upload
       await wait.for({ seconds: 1 });
@@ -240,7 +237,7 @@ export class TwitterPostClient extends PostClient {
       const allowedMedia = media.slice(0, this.#IMAGE_LIMIT);
       for (const medium of allowedMedia) {
         if (medium.type === "video") continue;
-        this.#requests.push({ uploadRequest: { file: medium } });
+        this.requests.push({ uploadRequest: { file: medium } });
         const file = await this.getFile(medium);
         const buffer = Buffer.from(await file.arrayBuffer());
 
@@ -251,7 +248,7 @@ export class TwitterPostClient extends PostClient {
           isOAuth2,
         });
 
-        this.#responses.push({ uploadResponse: { mediaId } });
+        this.responses.push({ uploadResponse: { mediaId } });
         mediaIds.push(mediaId);
       }
       // Add a small delay after uploads

--- a/trigger/posting/platforms/youtube-post-client.ts
+++ b/trigger/posting/platforms/youtube-post-client.ts
@@ -1,5 +1,4 @@
 import { PostClient } from "../post-client";
-import { TimestampedArray } from "../timestamped-array";
 import { google, youtube_v3 } from "googleapis";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { logger, wait } from "@trigger.dev/sdk";
@@ -22,8 +21,6 @@ export class YouTubePostClient extends PostClient {
   #oauth2Client: any;
   #googleClientId: string;
   #googleClientSecret: string;
-  #requests: TimestampedArray = new TimestampedArray();
-  #responses: TimestampedArray = new TimestampedArray();
 
   // Must be a multiple of 256KB per YouTube resumable upload guidance.
   static readonly DEFAULT_CHUNK_SIZE_BYTES = 8 * 1024 * 1024; // 8MB
@@ -47,7 +44,7 @@ export class YouTubePostClient extends PostClient {
   async refreshAccessToken(
     account: SocialAccount,
   ): Promise<RefreshTokenResult> {
-    this.#requests.push({ refreshRequest: "refreshing access token" });
+    this.requests.push({ refreshRequest: "refreshing access token" });
     this.#oauth2Client = new google.auth.OAuth2(
       this.#googleClientId,
       this.#googleClientSecret,
@@ -62,7 +59,7 @@ export class YouTubePostClient extends PostClient {
 
     const { credentials } = await this.#oauth2Client.refreshAccessToken();
 
-    this.#responses.push({
+    this.responses.push({
       refreshResponse: {
         scope: credentials.scope,
         token_type: credentials.token_type,
@@ -168,7 +165,7 @@ export class YouTubePostClient extends PostClient {
         },
       };
 
-      this.#requests.push({
+      this.requests.push({
         postRequest: {
           ...videoRequest,
           media: medium,
@@ -202,7 +199,7 @@ export class YouTubePostClient extends PostClient {
         chunkSizeBytes: YouTubePostClient.DEFAULT_CHUNK_SIZE_BYTES,
       });
 
-      this.#responses.push({ postResponse: uploadedVideo });
+      this.responses.push({ postResponse: uploadedVideo });
 
       const videoId = uploadedVideo.id!;
       const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
@@ -232,8 +229,8 @@ export class YouTubePostClient extends PostClient {
           provider_post_url: videoUrl,
           error_message: processingResult.message,
           details: {
-            requests: this.#requests,
-            responses: this.#responses,
+            requests: this.requests,
+            responses: this.responses,
           },
         };
       }
@@ -246,8 +243,8 @@ export class YouTubePostClient extends PostClient {
         provider_post_url: videoUrl,
         details: {
           message: processingResult.message,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } catch (error: any) {
@@ -263,8 +260,8 @@ export class YouTubePostClient extends PostClient {
         error_message: `Failed to post to Youtube: ${error.message}`,
         details: {
           error: error?.response?.data || error,
-          requests: this.#requests,
-          responses: this.#responses,
+          requests: this.requests,
+          responses: this.responses,
         },
       };
     } finally {
@@ -286,7 +283,7 @@ export class YouTubePostClient extends PostClient {
       const pollRequest = {
         processingStatusPollRequest: { videoId, attempt },
       };
-      this.#requests.push(pollRequest);
+      this.requests.push(pollRequest);
       console.log(
         `Polling YouTube processing status for video ${videoId} (attempt ${attempt}/${YouTubePostClient.MAX_PROCESSING_POLL_ATTEMPTS})`,
       );
@@ -300,7 +297,7 @@ export class YouTubePostClient extends PostClient {
       const processingDetails = video?.processingDetails;
       const processingStatus = processingDetails?.processingStatus;
 
-      this.#responses.push({
+      this.responses.push({
         processingStatusPollResponse: {
           attempt,
           videoId,
@@ -339,7 +336,7 @@ export class YouTubePostClient extends PostClient {
         console.log(
           `Video ${videoId} still processing (status: ${processingStatus}); waiting ${waitMs}ms before next poll`,
         );
-        this.#responses.push({
+        this.responses.push({
           processingStatusPollWait: { attempt, processingStatus, waitMs },
         });
         await this.#sleep(waitMs);
@@ -397,7 +394,7 @@ export class YouTubePostClient extends PostClient {
       );
     }
 
-    this.#responses.push({
+    this.responses.push({
       resumableSession: {
         status: res.status,
         location,
@@ -483,7 +480,7 @@ export class YouTubePostClient extends PostClient {
           tempPath,
         });
 
-        this.#responses.push({
+        this.responses.push({
           mediaStagedForYoutube: {
             attempt,
             size: stat.size,
@@ -504,7 +501,7 @@ export class YouTubePostClient extends PostClient {
           YouTubePostClient.MEDIA_DOWNLOAD_INITIAL_RETRY_DELAY_MS *
             2 ** (attempt - 1),
         );
-        this.#responses.push({
+        this.responses.push({
           mediaStageRetry: {
             attempt,
             maxAttempts: YouTubePostClient.MAX_MEDIA_DOWNLOAD_ATTEMPTS,
@@ -630,7 +627,7 @@ export class YouTubePostClient extends PostClient {
 
               nextStart = lastByte + 1;
 
-              this.#responses.push({
+              this.responses.push({
                 resumableChunk: {
                   status: res.status,
                   contentRange,
@@ -662,7 +659,7 @@ export class YouTubePostClient extends PostClient {
                 );
               }
 
-              this.#responses.push({
+              this.responses.push({
                 resumableComplete: {
                   status: res.status,
                   contentRange,
@@ -711,7 +708,7 @@ export class YouTubePostClient extends PostClient {
           }
 
           const waitMs = Math.min(30_000, 1_000 * 2 ** (attempt - 1));
-          this.#responses.push({
+          this.responses.push({
             resumableChunkRetry: {
               attempt,
               maxAttempts: YouTubePostClient.MAX_RESUMABLE_UPLOAD_ATTEMPTS,
@@ -813,7 +810,7 @@ export class YouTubePostClient extends PostClient {
         const res = await fetch(url, init);
         if (res.status === 429 || (res.status >= 500 && res.status <= 599)) {
           // Retry throttling/transient server errors.
-          this.#responses.push({
+          this.responses.push({
             resumableRetry: {
               attempt,
               status: res.status,
@@ -827,7 +824,7 @@ export class YouTubePostClient extends PostClient {
         return res;
       } catch (err) {
         lastErr = err;
-        this.#responses.push({
+        this.responses.push({
           resumableRetry: {
             attempt,
             error: String(err),
@@ -900,7 +897,7 @@ export class YouTubePostClient extends PostClient {
       const rawContentType = res.headers.get("content-type") ?? "image/jpeg";
       const mimeType = rawContentType.split(";")[0].trim() || "image/jpeg";
 
-      this.#requests.push({
+      this.requests.push({
         thumbnailUploadRequest: {
           videoId,
           thumbnail: medium.thumbnail_url,
@@ -917,11 +914,11 @@ export class YouTubePostClient extends PostClient {
         },
       });
 
-      this.#responses.push({ thumbnailResponse: thumbnailResponse.data });
+      this.responses.push({ thumbnailResponse: thumbnailResponse.data });
       console.log("Thumbnail uploaded successfully for video:", videoId);
     } catch (error) {
       console.error("Error uploading thumbnail:", error);
-      this.#responses.push({
+      this.responses.push({
         thumbnailError: {
           videoId,
           thumbnail: medium.thumbnail_url,

--- a/trigger/posting/platforms/youtube-post-client.ts
+++ b/trigger/posting/platforms/youtube-post-client.ts
@@ -1,4 +1,5 @@
 import { PostClient } from "../post-client";
+import { TimestampedArray } from "../timestamped-array";
 import { google, youtube_v3 } from "googleapis";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { logger, wait } from "@trigger.dev/sdk";
@@ -21,8 +22,8 @@ export class YouTubePostClient extends PostClient {
   #oauth2Client: any;
   #googleClientId: string;
   #googleClientSecret: string;
-  #requests: any[] = [];
-  #responses: any[] = [];
+  #requests: TimestampedArray = new TimestampedArray();
+  #responses: TimestampedArray = new TimestampedArray();
 
   // Must be a multiple of 256KB per YouTube resumable upload guidance.
   static readonly DEFAULT_CHUNK_SIZE_BYTES = 8 * 1024 * 1024; // 8MB

--- a/trigger/posting/post-client.ts
+++ b/trigger/posting/post-client.ts
@@ -7,6 +7,7 @@ import path from "path";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { TimestampedArray } from "./timestamped-array";
 import type {
   BlueskyConfiguration,
   FacebookConfiguration,
@@ -25,6 +26,9 @@ import type {
 } from "./post.types";
 
 export class PostClient {
+  protected requests: TimestampedArray = new TimestampedArray();
+  protected responses: TimestampedArray = new TimestampedArray();
+
   constructor(
     _supabaseClient: SupabaseClient,
     _appCredentials: PlatformAppCredentials,

--- a/trigger/posting/timestamped-array.test.ts
+++ b/trigger/posting/timestamped-array.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { TimestampedArray } from "./timestamped-array";
+
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+describe("TimestampedArray", () => {
+  it("adds an ISO timestamp to a pushed entry", () => {
+    const arr = new TimestampedArray();
+    arr.push({ postRequest: { text: "hello" } });
+
+    expect(arr[0].timestamp).toMatch(ISO_TIMESTAMP);
+  });
+
+  it("preserves the existing keys on the pushed object", () => {
+    const arr = new TimestampedArray();
+    arr.push({ postRequest: { text: "hello" }, extra: 1 });
+
+    expect(arr[0]).toMatchObject({
+      postRequest: { text: "hello" },
+      extra: 1,
+    });
+    expect(arr[0].timestamp).toMatch(ISO_TIMESTAMP);
+  });
+
+  it("lets an explicit timestamp on the pushed item win over the injected default", () => {
+    const arr = new TimestampedArray();
+    arr.push({ timestamp: "explicit-value", postRequest: {} });
+
+    expect(arr[0].timestamp).toBe("explicit-value");
+  });
+
+  it("preserves insertion order across separate push calls", () => {
+    const arr = new TimestampedArray();
+    arr.push({ step: "request" });
+    arr.push({ step: "response" });
+    arr.push({ step: "retry-request" });
+
+    expect(arr.map((entry) => entry.step)).toEqual([
+      "request",
+      "response",
+      "retry-request",
+    ]);
+  });
+
+  it("stamps each item independently when multiple items are pushed in one call", () => {
+    const arr = new TimestampedArray();
+    arr.push({ step: "a" }, { step: "b" });
+
+    expect(arr).toHaveLength(2);
+    expect(arr[0].step).toBe("a");
+    expect(arr[1].step).toBe("b");
+    expect(arr[0].timestamp).toMatch(ISO_TIMESTAMP);
+    expect(arr[1].timestamp).toMatch(ISO_TIMESTAMP);
+  });
+
+  it("serializes as a plain array via JSON.stringify, e.g. inside details: { requests: arr }", () => {
+    const arr = new TimestampedArray();
+    arr.push({ postRequest: { text: "hello" } });
+
+    const details = { requests: arr, responses: new TimestampedArray() };
+    const parsed = JSON.parse(JSON.stringify(details));
+
+    expect(Array.isArray(parsed.requests)).toBe(true);
+    expect(parsed.requests[0].postRequest).toEqual({ text: "hello" });
+    expect(parsed.requests[0].timestamp).toMatch(ISO_TIMESTAMP);
+    expect(parsed.responses).toEqual([]);
+  });
+
+  it("spreads into a plain array as used at the call sites (e.g. [...this.#requests])", () => {
+    const arr = new TimestampedArray();
+    arr.push({ step: 1 });
+    arr.push({ step: 2 });
+
+    const spread = [...arr];
+    expect(Array.isArray(spread)).toBe(true);
+    expect(spread).toHaveLength(2);
+  });
+});

--- a/trigger/posting/timestamped-array.ts
+++ b/trigger/posting/timestamped-array.ts
@@ -1,0 +1,11 @@
+export class TimestampedArray<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> extends Array<T & { timestamp: string }> {
+  push(...items: T[]): number {
+    const stamped = items.map((item) => ({
+      timestamp: new Date().toISOString(),
+      ...item,
+    }));
+    return super.push(...stamped);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a UTC ISO timestamp to every request/response log entry captured in `social_post_results.details`, so auditing can tell when each request was sent / response received, not just that it happened. Purely additive — existing log ordering and keys are unchanged.

## Changes

- New `trigger/posting/timestamped-array.ts` — an `Array` subclass whose `push()` stamps a `timestamp` (UTC ISO string) onto every pushed entry.
- `requests`/`responses` are now declared once, as `protected TimestampedArray` fields on the shared `PostClient` base class (`trigger/posting/post-client.ts`), instead of being redeclared as `#private` fields in each of the 10 platform clients (`bluesky`, `facebook`, `instagram`, `linkedin`, `pinterest`, `threads`, `tiktok`, `tiktok_business`, `twitter`, `youtube`). `#private` fields aren't inheritable, so hoisting them required switching to `protected` and updating every `this.#requests`/`this.#responses` call site (~123 of them) to `this.requests`/`this.responses`. No behavioral change — same push-based timestamping, just declared in one place instead of ten.
- Added `trigger/posting/timestamped-array.test.ts` covering timestamp injection, key preservation, insertion-order, multi-item pushes, and `JSON.stringify`/spread behavior.
- Added a `"test": "bun test"` script to `trigger/package.json` — this is the first test suite in the `trigger/` package (uses Bun's built-in runner, no new dependencies).
- Pinned `@types/bun` as a devDependency (`trigger/package.json` / `bun.lock`). It was present in local `node_modules` but untracked in the lockfile, so `tsc` resolved `bun:test` locally but CI's frozen-lockfile install didn't, failing typecheck on `timestamped-array.test.ts`.
- No API, DTO, dashboard, or DB changes — `details` is passed through as opaque JSON end-to-end, so the new field surfaces automatically in the existing "View Logs" raw dump.

## Testing

- `bun run typecheck` — passes clean, including the two non-uniform push sites (`tiktok_business`'s extra `attempt` metadata, `youtube`'s pre-built `pollRequest` variable).
- `bun run lint` — passes clean.
- `bun test` — 7/7 unit tests pass.
- Not covered: a full end-to-end `post()` smoke test per platform, since that would require mocking each platform's third-party SDK (AtpAgent, TwitterApi, googleapis) and trigger.dev's `wait.for`/`tasks.triggerAndWait` helpers — disproportionate to a field-declaration change. Manual verification of the real `social_post_results.details` shape (via a live/local post trigger) is still recommended before merge.

## Notes

Related to PFM-750 (a separate, more ambitious `/social-post-results/$id` page with a step-rail log UI) — confirmed that page doesn't exist on `main` today, so this PR intentionally targets only the data layer, per the ticket owner's "additive, for future cases" framing.

The base-class hoist and `@types/bun` fix were added after an initial `/code-review` pass flagged the field duplication and CI's `bun run test`/typecheck gaps.

Closes PFM-749

🤖 Generated with AI
