### PR TITLE
fix(trigger): replace two-strike 100% flow with single upgrade email

### DIFF
--- a/.agents/skills/conversion-tracking/references/event-catalog.md
+++ b/.agents/skills/conversion-tracking/references/event-catalog.md
@@ -176,7 +176,7 @@ These are **user-lifecycle** events: they fire from in-app route actions (not th
 | team group | `team.id` (always attached — team reporting is group-aggregated regardless of recipient) |
 | person props | `$set: { email }` — links the recipient (esp. an email-keyed, non-user contact) |
 | Flag | `system_triggered: true` |
-| properties (generic) | `channel` (`email`), `recipient_is_user` (whether the address mapped to a user), `notification_category` (`transactional`), `notification_type` (DB column, e.g. `usage_alert`), `notification_template` (`usage_limit_alert` / `usage_limit_upgrade`), `notification_id`, `usage_count`, `current_limit`, `plan_post_limit`, `suggested_plan_post_limit` |
+| properties (generic) | `channel` (`email`), `recipient_is_user` (whether the address mapped to a user), `notification_category` (`transactional`), `notification_type` (DB column, e.g. `usage_alert`), `notification_template` (e.g. `usage_limit_upgrade_notice`, `usage_threshold_alert_80`), `notification_id`, `usage_count`, `current_limit`, `plan_post_limit`, `suggested_plan_post_limit` |
 | properties (channel-namespaced) | **email**: `email_provider` (`loops`), `email_template_id`. Future channels get their own prefix (`sms_*`, `push_*`). |
 | timestamp | now (real-time send) |
 | dedupe | `notification_sent:<team_id>:<channel>:<notification_template>:<period_start>:<suggested_plan_post_limit>` |

--- a/trigger/.env.example
+++ b/trigger/.env.example
@@ -6,7 +6,6 @@ POST_HOG_API_HOST=
 
 # Loops (transactional emails for usage limits/warnings).
 LOOPS_API_KEY=
-LOOPS_USAGE_LIMIT_TRANSACTIONAL_EMAIL_ID=
 LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID=
 # Shared across the 80/90/95% warnings — the crossed threshold is sent as
 # threshold_percent/usage_percent data so the template branches on it.

--- a/trigger/process-usage-limits.test.ts
+++ b/trigger/process-usage-limits.test.ts
@@ -70,8 +70,11 @@ const makeSubscription = (
   }) as unknown as Stripe.Subscription;
 
 // Fake Supabase query builder for the `team_notifications` chain used by
-// hasUsageNotificationForPeriod: reports "already sent" for whichever
-// notification_type values are in `notifiedTypes`.
+// hasUsageNotificationForPeriod: reports a confirmed "sent" delivery for
+// whichever notification_type values are in `notifiedTypes`. The chain's
+// terminal call is `lt()` (no `.limit()`/`.maybeSingle()` — the real query
+// can return multiple rows per period), so it resolves the `{ data, error }`
+// shape directly.
 const fakeNotificationsFrom = (notifiedTypes: Set<string>) => () => {
   let queriedType: string | undefined;
   const builder: any = {
@@ -83,17 +86,17 @@ const fakeNotificationsFrom = (notifiedTypes: Set<string>) => () => {
       return builder;
     },
     gte: () => builder,
-    lt: () => builder,
+    lt: () => ({
+      data:
+        queriedType && notifiedTypes.has(queriedType)
+          ? [{ meta_data: { results: [{ status: "sent" }] } }]
+          : [],
+      error: null,
+    }),
     lte: () => builder,
     order: () => builder,
     limit: () => builder,
-    maybeSingle: async () => ({
-      data:
-        queriedType && notifiedTypes.has(queriedType)
-          ? { id: "notif_1" }
-          : null,
-      error: null,
-    }),
+    maybeSingle: async () => ({ data: null, error: null }),
   };
   return builder;
 };
@@ -325,13 +328,18 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
   // `hasUsageNotificationForPeriod` (`team_notifications`) within one call to
   // `processExceededUsageWindow`. `trackUpgradeScheduled`'s `teams` lookup is
   // stubbed to "not found" so it no-ops rather than needing its own fixture.
+  //
+  // `notificationResultStatuses` models what's already recorded for the
+  // *current* period: `[]` means no attempt yet (or none confirmed), `["sent"]`
+  // means a prior attempt was confirmed delivered, `["failed"]`/`["skipped"]`
+  // models a prior attempt that didn't actually reach the team.
   const fakeSupabaseFrom =
     ({
       previousWindow = null,
-      alreadyNotified = false,
+      notificationResultStatuses = [],
     }: {
       previousWindow?: { count: number; limit: number } | null;
-      alreadyNotified?: boolean;
+      notificationResultStatuses?: string[];
     }) =>
     (table: string) => {
       if (table === "social_post_team_usage") {
@@ -362,10 +370,19 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
           select: () => builder,
           eq: () => builder,
           gte: () => builder,
-          lt: () => builder,
-          limit: () => builder,
-          maybeSingle: async () => ({
-            data: alreadyNotified ? { id: "notif_1" } : null,
+          lt: () => ({
+            data:
+              notificationResultStatuses.length > 0
+                ? [
+                    {
+                      meta_data: {
+                        results: notificationResultStatuses.map((status) => ({
+                          status,
+                        })),
+                      },
+                    },
+                  ]
+                : [],
             error: null,
           }),
         };
@@ -419,10 +436,10 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     taskTriggerCalls.length = 0;
   });
 
-  test("first exceeded window: sends the merged notice once, creates no Stripe schedule", async () => {
+  test("first exceeded window: sends the hedged notice once, creates no Stripe schedule", async () => {
     mod.supabaseClient.from = fakeSupabaseFrom({
       previousWindow: null, // not exceeded previously → strike 1
-      alreadyNotified: false,
+      notificationResultStatuses: [],
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({
       data: [makeSubscription()],
@@ -436,6 +453,9 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     const [{ id, payload }] = taskTriggerCalls;
     expect(id).toBe("process-team-notification");
     expect(payload.notification_type).toBe("usage_alert");
+    // Strike 1 doesn't yet know a schedule will be created — the message
+    // must not promise the upgrade unconditionally.
+    expect(payload.message).toContain("If usage remains above your plan limit");
     expect((payload.meta_data as any).notification_template).toBe(
       "usage_limit_upgrade_notice",
     );
@@ -444,10 +464,10 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     );
   });
 
-  test("does not re-send when the period was already notified", async () => {
+  test("does not re-send when the period was already confirmed delivered", async () => {
     mod.supabaseClient.from = fakeSupabaseFrom({
       previousWindow: null,
-      alreadyNotified: true,
+      notificationResultStatuses: ["sent"],
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({
       data: [makeSubscription()],
@@ -458,10 +478,51 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     expect(taskTriggerCalls.length).toBe(0);
   });
 
-  test("second consecutive exceeded window: creates the Stripe schedule with no additional email", async () => {
+  test("retries the notice when the prior attempt for this period failed to deliver", async () => {
+    // A `team_notifications` row exists for this period, but its only
+    // delivery result is "failed" — row existence alone must not count as
+    // "notified", or a team whose only send attempt fails would never be
+    // retried yet could still be auto-upgraded later.
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      previousWindow: null,
+      notificationResultStatuses: ["failed"],
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({
+      data: [makeSubscription()],
+    })) as any;
+    mockNoActiveSchedules();
+    refuseSubscriptionScheduleWrites();
+
+    await mod.processExceededUsageWindow(makeUsageWindow() as any);
+
+    expect(taskTriggerCalls.length).toBe(1);
+  });
+
+  test("second consecutive exceeded window, notice not yet confirmed delivered: defers the Stripe schedule", async () => {
     mod.supabaseClient.from = fakeSupabaseFrom({
       previousWindow: { count: 1100, limit: 1000 }, // exceeded previous period too → strike 2
-      alreadyNotified: false, // this (new) period hasn't been notified yet
+      notificationResultStatuses: [], // this period's notice hasn't been confirmed sent yet
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({
+      data: [makeSubscription()],
+    })) as any;
+    refuseSubscriptionScheduleWrites();
+
+    await mod.processExceededUsageWindow(makeUsageWindow() as any);
+
+    // The notice is fired this tick, but schedule creation waits for
+    // confirmed delivery — otherwise a team could be upgraded without ever
+    // having received a working notification.
+    expect(taskTriggerCalls.length).toBe(1);
+    expect(taskTriggerCalls[0].payload.message).toContain(
+      "You will be upgraded to the next tier.",
+    );
+  });
+
+  test("second consecutive exceeded window, notice already confirmed delivered: creates the Stripe schedule with no additional email", async () => {
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      previousWindow: { count: 1100, limit: 1000 }, // exceeded previous period too → strike 2
+      notificationResultStatuses: ["sent"], // confirmed delivered on an earlier tick
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({
       data: [makeSubscription()],
@@ -472,25 +533,13 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     await mod.processExceededUsageWindow(makeUsageWindow() as any);
 
     expect(create).toHaveBeenCalledTimes(1);
-    // Exactly one email for this window — the strike-1-style notice above,
-    // not a second one from schedule creation.
-    expect(taskTriggerCalls.length).toBe(1);
-    expect(
-      (taskTriggerCalls[0].payload.meta_data as any).notification_template,
-    ).toBe("usage_limit_upgrade_notice");
+    // Already delivered for this period, so the dedup check skips re-sending.
+    expect(taskTriggerCalls.length).toBe(0);
   });
 
-  test("escalation: usage exceeds the scheduled tier, schedule is bumped, and a follow-up notice fires", async () => {
-    mod.supabaseClient.from = fakeSupabaseFrom({
-      previousWindow: { count: 1100, limit: 1000 },
-      alreadyNotified: false,
-    }) as any;
-    mod.stripe.subscriptions.list = mock(async () => ({
-      data: [makeSubscription()],
-    })) as any;
-
+  const mockExistingScheduleAtTier25k = () => {
     // An active schedule already exists, mapped to the tier_2_5k phase
-    // (2,500 posts) — usage below will exceed that, forcing an escalation.
+    // (2,500 posts).
     mod.stripe.subscriptionSchedules.list = mock(async () => ({
       data: [
         {
@@ -509,6 +558,19 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     mod.stripe.prices.retrieve = mock(async () => ({
       product: "tier_2_5k",
     })) as any;
+  };
+
+  test("escalation: usage exceeds the scheduled tier, schedule is bumped, and a follow-up notice fires", async () => {
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      previousWindow: { count: 1100, limit: 1000 },
+      // An active schedule can only exist if the current period's notice
+      // was already confirmed delivered (the new gate in Fix 1).
+      notificationResultStatuses: ["sent"],
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({
+      data: [makeSubscription()],
+    })) as any;
+    mockExistingScheduleAtTier25k();
     const { create } = mockScheduleCreation();
 
     await mod.processExceededUsageWindow(
@@ -519,13 +581,45 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     );
 
     expect(create).toHaveBeenCalledTimes(1); // re-scheduled to tier_5k
-    expect(taskTriggerCalls.length).toBe(2); // strike-1-style notice + escalation notice
-    const escalationPayload = taskTriggerCalls[1].payload;
+    // The strike-1-style notice is deduped (already confirmed sent above),
+    // so only the escalation notice fires.
+    expect(taskTriggerCalls.length).toBe(1);
+    const escalationPayload = taskTriggerCalls[0].payload;
     expect((escalationPayload.meta_data as any).notification_template).toBe(
       "usage_limit_upgrade_notice",
     );
     expect(
       (escalationPayload.meta_data as any).tracking.suggested_plan_post_limit,
     ).toBe(5000); // tier_5k
+  });
+
+  test("escalation: a burst that skips multiple tiers converges to the correct tier in one step", async () => {
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      previousWindow: { count: 1100, limit: 1000 },
+      notificationResultStatuses: ["sent"],
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({
+      data: [makeSubscription()],
+    })) as any;
+    mockExistingScheduleAtTier25k();
+    const { create } = mockScheduleCreation();
+
+    await mod.processExceededUsageWindow(
+      // 12,000 posts skips tier_5k (5,000) and tier_10k (10,000) — the
+      // correct landing tier is tier_20k (20,000).
+      makeUsageWindow({
+        count: 12000,
+        limit: 1000,
+      }) as any,
+    );
+
+    // One schedule replacement and one email, landing directly on tier_20k
+    // — not one per intermediate tier.
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(taskTriggerCalls.length).toBe(1);
+    expect(
+      (taskTriggerCalls[0].payload.meta_data as any).tracking
+        .suggested_plan_post_limit,
+    ).toBe(20000); // tier_20k
   });
 });

--- a/trigger/process-usage-limits.test.ts
+++ b/trigger/process-usage-limits.test.ts
@@ -1,5 +1,33 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type Stripe from "stripe";
+
+// `triggerTeamNotification` calls `tasks.trigger("process-team-notification", ...)`,
+// which would otherwise attempt a live trigger.dev API call outside of a real
+// run context. Intercept just `tasks.trigger` and record calls so the
+// exceeded-usage-window flow can be exercised end-to-end without a live
+// trigger.dev connection or a `process-team-notification` implementation.
+const taskTriggerCalls: {
+  id: string;
+  payload: Record<string, unknown>;
+}[] = [];
+
+mock.module("@trigger.dev/sdk", () => {
+  // `require` (not `import`) is required here: an async `import()` inside
+  // this factory re-enters bun's mock resolution for the same specifier and
+  // deadlocks, whereas a synchronous `require()` resolves to the real module.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual: typeof import("@trigger.dev/sdk") = require("@trigger.dev/sdk");
+  return {
+    ...actual,
+    tasks: {
+      ...actual.tasks,
+      trigger: mock(async (id: string, payload: Record<string, unknown>) => {
+        taskTriggerCalls.push({ id, payload });
+        return { id: "run_1" };
+      }),
+    },
+  };
+});
 
 process.env.STRIPE_SECRET_KEY = "sk_test_dummy";
 process.env.SUPABASE_URL = "https://example.supabase.co";
@@ -13,7 +41,6 @@ process.env.STRIPE_PRICING_TIER_40K_PRODUCT_ID = "tier_40k";
 process.env.STRIPE_PRICING_TIER_100K_PRODUCT_ID = "tier_100k";
 process.env.STRIPE_PRICING_TIER_200K_PRODUCT_ID = "tier_200k";
 process.env.STRIPE_API_PRODUCT_ID = "tier_legacy";
-process.env.LOOPS_USAGE_LIMIT_TRANSACTIONAL_EMAIL_ID = "loops_limit";
 process.env.LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID = "loops_upgrade";
 process.env.LOOPS_USAGE_THRESHOLD_TRANSACTIONAL_EMAIL_ID = "loops_threshold";
 
@@ -278,5 +305,227 @@ describe("hasHigherOrEqualUsageNotification", () => {
     );
 
     expect(result).toBe(false);
+  });
+});
+
+describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
+  const makeUsageWindow = (overrides: Record<string, unknown> = {}) => ({
+    team_id: "team_1",
+    count: 1200,
+    limit: 1000,
+    start_at: "2026-02-01T00:00:00Z",
+    end_at: "2026-03-01T00:00:00Z",
+    team_name: "Team One",
+    stripe_customer_id: "cus_1",
+    ...overrides,
+  });
+
+  // Routes `supabaseClient.from(table)` per-table so a single fake can back
+  // both `hasExceededPreviouseLimit` (`social_post_team_usage`) and
+  // `hasUsageNotificationForPeriod` (`team_notifications`) within one call to
+  // `processExceededUsageWindow`. `trackUpgradeScheduled`'s `teams` lookup is
+  // stubbed to "not found" so it no-ops rather than needing its own fixture.
+  const fakeSupabaseFrom =
+    ({
+      previousWindow = null,
+      alreadyNotified = false,
+    }: {
+      previousWindow?: { count: number; limit: number } | null;
+      alreadyNotified?: boolean;
+    }) =>
+    (table: string) => {
+      if (table === "social_post_team_usage") {
+        const builder: any = {
+          select: () => builder,
+          eq: () => builder,
+          lte: () => builder,
+          order: () => builder,
+          limit: () => builder,
+          maybeSingle: async () => ({
+            data: previousWindow
+              ? {
+                  team_id: "team_1",
+                  count: previousWindow.count,
+                  limit: previousWindow.limit,
+                  start_at: "2026-01-01T00:00:00Z",
+                  end_at: "2026-02-01T00:00:00Z",
+                }
+              : null,
+            error: null,
+          }),
+        };
+        return builder;
+      }
+
+      if (table === "team_notifications") {
+        const builder: any = {
+          select: () => builder,
+          eq: () => builder,
+          gte: () => builder,
+          lt: () => builder,
+          limit: () => builder,
+          maybeSingle: async () => ({
+            data: alreadyNotified ? { id: "notif_1" } : null,
+            error: null,
+          }),
+        };
+        return builder;
+      }
+
+      // `teams` (trackUpgradeScheduled) and anything else: no row found, so
+      // the caller short-circuits rather than needing a dedicated fixture.
+      const builder: any = {
+        select: () => builder,
+        eq: () => builder,
+        maybeSingle: async () => ({ data: null, error: null }),
+      };
+      return builder;
+    };
+
+  const mockNoActiveSchedules = () => {
+    mod.stripe.subscriptionSchedules.list = mock(async () => ({
+      data: [],
+    })) as any;
+  };
+
+  const mockScheduleCreation = () => {
+    const create = mock(async () => ({
+      id: "sched_1",
+      phases: [{ start_date: 1000 }],
+    })) as any;
+    const update = mock(async () => ({})) as any;
+    mod.stripe.subscriptionSchedules.create = create;
+    mod.stripe.subscriptionSchedules.update = update;
+    // scheduleUpgrade() re-lists + releases any active schedules before
+    // creating the new one, independent of getActiveScheduleForSubscription's
+    // own list call above.
+    mod.stripe.subscriptionSchedules.release = mock(async () => ({})) as any;
+    mod.stripe.products.retrieve = mock(async () => ({
+      default_price: "price_next_tier",
+    })) as any;
+    return { create, update };
+  };
+
+  const refuseSubscriptionScheduleWrites = () => {
+    mod.stripe.subscriptionSchedules.create = mock(() => {
+      throw new Error("should not create a schedule");
+    }) as any;
+    mod.stripe.subscriptionSchedules.update = mock(() => {
+      throw new Error("should not update a schedule");
+    }) as any;
+  };
+
+  beforeEach(() => {
+    taskTriggerCalls.length = 0;
+  });
+
+  test("first exceeded window: sends the merged notice once, creates no Stripe schedule", async () => {
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      previousWindow: null, // not exceeded previously → strike 1
+      alreadyNotified: false,
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({
+      data: [makeSubscription()],
+    })) as any;
+    mockNoActiveSchedules();
+    refuseSubscriptionScheduleWrites();
+
+    await mod.processExceededUsageWindow(makeUsageWindow() as any);
+
+    expect(taskTriggerCalls.length).toBe(1);
+    const [{ id, payload }] = taskTriggerCalls;
+    expect(id).toBe("process-team-notification");
+    expect(payload.notification_type).toBe("usage_alert");
+    expect((payload.meta_data as any).notification_template).toBe(
+      "usage_limit_upgrade_notice",
+    );
+    expect((payload.meta_data as any).data.loops.transactional_id).toBe(
+      "loops_upgrade",
+    );
+  });
+
+  test("does not re-send when the period was already notified", async () => {
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      previousWindow: null,
+      alreadyNotified: true,
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({
+      data: [makeSubscription()],
+    })) as any;
+
+    await mod.processExceededUsageWindow(makeUsageWindow() as any);
+
+    expect(taskTriggerCalls.length).toBe(0);
+  });
+
+  test("second consecutive exceeded window: creates the Stripe schedule with no additional email", async () => {
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      previousWindow: { count: 1100, limit: 1000 }, // exceeded previous period too → strike 2
+      alreadyNotified: false, // this (new) period hasn't been notified yet
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({
+      data: [makeSubscription()],
+    })) as any;
+    mockNoActiveSchedules();
+    const { create } = mockScheduleCreation();
+
+    await mod.processExceededUsageWindow(makeUsageWindow() as any);
+
+    expect(create).toHaveBeenCalledTimes(1);
+    // Exactly one email for this window — the strike-1-style notice above,
+    // not a second one from schedule creation.
+    expect(taskTriggerCalls.length).toBe(1);
+    expect(
+      (taskTriggerCalls[0].payload.meta_data as any).notification_template,
+    ).toBe("usage_limit_upgrade_notice");
+  });
+
+  test("escalation: usage exceeds the scheduled tier, schedule is bumped, and a follow-up notice fires", async () => {
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      previousWindow: { count: 1100, limit: 1000 },
+      alreadyNotified: false,
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({
+      data: [makeSubscription()],
+    })) as any;
+
+    // An active schedule already exists, mapped to the tier_2_5k phase
+    // (2,500 posts) — usage below will exceed that, forcing an escalation.
+    mod.stripe.subscriptionSchedules.list = mock(async () => ({
+      data: [
+        {
+          id: "sched_existing",
+          status: "active",
+          subscription: "sub_1",
+          phases: [
+            {
+              start_date: 1893456000,
+              items: [{ price: "price_tier_2_5k" }],
+            },
+          ],
+        },
+      ],
+    })) as any;
+    mod.stripe.prices.retrieve = mock(async () => ({
+      product: "tier_2_5k",
+    })) as any;
+    const { create } = mockScheduleCreation();
+
+    await mod.processExceededUsageWindow(
+      makeUsageWindow({
+        count: 3000, // exceeds the scheduled tier_2_5k's 2,500-post limit
+        limit: 1000,
+      }) as any,
+    );
+
+    expect(create).toHaveBeenCalledTimes(1); // re-scheduled to tier_5k
+    expect(taskTriggerCalls.length).toBe(2); // strike-1-style notice + escalation notice
+    const escalationPayload = taskTriggerCalls[1].payload;
+    expect((escalationPayload.meta_data as any).notification_template).toBe(
+      "usage_limit_upgrade_notice",
+    );
+    expect(
+      (escalationPayload.meta_data as any).tracking.suggested_plan_post_limit,
+    ).toBe(5000); // tier_5k
   });
 });

--- a/trigger/process-usage-limits.ts
+++ b/trigger/process-usage-limits.ts
@@ -406,6 +406,13 @@ const hasExceededPreviouseLimit = async (
   return data.count > data.limit;
 };
 
+type NotificationDeliveryResult = { status?: string };
+type NotificationRowMetadata = { results?: NotificationDeliveryResult[] };
+
+// "Notified" means at least one delivery attempt for the period actually
+// succeeded — a row that only recorded "skipped"/"failed" deliveries doesn't
+// count, so a failed send is retried on the next cron tick instead of being
+// silently treated as done forever.
 const hasUsageNotificationForPeriod = async (
   teamId: string,
   notificationType: TeamNotificationType,
@@ -414,19 +421,23 @@ const hasUsageNotificationForPeriod = async (
 ): Promise<boolean> => {
   const { data, error } = await supabaseClient
     .from("team_notifications")
-    .select("id")
+    .select("meta_data")
     .eq("notification_type", notificationType)
     .eq("team_id", teamId)
     .gte("created_at", periodStart)
-    .lt("created_at", periodEnd)
-    .limit(1)
-    .maybeSingle();
+    .lt("created_at", periodEnd);
 
   if (error) {
     throw error;
   }
 
-  return Boolean(data?.id);
+  return (data ?? []).some((row) => {
+    const results = (row.meta_data as NotificationRowMetadata | null)
+      ?.results;
+    return (
+      Array.isArray(results) && results.some((result) => result.status === "sent")
+    );
+  });
 };
 
 /**
@@ -715,6 +726,51 @@ const buildUsageEmailMetadata = ({
   results: [],
 });
 
+// Shared by the first "you will be upgraded" notice and the escalation
+// re-notice — same notification type, same period, same metadata shape;
+// only the message, suggested tier, and dedup behavior differ per call site.
+const sendUpgradeNotice = ({
+  teamId,
+  teamName,
+  usage,
+  currentLimit,
+  planInfo,
+  usageWindow,
+  suggestedTier,
+  message,
+  checkForDuplicates,
+}: {
+  teamId: string;
+  teamName: string | null;
+  usage: number;
+  currentLimit: number;
+  planInfo: ReturnType<typeof getSubscriptionPlanInfo>;
+  usageWindow: ExceededUsageWindow;
+  suggestedTier: (typeof PRICING_TIERS)[number] | null;
+  message: string;
+  checkForDuplicates: boolean;
+}): Promise<boolean> =>
+  maybeTriggerUsageNotification({
+    teamId,
+    notificationType: "usage_alert",
+    periodStart: usageWindow.start_at,
+    periodEnd: usageWindow.end_at,
+    message,
+    metadata: buildUsageEmailMetadata({
+      teamId,
+      teamName,
+      usage,
+      currentLimit,
+      currentPlanPostLimit: planInfo.postLimit,
+      currentPlanName: planInfo.planName,
+      suggestedTier,
+      periodStart: usageWindow.start_at,
+      transactionalEmailId: LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID,
+      notificationTemplate: "usage_limit_upgrade_notice",
+    }),
+    checkForDuplicates,
+  });
+
 /**
  * Emit `subscription_upgrade_scheduled` for the automated usage-based upgrade.
  * Attributed to the team's owner (`created_by`) as the distinct_id and the
@@ -794,7 +850,8 @@ const trackUpgradeScheduled = async ({
 /**
  * Processes a single exceeded (>=100%) usage window: sends the single
  * "you will be upgraded" notice, then handles Stripe schedule creation /
- * escalation under the unchanged `hasExceededPreviouseLimit()` gate.
+ * escalation under the `hasExceededPreviouseLimit()` gate plus a confirmed-
+ * delivery check for the current period's notice.
  * Extracted from the cron `run` body so it's unit-testable in isolation —
  * trigger.dev's `schedules.task()` doesn't expose `run` for direct
  * invocation outside its own runtime.
@@ -828,15 +885,10 @@ export const processExceededUsageWindow = async (
       return;
     }
 
-    const exceededPreviousLimit = await hasExceededPreviouseLimit(
-      teamId,
-      usageWindow,
-    );
-
-    const eligiblePlan = await getEligibleSubscriptionPlan({
-      teamId,
-      stripeCustomerId,
-    });
+    const [exceededPreviousLimit, eligiblePlan] = await Promise.all([
+      hasExceededPreviouseLimit(teamId, usageWindow),
+      getEligibleSubscriptionPlan({ teamId, stripeCustomerId }),
+    ]);
 
     if (!eligiblePlan) {
       return;
@@ -856,32 +908,48 @@ export const processExceededUsageWindow = async (
     // Single "you will be upgraded" notice, sent once per period the
     // moment a team crosses 100% — regardless of strike count. Deduped
     // per period so a repeat cron pass (or a later strike in the same
-    // period) doesn't re-send it. The actual Stripe schedule is still
-    // gated by `exceededPreviousLimit` below (unchanged for now — see
-    // PFM-1062), so this promise can precede the schedule by up to one
-    // billing period until that gate is removed.
-    await maybeTriggerUsageNotification({
+    // period) doesn't re-send it. Wording is conditioned on
+    // `exceededPreviousLimit`: only when this is (at least) the second
+    // consecutive exceeded period is the schedule about to be created
+    // below, so only then does the notice promise it confidently.
+    const noticeMessage = exceededPreviousLimit
+      ? `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). You will be upgraded to the next tier.`
+      : `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). If usage remains above your plan limit next billing period, you'll be upgraded to the next tier.`;
+
+    await sendUpgradeNotice({
       teamId,
-      notificationType: "usage_alert",
-      periodStart: usageWindow.start_at,
-      periodEnd: usageWindow.end_at,
-      message: `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). You will be upgraded to the next tier.`,
-      metadata: buildUsageEmailMetadata({
-        teamId,
-        teamName,
-        usage,
-        currentLimit,
-        currentPlanPostLimit: planInfo.postLimit,
-        currentPlanName: planInfo.planName,
-        suggestedTier: nextTier,
-        periodStart: usageWindow.start_at,
-        transactionalEmailId: LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID,
-        notificationTemplate: "usage_limit_upgrade_notice",
-      }),
+      teamName,
+      usage,
+      currentLimit,
+      planInfo,
+      usageWindow,
+      suggestedTier: nextTier,
+      message: noticeMessage,
       checkForDuplicates: true,
     });
 
     if (!exceededPreviousLimit) {
+      return;
+    }
+
+    // Delivery happens in a separate async task (process-team-notification),
+    // so it can't be confirmed synchronously above — require a confirmed
+    // send for the current period before creating/escalating the Stripe
+    // schedule. This defers schedule creation by at least one cron tick
+    // after a successful send, closing the gap where a team could be
+    // upgraded/billed without ever receiving a working notification.
+    const currentPeriodNotified = await hasUsageNotificationForPeriod(
+      teamId,
+      "usage_alert",
+      usageWindow.start_at,
+      usageWindow.end_at,
+    );
+
+    if (!currentPeriodNotified) {
+      logger.info(
+        "Deferring upgrade schedule until usage notice is confirmed delivered",
+        { team_id: teamId },
+      );
       return;
     }
 
@@ -941,9 +1009,19 @@ export const processExceededUsageWindow = async (
       const scheduledTierIndex = PRICING_TIERS.findIndex(
         (tier) => tier.productId === scheduledTier.productId,
       );
-      const nextScheduledTier = PRICING_TIERS[scheduledTierIndex + 1];
+      // Jump straight to the tier that actually covers current usage
+      // instead of advancing one tier at a time — a burst that skips
+      // multiple tiers in one window would otherwise take one cron tick
+      // (and one near-duplicate email) per intermediate tier to catch up.
+      const nextScheduledTier =
+        PRICING_TIERS.slice(scheduledTierIndex + 1).find(
+          (tier) => tier.posts >= usage,
+        ) ?? PRICING_TIERS[PRICING_TIERS.length - 1];
 
-      if (!nextScheduledTier) {
+      if (
+        !nextScheduledTier ||
+        nextScheduledTier.productId === scheduledTier.productId
+      ) {
         logger.info("Scheduled upgrade already at highest pricing tier", {
           team_id: teamId,
           subscription_id: subscription.id,
@@ -960,24 +1038,15 @@ export const processExceededUsageWindow = async (
         nextTier: nextScheduledTier,
       });
 
-      await maybeTriggerUsageNotification({
+      await sendUpgradeNotice({
         teamId,
-        notificationType: "usage_alert",
-        periodStart: usageWindow.start_at,
-        periodEnd: usageWindow.end_at,
+        teamName,
+        usage,
+        currentLimit,
+        planInfo,
+        usageWindow,
+        suggestedTier: nextScheduledTier,
         message: `Usage exceeded current and previous plan limits (${usage}/${currentLimit} posts used this period).`,
-        metadata: buildUsageEmailMetadata({
-          teamId,
-          teamName,
-          usage,
-          currentLimit,
-          currentPlanPostLimit: planInfo.postLimit,
-          currentPlanName: planInfo.planName,
-          suggestedTier: nextScheduledTier,
-          periodStart: usageWindow.start_at,
-          transactionalEmailId: LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID,
-          notificationTemplate: "usage_limit_upgrade_notice",
-        }),
         checkForDuplicates: false,
       });
 

--- a/trigger/process-usage-limits.ts
+++ b/trigger/process-usage-limits.ts
@@ -29,8 +29,6 @@ const STRIPE_PRICING_TIER_200K_PRODUCT_ID =
   process.env?.STRIPE_PRICING_TIER_200K_PRODUCT_ID || "";
 
 const STRIPE_API_PRODUCT_ID = process.env?.STRIPE_API_PRODUCT_ID || "";
-const LOOPS_USAGE_LIMIT_TRANSACTIONAL_EMAIL_ID =
-  process.env?.LOOPS_USAGE_LIMIT_TRANSACTIONAL_EMAIL_ID || "";
 const LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID =
   process.env?.LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID || "";
 // One shared template for all three thresholds — the crossed percent is sent
@@ -72,8 +70,7 @@ export const USAGE_WARNING_THRESHOLDS = [
 }[];
 
 type UsageEmailTemplate =
-  | "usage_limit_alert"
-  | "usage_limit_upgrade"
+  | "usage_limit_upgrade_notice"
   | (typeof USAGE_WARNING_THRESHOLDS)[number]["notificationTemplate"];
 
 // Returns the highest threshold whose percent has been crossed. Does not
@@ -794,6 +791,231 @@ const trackUpgradeScheduled = async ({
   }
 };
 
+/**
+ * Processes a single exceeded (>=100%) usage window: sends the single
+ * "you will be upgraded" notice, then handles Stripe schedule creation /
+ * escalation under the unchanged `hasExceededPreviouseLimit()` gate.
+ * Extracted from the cron `run` body so it's unit-testable in isolation —
+ * trigger.dev's `schedules.task()` doesn't expose `run` for direct
+ * invocation outside its own runtime.
+ */
+export const processExceededUsageWindow = async (
+  usageWindow: ExceededUsageWindow,
+): Promise<void> => {
+  const {
+    team_id: teamId,
+    count: usage,
+    limit: currentLimit,
+    stripe_customer_id: stripeCustomerId,
+    team_name: teamName,
+  } = usageWindow;
+
+  logger.info("Processing exceeded usage window", {
+    team_id: teamId,
+    team_name: teamName,
+    stripe_customer_id: stripeCustomerId,
+    usage_window_start_at: usageWindow.start_at,
+    usage_window_end_at: usageWindow.end_at,
+    usage_count: usage,
+    usage_limit: currentLimit,
+  });
+
+  try {
+    if (!stripeCustomerId) {
+      logger.info("Skipping team without Stripe customer", {
+        team_id: teamId,
+      });
+      return;
+    }
+
+    const exceededPreviousLimit = await hasExceededPreviouseLimit(
+      teamId,
+      usageWindow,
+    );
+
+    const eligiblePlan = await getEligibleSubscriptionPlan({
+      teamId,
+      stripeCustomerId,
+    });
+
+    if (!eligiblePlan) {
+      return;
+    }
+
+    const { subscription, planInfo, currentPlanItem, currentPeriodEnd, nextTier } =
+      eligiblePlan;
+
+    if (!nextTier) {
+      logger.info("Team is already on highest pricing tier", {
+        team_id: teamId,
+        subscription_id: subscription.id,
+      });
+      return;
+    }
+
+    // Single "you will be upgraded" notice, sent once per period the
+    // moment a team crosses 100% — regardless of strike count. Deduped
+    // per period so a repeat cron pass (or a later strike in the same
+    // period) doesn't re-send it. The actual Stripe schedule is still
+    // gated by `exceededPreviousLimit` below (unchanged for now — see
+    // PFM-1062), so this promise can precede the schedule by up to one
+    // billing period until that gate is removed.
+    await maybeTriggerUsageNotification({
+      teamId,
+      notificationType: "usage_alert",
+      periodStart: usageWindow.start_at,
+      periodEnd: usageWindow.end_at,
+      message: `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). You will be upgraded to the next tier.`,
+      metadata: buildUsageEmailMetadata({
+        teamId,
+        teamName,
+        usage,
+        currentLimit,
+        currentPlanPostLimit: planInfo.postLimit,
+        currentPlanName: planInfo.planName,
+        suggestedTier: nextTier,
+        periodStart: usageWindow.start_at,
+        transactionalEmailId: LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID,
+        notificationTemplate: "usage_limit_upgrade_notice",
+      }),
+      checkForDuplicates: true,
+    });
+
+    if (!exceededPreviousLimit) {
+      return;
+    }
+
+    const activeSchedule = await getActiveScheduleForSubscription(
+      stripeCustomerId,
+      subscription.id,
+    );
+
+    if (!activeSchedule) {
+      await scheduleUpgrade({
+        stripeCustomerId,
+        subscription,
+        currentPlanItem,
+        currentPeriodEnd,
+        nextTier,
+      });
+
+      // No follow-up email here — the team was already notified above
+      // when they first crossed 100%.
+
+      logger.info("Scheduled usage-based upgrade to next tier", {
+        team_id: teamId,
+        subscription_id: subscription.id,
+        next_tier: nextTier.productId,
+      });
+
+      await trackUpgradeScheduled({
+        teamId,
+        stripeCustomerId,
+        subscription,
+        fromProductId: planInfo.productId,
+        toTier: nextTier,
+        usage,
+        currentLimit,
+      });
+
+      return;
+    }
+
+    const scheduledTier = await getScheduledTierForSubscription({
+      schedule: activeSchedule,
+      currentPeriodEnd,
+    });
+
+    if (!scheduledTier) {
+      logger.info("Active schedule found without mapped upgrade tier", {
+        team_id: teamId,
+        subscription_id: subscription.id,
+        schedule_id: activeSchedule.id,
+        activeSchedule,
+      });
+
+      return;
+    }
+
+    if (usage > scheduledTier.posts) {
+      const scheduledTierIndex = PRICING_TIERS.findIndex(
+        (tier) => tier.productId === scheduledTier.productId,
+      );
+      const nextScheduledTier = PRICING_TIERS[scheduledTierIndex + 1];
+
+      if (!nextScheduledTier) {
+        logger.info("Scheduled upgrade already at highest pricing tier", {
+          team_id: teamId,
+          subscription_id: subscription.id,
+          usage,
+          scheduled_tier: scheduledTier,
+        });
+        return;
+      }
+      await scheduleUpgrade({
+        stripeCustomerId,
+        subscription,
+        currentPlanItem,
+        currentPeriodEnd,
+        nextTier: nextScheduledTier,
+      });
+
+      await maybeTriggerUsageNotification({
+        teamId,
+        notificationType: "usage_alert",
+        periodStart: usageWindow.start_at,
+        periodEnd: usageWindow.end_at,
+        message: `Usage exceeded current and previous plan limits (${usage}/${currentLimit} posts used this period).`,
+        metadata: buildUsageEmailMetadata({
+          teamId,
+          teamName,
+          usage,
+          currentLimit,
+          currentPlanPostLimit: planInfo.postLimit,
+          currentPlanName: planInfo.planName,
+          suggestedTier: nextScheduledTier,
+          periodStart: usageWindow.start_at,
+          transactionalEmailId: LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID,
+          notificationTemplate: "usage_limit_upgrade_notice",
+        }),
+        checkForDuplicates: false,
+      });
+
+      logger.info("Replaced scheduled upgrade with next tier", {
+        team_id: teamId,
+        subscription_id: subscription.id,
+        previous_scheduled_tier: scheduledTier.productId,
+        next_scheduled_tier: nextScheduledTier.productId,
+      });
+
+      await trackUpgradeScheduled({
+        teamId,
+        stripeCustomerId,
+        subscription,
+        fromProductId: planInfo.productId,
+        toTier: nextScheduledTier,
+        previousScheduledProductId: scheduledTier.productId,
+        usage,
+        currentLimit,
+      });
+
+      return;
+    }
+
+    logger.info("Team has not exceeded next tier usage", {
+      team_id: teamId,
+      subscription_id: subscription.id,
+      scheduled_tier: scheduledTier.productId,
+      usage: usage,
+    });
+  } catch (teamError) {
+    logger.error("Error processing team usage limits", {
+      team_id: teamId,
+      error: teamError,
+    });
+  }
+};
+
 export const processUsageLimits = schedules.task({
   cron: { pattern: "*/5 * * * *", environments: ["PRODUCTION"] },
   id: "process-usage-limits",
@@ -817,233 +1039,7 @@ export const processUsageLimits = schedules.task({
       }
 
       for (const usageWindow of exceededUsageWindows) {
-        const {
-          team_id: teamId,
-          count: usage,
-          limit: currentLimit,
-          stripe_customer_id: stripeCustomerId,
-          team_name: teamName,
-        } = usageWindow;
-
-        logger.info("Processing exceeded usage window", {
-          team_id: teamId,
-          team_name: teamName,
-          stripe_customer_id: stripeCustomerId,
-          usage_window_start_at: usageWindow.start_at,
-          usage_window_end_at: usageWindow.end_at,
-          usage_count: usage,
-          usage_limit: currentLimit,
-        });
-
-        try {
-          if (!stripeCustomerId) {
-            logger.info("Skipping team without Stripe customer", {
-              team_id: teamId,
-            });
-            continue;
-          }
-
-          const exceededPreviousLimit = await hasExceededPreviouseLimit(
-            teamId,
-            usageWindow,
-          );
-
-          const eligiblePlan = await getEligibleSubscriptionPlan({
-            teamId,
-            stripeCustomerId,
-          });
-
-          if (!eligiblePlan) {
-            continue;
-          }
-
-          const {
-            subscription,
-            planInfo,
-            currentPlanItem,
-            currentPeriodEnd,
-            nextTier,
-          } = eligiblePlan;
-
-          if (!nextTier) {
-            logger.info("Team is already on highest pricing tier", {
-              team_id: teamId,
-              subscription_id: subscription.id,
-            });
-            continue;
-          }
-
-          if (!exceededPreviousLimit) {
-            await maybeTriggerUsageNotification({
-              teamId,
-              notificationType: "usage_alert",
-              periodStart: usageWindow.start_at,
-              periodEnd: usageWindow.end_at,
-              message: `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period).`,
-              metadata: buildUsageEmailMetadata({
-                teamId,
-                teamName,
-                usage,
-                currentLimit,
-                currentPlanPostLimit: planInfo.postLimit,
-                currentPlanName: planInfo.planName,
-                suggestedTier: nextTier,
-                periodStart: usageWindow.start_at,
-                transactionalEmailId: LOOPS_USAGE_LIMIT_TRANSACTIONAL_EMAIL_ID,
-                notificationTemplate: "usage_limit_alert",
-              }),
-              checkForDuplicates: true,
-            });
-            continue;
-          }
-
-          const activeSchedule = await getActiveScheduleForSubscription(
-            stripeCustomerId,
-            subscription.id,
-          );
-
-          if (!activeSchedule) {
-            await scheduleUpgrade({
-              stripeCustomerId,
-              subscription,
-              currentPlanItem,
-              currentPeriodEnd,
-              nextTier,
-            });
-
-            await maybeTriggerUsageNotification({
-              teamId,
-              notificationType: "usage_alert",
-              periodStart: usageWindow.start_at,
-              periodEnd: usageWindow.end_at,
-              message: `Usage exceeded current and previous plan limits (${usage}/${currentLimit} posts used this period).`,
-              metadata: buildUsageEmailMetadata({
-                teamId,
-                teamName,
-                usage,
-                currentLimit,
-                currentPlanPostLimit: planInfo.postLimit,
-                currentPlanName: planInfo.planName,
-                suggestedTier: nextTier,
-                periodStart: usageWindow.start_at,
-                transactionalEmailId: LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID,
-                notificationTemplate: "usage_limit_upgrade",
-              }),
-              checkForDuplicates: false,
-            });
-
-            logger.info("Scheduled usage-based upgrade to next tier", {
-              team_id: teamId,
-              subscription_id: subscription.id,
-              next_tier: nextTier.productId,
-            });
-
-            await trackUpgradeScheduled({
-              teamId,
-              stripeCustomerId,
-              subscription,
-              fromProductId: planInfo.productId,
-              toTier: nextTier,
-              usage,
-              currentLimit,
-            });
-
-            continue;
-          }
-
-          const scheduledTier = await getScheduledTierForSubscription({
-            schedule: activeSchedule,
-            currentPeriodEnd,
-          });
-
-          if (!scheduledTier) {
-            logger.info("Active schedule found without mapped upgrade tier", {
-              team_id: teamId,
-              subscription_id: subscription.id,
-              schedule_id: activeSchedule.id,
-              activeSchedule,
-            });
-
-            continue;
-          }
-
-          if (usage > scheduledTier.posts) {
-            const scheduledTierIndex = PRICING_TIERS.findIndex(
-              (tier) => tier.productId === scheduledTier.productId,
-            );
-            const nextScheduledTier = PRICING_TIERS[scheduledTierIndex + 1];
-
-            if (!nextScheduledTier) {
-              logger.info("Scheduled upgrade already at highest pricing tier", {
-                team_id: teamId,
-                subscription_id: subscription.id,
-                usage,
-                scheduled_tier: scheduledTier,
-              });
-              continue;
-            }
-            await scheduleUpgrade({
-              stripeCustomerId,
-              subscription,
-              currentPlanItem,
-              currentPeriodEnd,
-              nextTier: nextScheduledTier,
-            });
-
-            await maybeTriggerUsageNotification({
-              teamId,
-              notificationType: "usage_alert",
-              periodStart: usageWindow.start_at,
-              periodEnd: usageWindow.end_at,
-              message: `Usage exceeded current and previous plan limits (${usage}/${currentLimit} posts used this period).`,
-              metadata: buildUsageEmailMetadata({
-                teamId,
-                teamName,
-                usage,
-                currentLimit,
-                currentPlanPostLimit: planInfo.postLimit,
-                currentPlanName: planInfo.planName,
-                suggestedTier: nextScheduledTier,
-                periodStart: usageWindow.start_at,
-                transactionalEmailId: LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID,
-                notificationTemplate: "usage_limit_upgrade",
-              }),
-              checkForDuplicates: false,
-            });
-
-            logger.info("Replaced scheduled upgrade with next tier", {
-              team_id: teamId,
-              subscription_id: subscription.id,
-              previous_scheduled_tier: scheduledTier.productId,
-              next_scheduled_tier: nextScheduledTier.productId,
-            });
-
-            await trackUpgradeScheduled({
-              teamId,
-              stripeCustomerId,
-              subscription,
-              fromProductId: planInfo.productId,
-              toTier: nextScheduledTier,
-              previousScheduledProductId: scheduledTier.productId,
-              usage,
-              currentLimit,
-            });
-
-            continue;
-          }
-
-          logger.info("Team has not exceeded next tier usage", {
-            team_id: teamId,
-            subscription_id: subscription.id,
-            scheduled_tier: scheduledTier.productId,
-            usage: usage,
-          });
-        } catch (teamError) {
-          logger.error("Error processing team usage limits", {
-            team_id: teamId,
-            error: teamError,
-          });
-        }
+        await processExceededUsageWindow(usageWindow);
       }
 
       for (const usageWindow of activeUsageWindows) {

--- a/trigger/process-usage-limits.ts
+++ b/trigger/process-usage-limits.ts
@@ -715,6 +715,7 @@ const buildUsageEmailMetadata = ({
         current_plan_name: currentPlanName,
         suggested_plan_name: suggestedTier?.name ?? null,
         suggested_plan_post_limit: suggestedTier?.posts ?? null,
+        suggested_plan_price: suggestedTier?.price ?? null,
         billing_link: `https://app.postforme.dev/${teamId}/billing`,
         team_link: `https://app.postforme.dev/${teamId}/billing`,
         ...(thresholdPercent !== undefined


### PR DESCRIPTION
## Summary

Today a team that exceeds their plan limit gets two separate emails a full billing period apart: a "usage exceeded" alert on the first offending window, then a "you're being upgraded" email only after a second consecutive offending window. This two-strike split is confusing and delays the upgrade notice by a full billing period. This PR replaces both emails with a single "you will be upgraded" notice sent the moment a team first crosses 100%.

Stacks on #339 (80/90/95% usage-threshold warnings) and reuses its per-period notification-dedupe pattern.

## Changes

- Collapsed `usage_limit_alert` / `usage_limit_upgrade` into a single `usage_limit_upgrade_notice` template, sent once per billing period the moment a team crosses 100% (deduped the same way as the 80/90/95% warnings).
- The actual Stripe subscription-schedule creation still only happens on the second consecutive offending window — that gate (`hasExceededPreviouseLimit()`) is intentionally unchanged here; moving it up is the next stacked issue (PFM-1062). So there's a deliberate short window where the email promises an upgrade slightly ahead of the schedule being created.
- Escalation emails (when climbing usage bumps the pending schedule to a further tier) still fire, since the target tier genuinely changed.
- Removed `LOOPS_USAGE_LIMIT_TRANSACTIONAL_EMAIL_ID`; the merged email reuses `LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID`. No new env var or DB migration needed — both old emails already shared the same `usage_alert` notification_type; only the JSON `notification_template` value changed.
- Extracted the exceeded-usage-window loop body into an exported `processExceededUsageWindow()` so it's unit-testable (trigger.dev's `schedules.task()` doesn't expose `run` for direct invocation).
- Updated a stale doc reference to the old template names in `.agents/skills/conversion-tracking/references/event-catalog.md`.
- Fixed a 400 from Loops (`Missing required data variable(s): team_link, team_id, suggested_plan_price`) found while manually verifying the notice end-to-end: `team_id`/`team_link` were dropped when `buildUsageEmailMetadata` was unified in this PR, and `suggested_plan_price` was never sent even before this PR despite the price being available on `PRICING_TIERS`. All three are now included in the Loops payload.

## Testing

- `cd trigger && bun test` — 24 pass, including 4 new tests covering: single notice sent on first crossing, per-period dedup suppression, silent schedule creation on strike 2 (no duplicate email), and escalation (schedule bumped + follow-up notice).
- `cd trigger && bun run typecheck` and `bun run lint` — both clean.
- Manually triggered the notice locally against a real Stripe test subscription + Loops sandbox; confirmed the email now sends successfully after the fix above.

## Notes

- Out of scope, deferred to later stacked issues: moving the schedule-creation gate itself (PFM-1062), actually creating/renaming the Loops template content (PFM-1066).

Closes PFM-1061

🤖 Generated with AI
