### PR TITLE
fix(trigger): schedule upgrade on first 100% crossing, not the second

### DIFF
--- a/trigger/process-usage-limits.test.ts
+++ b/trigger/process-usage-limits.test.ts
@@ -135,9 +135,7 @@ describe("hasScheduledCancellation", () => {
 
   test("true when cancel_at is set", () => {
     expect(
-      mod.hasScheduledCancellation(
-        makeSubscription({ cancel_at: 1893456000 }),
-      ),
+      mod.hasScheduledCancellation(makeSubscription({ cancel_at: 1893456000 })),
     ).toBe(true);
   });
 });
@@ -329,36 +327,62 @@ describe("processExceededUsageWindow (PFM-1061/PFM-1062 single-strike upgrade fl
   // stubbed to "not found" so it no-ops rather than needing its own fixture.
   //
   // `notificationResultStatuses` models what's already recorded for the
-  // *current* period: `[]` means no attempt yet (or none confirmed), `["sent"]`
-  // means a prior attempt was confirmed delivered, `["failed"]`/`["skipped"]`
-  // models a prior attempt that didn't actually reach the team.
+  // *current* period when a query has no `meta_data->>notification_template`
+  // filter: `[]` means no attempt yet (or none confirmed), `["sent"]` means a
+  // prior attempt was confirmed delivered, `["failed"]`/`["skipped"]` models a
+  // prior attempt that didn't actually reach the team.
+  //
+  // `templateResultStatuses` overrides that per notification_template, for
+  // tests that need the "you will be upgraded" notice and the "upgrade
+  // failed" correction to report different delivery states within the same
+  // `processExceededUsageWindow` call.
+  //
+  // `teamNotificationsQueryCount` (reset in `beforeEach`) counts every
+  // `.from("team_notifications")` call so a regression reintroducing a
+  // redundant duplicate query is caught even though it wouldn't change any
+  // send/defer assertion.
+  let teamNotificationsQueryCount = 0;
+
   const fakeSupabaseFrom =
     ({
       notificationResultStatuses = [],
+      templateResultStatuses = {},
     }: {
       notificationResultStatuses?: string[];
-    }) =>
+      templateResultStatuses?: Record<string, string[]>;
+    } = {}) =>
     (table: string) => {
       if (table === "team_notifications") {
+        teamNotificationsQueryCount += 1;
+        let queriedTemplate: string | undefined;
         const builder: any = {
           select: () => builder,
-          eq: () => builder,
+          eq: (column: string, value: string) => {
+            if (column === "meta_data->>notification_template") {
+              queriedTemplate = value;
+            }
+            return builder;
+          },
           gte: () => builder,
-          lt: () => ({
-            data:
-              notificationResultStatuses.length > 0
-                ? [
-                    {
-                      meta_data: {
-                        results: notificationResultStatuses.map((status) => ({
-                          status,
-                        })),
+          lt: () => {
+            const statuses =
+              queriedTemplate && queriedTemplate in templateResultStatuses
+                ? templateResultStatuses[queriedTemplate]
+                : notificationResultStatuses;
+            return {
+              data:
+                statuses.length > 0
+                  ? [
+                      {
+                        meta_data: {
+                          results: statuses.map((status) => ({ status })),
+                        },
                       },
-                    },
-                  ]
-                : [],
-            error: null,
-          }),
+                    ]
+                  : [],
+              error: null,
+            };
+          },
         };
         return builder;
       }
@@ -408,6 +432,7 @@ describe("processExceededUsageWindow (PFM-1061/PFM-1062 single-strike upgrade fl
 
   beforeEach(() => {
     taskTriggerCalls.length = 0;
+    teamNotificationsQueryCount = 0;
   });
 
   test("first-ever exceeded window: sends the confident upgrade notice, defers the Stripe schedule", async () => {
@@ -436,6 +461,9 @@ describe("processExceededUsageWindow (PFM-1061/PFM-1062 single-strike upgrade fl
     expect((payload.meta_data as any).data.loops.transactional_id).toBe(
       "loops_upgrade",
     );
+    // Regression guard: the send-decision and the defer-decision must share
+    // a single `team_notifications` query, not issue it twice.
+    expect(teamNotificationsQueryCount).toBe(1);
   });
 
   test("does not re-send when the period was already confirmed delivered", async () => {
@@ -488,6 +516,64 @@ describe("processExceededUsageWindow (PFM-1061/PFM-1062 single-strike upgrade fl
 
     expect(create).toHaveBeenCalledTimes(1);
     // Already delivered for this period, so the dedup check skips re-sending.
+    expect(taskTriggerCalls.length).toBe(0);
+  });
+
+  test("eligibility lost after promising an upgrade: sends a correction notice", async () => {
+    // The "you will be upgraded" notice was confirmed delivered on an
+    // earlier tick, but this tick's eligibility check comes back ineligible
+    // (e.g. the customer cancelled in reaction to the email) — the broken
+    // promise must be corrected, not left silent.
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      templateResultStatuses: {
+        usage_limit_upgrade_notice: ["sent"],
+        usage_limit_upgrade_failed: [],
+      },
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({ data: [] })) as any;
+
+    await mod.processExceededUsageWindow(makeUsageWindow() as any);
+
+    expect(taskTriggerCalls.length).toBe(1);
+    const [{ id, payload }] = taskTriggerCalls;
+    expect(id).toBe("process-team-notification");
+    expect(payload.notification_type).toBe("usage_alert");
+    expect(payload.message).toContain("unable to automatically upgrade");
+    expect((payload.meta_data as any).notification_template).toBe(
+      "usage_limit_upgrade_failed",
+    );
+    expect((payload.meta_data as any).data.loops.transactional_id).toBe(
+      "loops_upgrade_failed",
+    );
+  });
+
+  test("eligibility lost after promising an upgrade: does not re-send an already-sent correction", async () => {
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      templateResultStatuses: {
+        usage_limit_upgrade_notice: ["sent"],
+        usage_limit_upgrade_failed: ["sent"],
+      },
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({ data: [] })) as any;
+
+    await mod.processExceededUsageWindow(makeUsageWindow() as any);
+
+    expect(taskTriggerCalls.length).toBe(0);
+  });
+
+  test("never-eligible team crossing 100%: no correction notice, since no upgrade was ever promised", async () => {
+    // The team was ineligible from the start this period (e.g. no active
+    // Stripe subscription) — nothing was promised, so no correction fires.
+    mod.supabaseClient.from = fakeSupabaseFrom({
+      templateResultStatuses: {
+        usage_limit_upgrade_notice: [],
+        usage_limit_upgrade_failed: [],
+      },
+    }) as any;
+    mod.stripe.subscriptions.list = mock(async () => ({ data: [] })) as any;
+
+    await mod.processExceededUsageWindow(makeUsageWindow() as any);
+
     expect(taskTriggerCalls.length).toBe(0);
   });
 

--- a/trigger/process-usage-limits.test.ts
+++ b/trigger/process-usage-limits.test.ts
@@ -333,9 +333,8 @@ describe("processExceededUsageWindow (PFM-1061/PFM-1062 single-strike upgrade fl
   // prior attempt that didn't actually reach the team.
   //
   // `templateResultStatuses` overrides that per notification_template, for
-  // tests that need the "you will be upgraded" notice and the "upgrade
-  // failed" correction to report different delivery states within the same
-  // `processExceededUsageWindow` call.
+  // tests that need a specific template's delivery state distinguished from
+  // the current period's general `notificationResultStatuses` default.
   //
   // `teamNotificationsQueryCount` (reset in `beforeEach`) counts every
   // `.from("team_notifications")` call so a regression reintroducing a
@@ -519,39 +518,14 @@ describe("processExceededUsageWindow (PFM-1061/PFM-1062 single-strike upgrade fl
     expect(taskTriggerCalls.length).toBe(0);
   });
 
-  test("eligibility lost after promising an upgrade: sends a correction notice", async () => {
+  test("eligibility lost after promising an upgrade: no notification is sent", async () => {
     // The "you will be upgraded" notice was confirmed delivered on an
     // earlier tick, but this tick's eligibility check comes back ineligible
-    // (e.g. the customer cancelled in reaction to the email) — the broken
-    // promise must be corrected, not left silent.
+    // (e.g. the customer cancelled in reaction to the email) — this is
+    // logged internally but no customer-facing email fires.
     mod.supabaseClient.from = fakeSupabaseFrom({
       templateResultStatuses: {
         usage_limit_upgrade_notice: ["sent"],
-        usage_limit_upgrade_failed: [],
-      },
-    }) as any;
-    mod.stripe.subscriptions.list = mock(async () => ({ data: [] })) as any;
-
-    await mod.processExceededUsageWindow(makeUsageWindow() as any);
-
-    expect(taskTriggerCalls.length).toBe(1);
-    const [{ id, payload }] = taskTriggerCalls;
-    expect(id).toBe("process-team-notification");
-    expect(payload.notification_type).toBe("usage_alert");
-    expect(payload.message).toContain("unable to automatically upgrade");
-    expect((payload.meta_data as any).notification_template).toBe(
-      "usage_limit_upgrade_failed",
-    );
-    expect((payload.meta_data as any).data.loops.transactional_id).toBe(
-      "loops_upgrade_failed",
-    );
-  });
-
-  test("eligibility lost after promising an upgrade: does not re-send an already-sent correction", async () => {
-    mod.supabaseClient.from = fakeSupabaseFrom({
-      templateResultStatuses: {
-        usage_limit_upgrade_notice: ["sent"],
-        usage_limit_upgrade_failed: ["sent"],
       },
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({ data: [] })) as any;
@@ -561,13 +535,12 @@ describe("processExceededUsageWindow (PFM-1061/PFM-1062 single-strike upgrade fl
     expect(taskTriggerCalls.length).toBe(0);
   });
 
-  test("never-eligible team crossing 100%: no correction notice, since no upgrade was ever promised", async () => {
+  test("never-eligible team crossing 100%: no notification, since no upgrade was ever promised", async () => {
     // The team was ineligible from the start this period (e.g. no active
-    // Stripe subscription) — nothing was promised, so no correction fires.
+    // Stripe subscription) — nothing was promised, so nothing fires or logs.
     mod.supabaseClient.from = fakeSupabaseFrom({
       templateResultStatuses: {
         usage_limit_upgrade_notice: [],
-        usage_limit_upgrade_failed: [],
       },
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({ data: [] })) as any;

--- a/trigger/process-usage-limits.test.ts
+++ b/trigger/process-usage-limits.test.ts
@@ -311,7 +311,7 @@ describe("hasHigherOrEqualUsageNotification", () => {
   });
 });
 
-describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
+describe("processExceededUsageWindow (PFM-1061/PFM-1062 single-strike upgrade flow)", () => {
   const makeUsageWindow = (overrides: Record<string, unknown> = {}) => ({
     team_id: "team_1",
     count: 1200,
@@ -324,8 +324,7 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
   });
 
   // Routes `supabaseClient.from(table)` per-table so a single fake can back
-  // both `hasExceededPreviouseLimit` (`social_post_team_usage`) and
-  // `hasUsageNotificationForPeriod` (`team_notifications`) within one call to
+  // `hasUsageNotificationForPeriod` (`team_notifications`) for
   // `processExceededUsageWindow`. `trackUpgradeScheduled`'s `teams` lookup is
   // stubbed to "not found" so it no-ops rather than needing its own fixture.
   //
@@ -335,36 +334,11 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
   // models a prior attempt that didn't actually reach the team.
   const fakeSupabaseFrom =
     ({
-      previousWindow = null,
       notificationResultStatuses = [],
     }: {
-      previousWindow?: { count: number; limit: number } | null;
       notificationResultStatuses?: string[];
     }) =>
     (table: string) => {
-      if (table === "social_post_team_usage") {
-        const builder: any = {
-          select: () => builder,
-          eq: () => builder,
-          lte: () => builder,
-          order: () => builder,
-          limit: () => builder,
-          maybeSingle: async () => ({
-            data: previousWindow
-              ? {
-                  team_id: "team_1",
-                  count: previousWindow.count,
-                  limit: previousWindow.limit,
-                  start_at: "2026-01-01T00:00:00Z",
-                  end_at: "2026-02-01T00:00:00Z",
-                }
-              : null,
-            error: null,
-          }),
-        };
-        return builder;
-      }
-
       if (table === "team_notifications") {
         const builder: any = {
           select: () => builder,
@@ -436,9 +410,11 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     taskTriggerCalls.length = 0;
   });
 
-  test("first exceeded window: sends the hedged notice once, creates no Stripe schedule", async () => {
+  test("first-ever exceeded window: sends the confident upgrade notice, defers the Stripe schedule", async () => {
+    // No prior exceeded period is modeled anywhere — PFM-1062 removed the
+    // two-strike gate, so a single crossing is enough to promise the
+    // upgrade. The schedule itself still waits for confirmed delivery.
     mod.supabaseClient.from = fakeSupabaseFrom({
-      previousWindow: null, // not exceeded previously → strike 1
       notificationResultStatuses: [],
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({
@@ -453,9 +429,7 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     const [{ id, payload }] = taskTriggerCalls;
     expect(id).toBe("process-team-notification");
     expect(payload.notification_type).toBe("usage_alert");
-    // Strike 1 doesn't yet know a schedule will be created — the message
-    // must not promise the upgrade unconditionally.
-    expect(payload.message).toContain("If usage remains above your plan limit");
+    expect(payload.message).toContain("You will be upgraded to the next tier.");
     expect((payload.meta_data as any).notification_template).toBe(
       "usage_limit_upgrade_notice",
     );
@@ -466,7 +440,6 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
 
   test("does not re-send when the period was already confirmed delivered", async () => {
     mod.supabaseClient.from = fakeSupabaseFrom({
-      previousWindow: null,
       notificationResultStatuses: ["sent"],
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({
@@ -484,7 +457,6 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     // "notified", or a team whose only send attempt fails would never be
     // retried yet could still be auto-upgraded later.
     mod.supabaseClient.from = fakeSupabaseFrom({
-      previousWindow: null,
       notificationResultStatuses: ["failed"],
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({
@@ -498,30 +470,12 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     expect(taskTriggerCalls.length).toBe(1);
   });
 
-  test("second consecutive exceeded window, notice not yet confirmed delivered: defers the Stripe schedule", async () => {
+  test("first-ever exceeded window, notice already confirmed delivered: creates the Stripe schedule with no additional email", async () => {
+    // Core PFM-1062 regression test: no prior exceeded period at all, yet a
+    // single confirmed-delivered crossing is enough to create the schedule —
+    // the old two-strike gate required this to be the *second* consecutive
+    // exceeded period before scheduling anything.
     mod.supabaseClient.from = fakeSupabaseFrom({
-      previousWindow: { count: 1100, limit: 1000 }, // exceeded previous period too → strike 2
-      notificationResultStatuses: [], // this period's notice hasn't been confirmed sent yet
-    }) as any;
-    mod.stripe.subscriptions.list = mock(async () => ({
-      data: [makeSubscription()],
-    })) as any;
-    refuseSubscriptionScheduleWrites();
-
-    await mod.processExceededUsageWindow(makeUsageWindow() as any);
-
-    // The notice is fired this tick, but schedule creation waits for
-    // confirmed delivery — otherwise a team could be upgraded without ever
-    // having received a working notification.
-    expect(taskTriggerCalls.length).toBe(1);
-    expect(taskTriggerCalls[0].payload.message).toContain(
-      "You will be upgraded to the next tier.",
-    );
-  });
-
-  test("second consecutive exceeded window, notice already confirmed delivered: creates the Stripe schedule with no additional email", async () => {
-    mod.supabaseClient.from = fakeSupabaseFrom({
-      previousWindow: { count: 1100, limit: 1000 }, // exceeded previous period too → strike 2
       notificationResultStatuses: ["sent"], // confirmed delivered on an earlier tick
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({
@@ -562,9 +516,8 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
 
   test("escalation: usage exceeds the scheduled tier, schedule is bumped, and a follow-up notice fires", async () => {
     mod.supabaseClient.from = fakeSupabaseFrom({
-      previousWindow: { count: 1100, limit: 1000 },
       // An active schedule can only exist if the current period's notice
-      // was already confirmed delivered (the new gate in Fix 1).
+      // was already confirmed delivered (the PFM-1061 delivery-confirmation gate).
       notificationResultStatuses: ["sent"],
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({
@@ -581,7 +534,7 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
     );
 
     expect(create).toHaveBeenCalledTimes(1); // re-scheduled to tier_5k
-    // The strike-1-style notice is deduped (already confirmed sent above),
+    // The initial crossing notice is deduped (already confirmed sent above),
     // so only the escalation notice fires.
     expect(taskTriggerCalls.length).toBe(1);
     const escalationPayload = taskTriggerCalls[0].payload;
@@ -595,7 +548,6 @@ describe("processExceededUsageWindow (PFM-1061 single-email flow)", () => {
 
   test("escalation: a burst that skips multiple tiers converges to the correct tier in one step", async () => {
     mod.supabaseClient.from = fakeSupabaseFrom({
-      previousWindow: { count: 1100, limit: 1000 },
       notificationResultStatuses: ["sent"],
     }) as any;
     mod.stripe.subscriptions.list = mock(async () => ({

--- a/trigger/process-usage-limits.ts
+++ b/trigger/process-usage-limits.ts
@@ -38,8 +38,6 @@ const LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID =
 const LOOPS_USAGE_THRESHOLD_TRANSACTIONAL_EMAIL_ID =
   process.env?.LOOPS_USAGE_THRESHOLD_TRANSACTIONAL_EMAIL_ID || "";
 
-type TeamUsageWindow =
-  Database["public"]["Tables"]["social_post_team_usage"]["Row"];
 type ExceededUsageWindow =
   Database["public"]["Functions"]["get_exceeded_team_usage_windows"]["Returns"][number];
 type ActiveUsageWindow =
@@ -378,32 +376,6 @@ const getActiveUsageWindows = async (): Promise<ActiveUsageWindow[]> => {
   }
 
   return data ?? [];
-};
-
-const hasExceededPreviouseLimit = async (
-  teamId: string,
-  currentWindow: TeamUsageWindow,
-): Promise<boolean> => {
-  const { data, error } = await supabaseClient
-    .from("social_post_team_usage")
-    .select("team_id, count, limit, start_at, end_at")
-    .eq("team_id", teamId)
-    .lte("end_at", currentWindow.start_at)
-    .order("end_at", { ascending: false })
-    .order("start_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
-    logger.error("Unable to get previouse usage window");
-    return false;
-  }
-
-  if (!data) {
-    return false;
-  }
-
-  return data.count > data.limit;
 };
 
 type NotificationDeliveryResult = { status?: string };
@@ -850,9 +822,9 @@ const trackUpgradeScheduled = async ({
 
 /**
  * Processes a single exceeded (>=100%) usage window: sends the single
- * "you will be upgraded" notice, then handles Stripe schedule creation /
- * escalation under the `hasExceededPreviouseLimit()` gate plus a confirmed-
- * delivery check for the current period's notice.
+ * "you will be upgraded" notice every period a team crosses 100%, then
+ * creates or escalates the Stripe schedule once this period's notice is
+ * confirmed delivered — no waiting for a second consecutive exceeded period.
  * Extracted from the cron `run` body so it's unit-testable in isolation —
  * trigger.dev's `schedules.task()` doesn't expose `run` for direct
  * invocation outside its own runtime.
@@ -886,10 +858,10 @@ export const processExceededUsageWindow = async (
       return;
     }
 
-    const [exceededPreviousLimit, eligiblePlan] = await Promise.all([
-      hasExceededPreviouseLimit(teamId, usageWindow),
-      getEligibleSubscriptionPlan({ teamId, stripeCustomerId }),
-    ]);
+    const eligiblePlan = await getEligibleSubscriptionPlan({
+      teamId,
+      stripeCustomerId,
+    });
 
     if (!eligiblePlan) {
       return;
@@ -907,16 +879,10 @@ export const processExceededUsageWindow = async (
     }
 
     // Single "you will be upgraded" notice, sent once per period the
-    // moment a team crosses 100% — regardless of strike count. Deduped
-    // per period so a repeat cron pass (or a later strike in the same
-    // period) doesn't re-send it. Wording is conditioned on
-    // `exceededPreviousLimit`: only when this is (at least) the second
-    // consecutive exceeded period is the schedule about to be created
-    // below, so only then does the notice promise it confidently.
-    const noticeMessage = exceededPreviousLimit
-      ? `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). You will be upgraded to the next tier.`
-      : `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). If usage remains above your plan limit next billing period, you'll be upgraded to the next tier.`;
-
+    // moment a team crosses 100%. Deduped per period so a repeat cron pass
+    // doesn't re-send it. The schedule creation below always follows this
+    // same crossing (once delivery is confirmed), so the notice can always
+    // promise the upgrade confidently.
     await sendUpgradeNotice({
       teamId,
       teamName,
@@ -925,13 +891,9 @@ export const processExceededUsageWindow = async (
       planInfo,
       usageWindow,
       suggestedTier: nextTier,
-      message: noticeMessage,
+      message: `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). You will be upgraded to the next tier.`,
       checkForDuplicates: true,
     });
-
-    if (!exceededPreviousLimit) {
-      return;
-    }
 
     // Delivery happens in a separate async task (process-team-notification),
     // so it can't be confirmed synchronously above — require a confirmed

--- a/trigger/process-usage-limits.ts
+++ b/trigger/process-usage-limits.ts
@@ -676,7 +676,7 @@ const buildUsageEmailMetadata = ({
         suggested_plan_post_limit: suggestedTier?.posts ?? null,
         suggested_plan_price: suggestedTier?.price ?? null,
         billing_link: `https://app.postforme.dev/${teamId}/billing`,
-        team_link: `https://app.postforme.dev/${teamId}/billing`,
+        team_link: `https://app.postforme.dev/${teamId}`,
         ...(thresholdPercent !== undefined
           ? { threshold_percent: thresholdPercent }
           : {}),

--- a/trigger/process-usage-limits.ts
+++ b/trigger/process-usage-limits.ts
@@ -69,6 +69,7 @@ export const USAGE_WARNING_THRESHOLDS = [
 
 type UsageEmailTemplate =
   | "usage_limit_upgrade_notice"
+  | "usage_limit_upgrade_failed"
   | (typeof USAGE_WARNING_THRESHOLDS)[number]["notificationTemplate"];
 
 // Returns the highest threshold whose percent has been crossed. Does not
@@ -216,8 +217,8 @@ export const hasScheduledCancellation = (
 ): boolean => {
   return Boolean(
     subscription.cancel_at_period_end ||
-      subscription.cancel_at ||
-      subscription.cancellation_details?.reason,
+    subscription.cancel_at ||
+    subscription.cancellation_details?.reason,
   );
 };
 
@@ -343,7 +344,9 @@ export const getEligibleSubscriptionPlan = async ({
     (tier) => tier.productId === planInfo.productId,
   );
   const nextTier =
-    currentTierIndex >= 0 ? (PRICING_TIERS[currentTierIndex + 1] ?? null) : null;
+    currentTierIndex >= 0
+      ? (PRICING_TIERS[currentTierIndex + 1] ?? null)
+      : null;
 
   return {
     subscription,
@@ -390,12 +393,19 @@ const hasUsageNotificationForPeriod = async (
   notificationType: TeamNotificationType,
   periodStart: string,
   periodEnd: string,
+  notificationTemplate?: UsageEmailTemplate,
 ): Promise<boolean> => {
-  const { data, error } = await supabaseClient
+  let query = supabaseClient
     .from("team_notifications")
     .select("meta_data")
     .eq("notification_type", notificationType)
-    .eq("team_id", teamId)
+    .eq("team_id", teamId);
+
+  if (notificationTemplate) {
+    query = query.eq("meta_data->>notification_template", notificationTemplate);
+  }
+
+  const { data, error } = await query
     .gte("created_at", periodStart)
     .lt("created_at", periodEnd);
 
@@ -404,10 +414,10 @@ const hasUsageNotificationForPeriod = async (
   }
 
   return (data ?? []).some((row) => {
-    const results = (row.meta_data as NotificationRowMetadata | null)
-      ?.results;
+    const results = (row.meta_data as NotificationRowMetadata | null)?.results;
     return (
-      Array.isArray(results) && results.some((result) => result.status === "sent")
+      Array.isArray(results) &&
+      results.some((result) => result.status === "sent")
     );
   });
 };
@@ -449,7 +459,6 @@ const maybeTriggerUsageNotification = async ({
   periodEnd,
   message,
   metadata,
-  checkForDuplicates,
 }: {
   teamId: string;
   notificationType: TeamNotificationType;
@@ -457,27 +466,7 @@ const maybeTriggerUsageNotification = async ({
   periodEnd: string;
   message: string;
   metadata: Json;
-  checkForDuplicates: boolean;
-}): Promise<boolean> => {
-  if (checkForDuplicates) {
-    const alreadySent = await hasUsageNotificationForPeriod(
-      teamId,
-      notificationType,
-      periodStart,
-      periodEnd,
-    );
-
-    if (alreadySent) {
-      logger.info("Usage notification already sent for period", {
-        team_id: teamId,
-        notification_type: notificationType,
-        period_start: periodStart,
-        period_end: periodEnd,
-      });
-      return false;
-    }
-  }
-
+}): Promise<void> => {
   logger.info("Triggering usage notification", {
     team_id: teamId,
     notification_type: notificationType,
@@ -485,7 +474,6 @@ const maybeTriggerUsageNotification = async ({
     period_end: periodEnd,
   });
   await triggerTeamNotification(teamId, message, metadata, notificationType);
-  return true;
 };
 
 const getActiveScheduleForSubscription = async (
@@ -711,7 +699,6 @@ const sendUpgradeNotice = ({
   usageWindow,
   suggestedTier,
   message,
-  checkForDuplicates,
 }: {
   teamId: string;
   teamName: string | null;
@@ -721,8 +708,7 @@ const sendUpgradeNotice = ({
   usageWindow: ExceededUsageWindow;
   suggestedTier: (typeof PRICING_TIERS)[number] | null;
   message: string;
-  checkForDuplicates: boolean;
-}): Promise<boolean> =>
+}): Promise<void> =>
   maybeTriggerUsageNotification({
     teamId,
     notificationType: "usage_alert",
@@ -741,7 +727,6 @@ const sendUpgradeNotice = ({
       transactionalEmailId: LOOPS_USAGE_UPGRADE_TRANSACTIONAL_EMAIL_ID,
       notificationTemplate: "usage_limit_upgrade_notice",
     }),
-    checkForDuplicates,
   });
 
 /**
@@ -784,8 +769,8 @@ const trackUpgradeScheduled = async ({
 
     const postLimitOf = (productId: string | null | undefined) =>
       productId
-        ? PRICING_TIERS.find((tier) => tier.productId === productId)?.posts ??
-          null
+        ? (PRICING_TIERS.find((tier) => tier.productId === productId)?.posts ??
+          null)
         : null;
 
     const isEscalation = previousScheduledProductId != null;
@@ -864,11 +849,70 @@ export const processExceededUsageWindow = async (
     });
 
     if (!eligiblePlan) {
+      // If we already promised this team an upgrade this period, eligibility
+      // being lost before the deferred schedule-creation tick (e.g. the
+      // customer cancels in reaction to the notice) breaks that promise —
+      // send a one-time correction so they're not left thinking it happened.
+      const wasPromisedUpgrade = await hasUsageNotificationForPeriod(
+        teamId,
+        "usage_alert",
+        usageWindow.start_at,
+        usageWindow.end_at,
+        "usage_limit_upgrade_notice",
+      );
+
+      if (!wasPromisedUpgrade) {
+        return;
+      }
+
+      const correctionAlreadySent = await hasUsageNotificationForPeriod(
+        teamId,
+        "usage_alert",
+        usageWindow.start_at,
+        usageWindow.end_at,
+        "usage_limit_upgrade_failed",
+      );
+
+      if (correctionAlreadySent) {
+        return;
+      }
+
+      await maybeTriggerUsageNotification({
+        teamId,
+        notificationType: "usage_alert",
+        periodStart: usageWindow.start_at,
+        periodEnd: usageWindow.end_at,
+        message: `We were unable to automatically upgrade your plan after usage exceeded the limit (${usage}/${currentLimit} posts used this period). Please upgrade manually from billing or contact support.`,
+        metadata: buildUsageEmailMetadata({
+          teamId,
+          teamName,
+          usage,
+          currentLimit,
+          currentPlanPostLimit: null,
+          currentPlanName: null,
+          suggestedTier: null,
+          periodStart: usageWindow.start_at,
+          transactionalEmailId:
+            LOOPS_USAGE_UPGRADE_FAILED_TRANSACTIONAL_EMAIL_ID,
+          notificationTemplate: "usage_limit_upgrade_failed",
+        }),
+      });
+
+      logger.warn(
+        "Upgrade eligibility lost after promising an upgrade; sent correction notice",
+        { team_id: teamId },
+      );
+
       return;
     }
 
-    const { subscription, planInfo, currentPlanItem, currentPeriodEnd, nextTier } =
-      eligiblePlan;
+    const {
+      subscription,
+      planInfo,
+      currentPlanItem,
+      currentPeriodEnd,
+      nextTier,
+    } = eligiblePlan;
 
     if (!nextTier) {
       logger.info("Team is already on highest pricing tier", {
@@ -878,29 +922,11 @@ export const processExceededUsageWindow = async (
       return;
     }
 
-    // Single "you will be upgraded" notice, sent once per period the
-    // moment a team crosses 100%. Deduped per period so a repeat cron pass
-    // doesn't re-send it. The schedule creation below always follows this
-    // same crossing (once delivery is confirmed), so the notice can always
-    // promise the upgrade confidently.
-    await sendUpgradeNotice({
-      teamId,
-      teamName,
-      usage,
-      currentLimit,
-      planInfo,
-      usageWindow,
-      suggestedTier: nextTier,
-      message: `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). You will be upgraded to the next tier.`,
-      checkForDuplicates: true,
-    });
-
-    // Delivery happens in a separate async task (process-team-notification),
-    // so it can't be confirmed synchronously above — require a confirmed
-    // send for the current period before creating/escalating the Stripe
-    // schedule. This defers schedule creation by at least one cron tick
-    // after a successful send, closing the gap where a team could be
-    // upgraded/billed without ever receiving a working notification.
+    // Single "you will be upgraded" notice, sent once per period the moment
+    // a team crosses 100%. Checked once up front and reused below for the
+    // defer decision — nothing between the two can change the answer, since
+    // delivery confirmation lands asynchronously via a separate task, not
+    // synchronously within this tick.
     const currentPeriodNotified = await hasUsageNotificationForPeriod(
       teamId,
       "usage_alert",
@@ -908,6 +934,25 @@ export const processExceededUsageWindow = async (
       usageWindow.end_at,
     );
 
+    if (!currentPeriodNotified) {
+      await sendUpgradeNotice({
+        teamId,
+        teamName,
+        usage,
+        currentLimit,
+        planInfo,
+        usageWindow,
+        suggestedTier: nextTier,
+        message: `Usage exceeded current plan limit (${usage}/${currentLimit} posts used this period). You will be upgraded to the next tier.`,
+      });
+    }
+
+    // Delivery happens in a separate async task (process-team-notification),
+    // so it can't be confirmed synchronously above — require a confirmed
+    // send for the current period before creating/escalating the Stripe
+    // schedule. This defers schedule creation by at least one cron tick
+    // after a successful send, closing the gap where a team could be
+    // upgraded/billed without ever receiving a working notification.
     if (!currentPeriodNotified) {
       logger.info(
         "Deferring upgrade schedule until usage notice is confirmed delivered",
@@ -1010,7 +1055,6 @@ export const processExceededUsageWindow = async (
         usageWindow,
         suggestedTier: nextScheduledTier,
         message: `Usage exceeded current and previous plan limits (${usage}/${currentLimit} posts used this period).`,
-        checkForDuplicates: false,
       });
 
       logger.info("Replaced scheduled upgrade with next tier", {
@@ -1159,11 +1203,11 @@ export const processUsageLimits = schedules.task({
               currentPlanName: planInfo.planName,
               suggestedTier: nextTier,
               periodStart,
-              transactionalEmailId: LOOPS_USAGE_THRESHOLD_TRANSACTIONAL_EMAIL_ID,
+              transactionalEmailId:
+                LOOPS_USAGE_THRESHOLD_TRANSACTIONAL_EMAIL_ID,
               notificationTemplate: crossedThreshold.notificationTemplate,
               thresholdPercent: crossedThreshold.percent,
             }),
-            checkForDuplicates: false,
           });
         } catch (teamError) {
           logger.error("Error processing team usage threshold warning", {

--- a/trigger/process-usage-limits.ts
+++ b/trigger/process-usage-limits.ts
@@ -69,7 +69,6 @@ export const USAGE_WARNING_THRESHOLDS = [
 
 type UsageEmailTemplate =
   | "usage_limit_upgrade_notice"
-  | "usage_limit_upgrade_failed"
   | (typeof USAGE_WARNING_THRESHOLDS)[number]["notificationTemplate"];
 
 // Returns the highest threshold whose percent has been crossed. Does not
@@ -851,8 +850,9 @@ export const processExceededUsageWindow = async (
     if (!eligiblePlan) {
       // If we already promised this team an upgrade this period, eligibility
       // being lost before the deferred schedule-creation tick (e.g. the
-      // customer cancels in reaction to the notice) breaks that promise —
-      // send a one-time correction so they're not left thinking it happened.
+      // customer cancels in reaction to the notice) breaks that promise.
+      // No customer-facing correction is sent for this — logged for internal
+      // visibility only.
       const wasPromisedUpgrade = await hasUsageNotificationForPeriod(
         teamId,
         "usage_alert",
@@ -861,47 +861,11 @@ export const processExceededUsageWindow = async (
         "usage_limit_upgrade_notice",
       );
 
-      if (!wasPromisedUpgrade) {
-        return;
+      if (wasPromisedUpgrade) {
+        logger.warn("Upgrade eligibility lost after promising an upgrade", {
+          team_id: teamId,
+        });
       }
-
-      const correctionAlreadySent = await hasUsageNotificationForPeriod(
-        teamId,
-        "usage_alert",
-        usageWindow.start_at,
-        usageWindow.end_at,
-        "usage_limit_upgrade_failed",
-      );
-
-      if (correctionAlreadySent) {
-        return;
-      }
-
-      await maybeTriggerUsageNotification({
-        teamId,
-        notificationType: "usage_alert",
-        periodStart: usageWindow.start_at,
-        periodEnd: usageWindow.end_at,
-        message: `We were unable to automatically upgrade your plan after usage exceeded the limit (${usage}/${currentLimit} posts used this period). Please upgrade manually from billing or contact support.`,
-        metadata: buildUsageEmailMetadata({
-          teamId,
-          teamName,
-          usage,
-          currentLimit,
-          currentPlanPostLimit: null,
-          currentPlanName: null,
-          suggestedTier: null,
-          periodStart: usageWindow.start_at,
-          transactionalEmailId:
-            LOOPS_USAGE_UPGRADE_FAILED_TRANSACTIONAL_EMAIL_ID,
-          notificationTemplate: "usage_limit_upgrade_failed",
-        }),
-      });
-
-      logger.warn(
-        "Upgrade eligibility lost after promising an upgrade; sent correction notice",
-        { team_id: teamId },
-      );
 
       return;
     }


### PR DESCRIPTION
## Summary

Stack 1, part 3/3 of "Refine Auto-Upgrade" (stacks on #340). The single "you will be upgraded" email now fires on the first 100% crossing, but the Stripe schedule that actually performs the upgrade still required a team to exceed their limit for two consecutive full billing periods before anything got scheduled. This closes that gap so the schedule follows the same first crossing the email already promises.

## Changes

- Removed `hasExceededPreviouseLimit()` (and its now-unused `TeamUsageWindow` type) — the two-strike gate that checked the team's *previous* billing period before allowing schedule creation.
- `processExceededUsageWindow` now creates/escalates the Stripe schedule as soon as the current period's upgrade notice is confirmed delivered (the existing PFM-1061 delivery-confirmation gate, unchanged) — no longer waiting on a second consecutive exceeded period.
- The notice message is now always the confident "You will be upgraded to the next tier." wording, since scheduling always follows the same crossing now.
- No changes to the escalation logic itself (`scheduleUpgrade`, tier-jump convergence) — verified via tests that it still correctly bumps an already-scheduled tier further if usage keeps climbing within the same period.
- **Removed the "upgrade failed" correction email.** If a team's eligibility for the automatic upgrade was lost after the "you will be upgraded" notice already went out (e.g. they cancel in reaction, or their subscription goes `past_due`), the code used to send a one-time correction email explaining the automatic upgrade didn't happen. That email is no longer needed — the eligibility-loss case is still detected and logged (`logger.warn`) for internal visibility, but no customer-facing email fires and no delivery-dedup notification row is written for it.
- **Fixed missing Loops data variables on the upgrade notice.** Manual verification against the live `usage_limit_upgrade_notice` Loops template surfaced a 400 (`Missing required data variable(s): team_link, team_id, suggested_plan_price.`) — `buildUsageEmailMetadata` was never sending those three variables even though `PRICING_TIERS` already carried a `price` per tier. Added `team_id`, `team_link` (team dashboard root), and `suggested_plan_price` to the shared Loops payload builder, so both the upgrade notice and the threshold-warning emails send them.

## Testing

- `cd trigger && bun test process-usage-limits.test.ts` — 25 pass, covering the single-crossing schedule creation, escalation/tier-jump convergence, and the (now email-less) eligibility-loss and never-eligible cases.
- `cd trigger && bun run typecheck` and `bun run lint` — clean.
- Manually triggered the upgrade-notice email against the live Loops transactional endpoint (test-mode team/Stripe customer) to catch the data-variable mismatch above; confirmed after the fix.

Closes PFM-1062

🤖 Generated with AI
