### PR TITLE
fix(dashboard): correct uninterrupted-service copy on usage page

### DIFF
--- a/dashboard/app/routes/_protected.$teamId.usage._index/route.component.tsx
+++ b/dashboard/app/routes/_protected.$teamId.usage._index/route.component.tsx
@@ -47,12 +47,12 @@ export function Component() {
       return {
         title: "Usage Limit Exceeded",
         description:
-          "You've exceeded your plan's post limit. Upgrade to continue posting without interruption.",
+          "You've exceeded your plan's post limit. Posting continues without interruption — upgrade anytime to raise your limit.",
       };
     } else if (usagePercentage >= 80) {
       return {
         title: "Approaching Usage Limit",
-        description: `You've used ${Math.round(usagePercentage)}% of your plan's post limit. Consider upgrading to avoid hitting your limit.`,
+        description: `You've used ${Math.round(usagePercentage)}% of your plan's post limit. Upgrade anytime to raise your limit.`,
       };
     }
     return { title: "", description: "" };


### PR DESCRIPTION
## Summary

The usage dashboard's warning card claimed that upgrading was required to "continue posting without interruption." That's inaccurate — there's no enforcement today; Unkey API keys are toggled by subscription status only, not usage, so posting is never actually blocked by exceeding the plan's post limit. This corrects the copy to reflect that service continues uninterrupted.

## Changes

- `dashboard/app/routes/_protected.$teamId.usage._index/route.component.tsx` — reworded the two warning messages in `getWarningMessage()`:
  - ≥100% (exceeded): now reads "Posting continues without interruption — upgrade anytime to raise your limit" instead of implying an interruption risk.
  - 80-99% (approaching): dropped "avoid hitting your limit" framing (same implied risk) in favor of "Upgrade anytime to raise your limit."
- No logic changes — threshold checks (`>= 80`, `>= 100`), colors, and the upgrade button are untouched.

## Testing

- `cd dashboard && bun run typecheck` — passes
- `cd dashboard && bun run lint` — passes
- Not manually verified in the browser (copy-only change, no logic touched); reviewer can sanity-check by viewing `/{teamId}/usage` for a team at ≥80%/≥100% usage.

## Notes

Scoped narrowly per the ticket — this page's percentage is computed client-side from Stripe meter event summaries, a separate counter from `social_post_team_usage` used by backend automation (`trigger/process-usage-limits.ts`), so the copy here intentionally doesn't reference that automation. The linked "80/90/95% usage-threshold warning emails" ticket doesn't exist yet in this repo; no stacking dependency, this lands independently.

Closes PFM-1065

🤖 Generated with AI