### PR TITLE
fix(billing): manual upgrade applies cap immediately + cleans up pending schedule

### DIFF
--- a/dashboard/app/routes/api.stripe.webhook/.server/subscription-event.test.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/subscription-event.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const updateAPIKeyAccessMock = vi.fn().mockResolvedValue(undefined);
+const trackSubscriptionLifecycleMock = vi.fn().mockResolvedValue(undefined);
+const syncTeamUsageLimitOnUpgradeMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("~/lib/.server/update-api-key-access.request", () => ({
+  updateAPIKeyAccess: (...args: unknown[]) => updateAPIKeyAccessMock(...args),
+}));
+
+vi.mock("./subscription-lifecycle-tracking", () => ({
+  trackSubscriptionLifecycle: (...args: unknown[]) =>
+    trackSubscriptionLifecycleMock(...args),
+}));
+
+vi.mock("./sync-usage-limit", () => ({
+  syncTeamUsageLimitOnUpgrade: (...args: unknown[]) =>
+    syncTeamUsageLimitOnUpgradeMock(...args),
+}));
+
+const { handleSubscriptionEvent } = await import("./subscription-event");
+
+const supabaseServiceRole = {} as never;
+
+function subscriptionEvent(
+  type: string,
+  subscription: Record<string, unknown> = {},
+): Parameters<typeof handleSubscriptionEvent>[0] {
+  const object = {
+    id: "sub_1",
+    customer: "cus_1",
+    status: "active",
+    ...subscription,
+  };
+
+  return { type, data: { object } } as unknown as Parameters<
+    typeof handleSubscriptionEvent
+  >[0];
+}
+
+beforeEach(() => {
+  updateAPIKeyAccessMock.mockClear();
+  trackSubscriptionLifecycleMock.mockClear();
+  syncTeamUsageLimitOnUpgradeMock.mockClear();
+});
+
+describe("handleSubscriptionEvent", () => {
+  it("invokes syncTeamUsageLimitOnUpgrade with the subscription on customer.subscription.updated", async () => {
+    const event = subscriptionEvent("customer.subscription.updated");
+
+    await handleSubscriptionEvent(event, supabaseServiceRole);
+
+    expect(syncTeamUsageLimitOnUpgradeMock).toHaveBeenCalledTimes(1);
+    expect(syncTeamUsageLimitOnUpgradeMock).toHaveBeenCalledWith(
+      event.data.object,
+      supabaseServiceRole,
+    );
+  });
+
+  it("does not invoke syncTeamUsageLimitOnUpgrade on customer.subscription.created", async () => {
+    const event = subscriptionEvent("customer.subscription.created");
+
+    await handleSubscriptionEvent(event, supabaseServiceRole);
+
+    expect(syncTeamUsageLimitOnUpgradeMock).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke syncTeamUsageLimitOnUpgrade on customer.subscription.deleted", async () => {
+    const event = subscriptionEvent("customer.subscription.deleted");
+
+    await handleSubscriptionEvent(event, supabaseServiceRole);
+
+    expect(syncTeamUsageLimitOnUpgradeMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows a syncTeamUsageLimitOnUpgrade failure without throwing or skipping the API key toggle", async () => {
+    syncTeamUsageLimitOnUpgradeMock.mockRejectedValueOnce(new Error("boom"));
+    const event = subscriptionEvent("customer.subscription.updated");
+
+    await expect(
+      handleSubscriptionEvent(event, supabaseServiceRole),
+    ).resolves.toBeUndefined();
+
+    expect(updateAPIKeyAccessMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/app/routes/api.stripe.webhook/.server/subscription-event.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/subscription-event.ts
@@ -1,6 +1,7 @@
 import { updateAPIKeyAccess } from "~/lib/.server/update-api-key-access.request";
 
 import { trackSubscriptionLifecycle } from "./subscription-lifecycle-tracking";
+import { syncTeamUsageLimitOnUpgrade } from "./sync-usage-limit";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Stripe } from "stripe";
@@ -33,5 +34,16 @@ export async function handleSubscriptionEvent(
     await trackSubscriptionLifecycle(event, supabaseServiceRole);
   } catch (error) {
     console.error("Failed to track subscription lifecycle in PostHog:", error);
+  }
+
+  // Apply a mid-period tier upgrade's raised cap immediately, and release any
+  // now-stale usage-based-upgrade schedule. Best-effort: never let this break
+  // the Unkey side effect above or the webhook response.
+  if (event.type === "customer.subscription.updated") {
+    try {
+      await syncTeamUsageLimitOnUpgrade(subscription, supabaseServiceRole);
+    } catch (error) {
+      console.error("Failed to sync team usage limit on upgrade:", error);
+    }
   }
 }

--- a/dashboard/app/routes/api.stripe.webhook/.server/subscription-lifecycle-tracking.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/subscription-lifecycle-tracking.ts
@@ -16,7 +16,7 @@ type SubscriptionEvent =
   | Stripe.CustomerSubscriptionUpdatedEvent
   | Stripe.CustomerSubscriptionDeletedEvent;
 
-type TeamRow = Pick<
+export type TeamRow = Pick<
   Database["public"]["Tables"]["teams"]["Row"],
   "id" | "created_by" | "name" | "billing_email"
 >;
@@ -148,7 +148,7 @@ export async function trackSubscriptionLifecycle(
  * redirect, which would otherwise drop a brand-new customer's conversion).
  * Fall back to the customer-id lookup for existing/older subscriptions.
  */
-async function resolveTeam(
+export async function resolveTeam(
   subscription: Stripe.Subscription,
   supabaseServiceRole: SupabaseClient<Database>,
 ): Promise<TeamRow | null> {

--- a/dashboard/app/routes/api.stripe.webhook/.server/sync-usage-limit.test.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/sync-usage-limit.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const retrieveProductMock = vi.fn();
+const releaseSchedulesForCustomerMock = vi.fn();
+
+vi.mock("~/lib/.server/stripe", () => ({
+  stripe: {
+    products: {
+      retrieve: (...args: unknown[]) => retrieveProductMock(...args),
+    },
+  },
+}));
+
+vi.mock("~/lib/.server/subscription-schedules", () => ({
+  releaseSchedulesForCustomer: (...args: unknown[]) =>
+    releaseSchedulesForCustomerMock(...args),
+  SCHEDULE_TYPE: {
+    USAGE_BASED_UPGRADE: "usage_based_upgrade",
+    ADDON_REMOVAL: "addon_removal",
+  },
+}));
+
+const resolveTeamMock = vi.fn();
+
+vi.mock("./subscription-lifecycle-tracking", () => ({
+  resolveTeam: (...args: unknown[]) => resolveTeamMock(...args),
+}));
+
+const { syncTeamUsageLimitOnUpgrade } = await import("./sync-usage-limit");
+
+function product(id: string, socialPostLimit?: string) {
+  return {
+    id,
+    deleted: false,
+    metadata: socialPostLimit ? { social_post_limit: socialPostLimit } : {},
+  };
+}
+
+function subscription({
+  customerId = "cus_1",
+  productId = "prod_1",
+}: {
+  customerId?: string;
+  productId?: string;
+} = {}) {
+  return {
+    customer: customerId,
+    items: {
+      data: [{ price: { product: productId } }],
+    },
+  } as never;
+}
+
+function usageWindowRow({
+  limit,
+  endAt,
+}: {
+  limit: number;
+  endAt: string;
+}) {
+  return {
+    team_id: "team_1",
+    count: 0,
+    limit,
+    start_at: "2026-08-01T00:00:00.000Z",
+    end_at: endAt,
+  };
+}
+
+function supabaseServiceRole({
+  window,
+}: {
+  window: ReturnType<typeof usageWindowRow> | null;
+}) {
+  const updateEqThird = vi.fn().mockResolvedValue({ error: null });
+  const updateEqSecond = vi.fn(() => ({ eq: updateEqThird }));
+  const updateEqFirst = vi.fn(() => ({ eq: updateEqSecond }));
+  const update = vi.fn(() => ({ eq: updateEqFirst }));
+
+  const maybeSingle = vi.fn().mockResolvedValue({ data: window, error: null });
+  const limitFn = vi.fn(() => ({ maybeSingle }));
+  const orderSecond = vi.fn(() => ({ limit: limitFn }));
+  const orderFirst = vi.fn(() => ({ order: orderSecond }));
+  const eq = vi.fn(() => ({ order: orderFirst }));
+  const select = vi.fn(() => ({ eq }));
+
+  const from = vi.fn(() => ({ select, update }));
+
+  return {
+    client: { from } as never,
+    update,
+    updateEqFirst,
+    updateEqSecond,
+    updateEqThird,
+  };
+}
+
+const oneHourFromNow = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const oneHourAgo = () => new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+beforeEach(() => {
+  retrieveProductMock.mockReset();
+  releaseSchedulesForCustomerMock.mockReset();
+  resolveTeamMock.mockReset();
+});
+
+describe("syncTeamUsageLimitOnUpgrade", () => {
+  it("does nothing when no team is found for the customer", async () => {
+    resolveTeamMock.mockResolvedValue(null);
+    const { client, update } = supabaseServiceRole({ window: null });
+
+    await syncTeamUsageLimitOnUpgrade(subscription(), client);
+
+    expect(retrieveProductMock).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(releaseSchedulesForCustomerMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no subscription item has valid social_post_limit metadata", async () => {
+    resolveTeamMock.mockResolvedValue({ id: "team_1" });
+    retrieveProductMock.mockResolvedValue(product("prod_1"));
+    const { client, update } = supabaseServiceRole({ window: null });
+
+    await expect(
+      syncTeamUsageLimitOnUpgrade(subscription(), client),
+    ).resolves.toBeUndefined();
+
+    expect(update).not.toHaveBeenCalled();
+    expect(releaseSchedulesForCustomerMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the team has no usage window at all", async () => {
+    resolveTeamMock.mockResolvedValue({ id: "team_1" });
+    retrieveProductMock.mockResolvedValue(product("prod_1", "5000"));
+    const { client, update } = supabaseServiceRole({ window: null });
+
+    await syncTeamUsageLimitOnUpgrade(subscription(), client);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(releaseSchedulesForCustomerMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the latest usage window has already closed", async () => {
+    resolveTeamMock.mockResolvedValue({ id: "team_1" });
+    retrieveProductMock.mockResolvedValue(product("prod_1", "5000"));
+    const { client, update } = supabaseServiceRole({
+      window: usageWindowRow({ limit: 1000, endAt: oneHourAgo() }),
+    });
+
+    await syncTeamUsageLimitOnUpgrade(subscription(), client);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(releaseSchedulesForCustomerMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the new limit is not an upgrade (same tier or downgrade)", async () => {
+    resolveTeamMock.mockResolvedValue({ id: "team_1" });
+    retrieveProductMock.mockResolvedValue(product("prod_1", "1000"));
+    const { client, update } = supabaseServiceRole({
+      window: usageWindowRow({ limit: 1000, endAt: oneHourFromNow() }),
+    });
+
+    await syncTeamUsageLimitOnUpgrade(subscription(), client);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(releaseSchedulesForCustomerMock).not.toHaveBeenCalled();
+  });
+
+  it("updates the open window's limit and releases the usage-based-upgrade schedule on a genuine upgrade", async () => {
+    resolveTeamMock.mockResolvedValue({ id: "team_1" });
+    retrieveProductMock.mockResolvedValue(product("prod_1", "5000"));
+    const endAt = oneHourFromNow();
+    const { client, update, updateEqFirst, updateEqSecond, updateEqThird } =
+      supabaseServiceRole({
+        window: usageWindowRow({ limit: 1000, endAt }),
+      });
+
+    await syncTeamUsageLimitOnUpgrade(
+      subscription({ customerId: "cus_42" }),
+      client,
+    );
+
+    expect(update).toHaveBeenCalledWith({ limit: 5000 });
+    expect(updateEqFirst).toHaveBeenCalledWith("team_id", "team_1");
+    expect(updateEqSecond).toHaveBeenCalledWith(
+      "start_at",
+      "2026-08-01T00:00:00.000Z",
+    );
+    expect(updateEqThird).toHaveBeenCalledWith("end_at", endAt);
+
+    expect(releaseSchedulesForCustomerMock).toHaveBeenCalledTimes(1);
+    expect(releaseSchedulesForCustomerMock).toHaveBeenCalledWith({
+      stripeCustomerId: "cus_42",
+      criteria: { mode: "matching", type: "usage_based_upgrade" },
+    });
+  });
+
+  it("resolves the limit from whichever line item carries valid social_post_limit metadata", async () => {
+    resolveTeamMock.mockResolvedValue({ id: "team_1" });
+    retrieveProductMock
+      .mockResolvedValueOnce(product("prod_addon"))
+      .mockResolvedValueOnce(product("prod_plan", "5000"));
+
+    const multiItemSubscription = {
+      customer: "cus_1",
+      items: {
+        data: [
+          { price: { product: "prod_addon" } },
+          { price: { product: "prod_plan" } },
+        ],
+      },
+    } as never;
+
+    const { client, update } = supabaseServiceRole({
+      window: usageWindowRow({ limit: 1000, endAt: oneHourFromNow() }),
+    });
+
+    await syncTeamUsageLimitOnUpgrade(multiItemSubscription, client);
+
+    expect(update).toHaveBeenCalledWith({ limit: 5000 });
+  });
+});

--- a/dashboard/app/routes/api.stripe.webhook/.server/sync-usage-limit.ts
+++ b/dashboard/app/routes/api.stripe.webhook/.server/sync-usage-limit.ts
@@ -1,0 +1,143 @@
+import { stripe } from "~/lib/.server/stripe";
+import {
+  releaseSchedulesForCustomer,
+  SCHEDULE_TYPE,
+} from "~/lib/.server/subscription-schedules";
+
+import { resolveTeam } from "./subscription-lifecycle-tracking";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Stripe } from "stripe";
+import type { Database } from "~/lib/.server/database.types";
+
+type UsageWindow =
+  Database["public"]["Tables"]["social_post_team_usage"]["Row"];
+
+// Vendored from trigger/backfill-team-usage.ts — dashboard and trigger are
+// separate siblings with no shared package, so this pattern is copied rather
+// than imported. `product.metadata.social_post_limit` is the actual source
+// of truth for `social_post_team_usage.limit` (unlike `PRICING_TIERS`, which
+// is display/tier-ordering only).
+const getSubscriptionItemProduct = async (
+  item: Stripe.SubscriptionItem,
+): Promise<Stripe.Product> => {
+  const product = item.price.product;
+  const productId = typeof product === "string" ? product : product.id;
+
+  const retrievedProduct = await stripe.products.retrieve(productId);
+
+  if ("deleted" in retrievedProduct && retrievedProduct.deleted) {
+    throw new Error("Subscription product is deleted");
+  }
+
+  return retrievedProduct;
+};
+
+const getSubscriptionLimitDetails = async (
+  subscription: Stripe.Subscription,
+): Promise<{ limit: number; item: Stripe.SubscriptionItem }> => {
+  for (const item of subscription.items.data) {
+    const product = await getSubscriptionItemProduct(item);
+    const limitValue = product.metadata.social_post_limit;
+    const limit = Number(limitValue);
+
+    if (limitValue && Number.isFinite(limit) && limit > 0) {
+      return { limit, item };
+    }
+  }
+
+  throw new Error(
+    "No subscription item has valid social_post_limit metadata",
+  );
+};
+
+const getLatestUsageWindow = async (
+  teamId: string,
+  supabaseServiceRole: SupabaseClient<Database>,
+): Promise<UsageWindow | null> => {
+  const { data, error } = await supabaseServiceRole
+    .from("social_post_team_usage")
+    .select("team_id, count, limit, start_at, end_at")
+    .eq("team_id", teamId)
+    .order("end_at", { ascending: false })
+    .order("start_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+};
+
+/**
+ * Apply a mid-period Stripe tier upgrade to the team's currently open usage
+ * window immediately, instead of leaving it flagged "exceeded" against the
+ * old cap until the window rolls over. Also releases any pending
+ * `usage_based_upgrade` schedule (see trigger/process-usage-limits.ts) for
+ * the customer, since the manual upgrade this webhook just applied makes
+ * that scheduled bump redundant.
+ *
+ * Downgrades are intentionally left alone — nothing writes `limit` on a
+ * downgrade today, so this only ever raises the cap, never lowers it.
+ */
+export async function syncTeamUsageLimitOnUpgrade(
+  subscription: Stripe.Subscription,
+  supabaseServiceRole: SupabaseClient<Database>,
+): Promise<void> {
+  const team = await resolveTeam(subscription, supabaseServiceRole);
+
+  if (!team) {
+    return;
+  }
+
+  let newLimit: number;
+  try {
+    ({ limit: newLimit } = await getSubscriptionLimitDetails(subscription));
+  } catch (error) {
+    console.error(
+      "Could not resolve social_post_limit for subscription, skipping usage limit sync:",
+      error,
+    );
+    return;
+  }
+
+  const window = await getLatestUsageWindow(team.id, supabaseServiceRole);
+
+  if (!window) {
+    return;
+  }
+
+  const isOpen = new Date(window.end_at).getTime() > Date.now();
+  if (!isOpen) {
+    return;
+  }
+
+  if (newLimit <= window.limit) {
+    return;
+  }
+
+  const { error: updateError } = await supabaseServiceRole
+    .from("social_post_team_usage")
+    .update({ limit: newLimit })
+    .eq("team_id", team.id)
+    .eq("start_at", window.start_at)
+    .eq("end_at", window.end_at);
+
+  if (updateError) {
+    throw updateError;
+  }
+
+  const customerId = subscription.customer as string;
+  await releaseSchedulesForCustomer({
+    stripeCustomerId: customerId,
+    criteria: { mode: "matching", type: SCHEDULE_TYPE.USAGE_BASED_UPGRADE },
+  });
+
+  console.log("Applied mid-period usage limit upgrade", {
+    team_id: team.id,
+    previous_limit: window.limit,
+    new_limit: newLimit,
+  });
+}


### PR DESCRIPTION
## Summary

When a team upgrades mid-period via the Stripe Billing Portal, nothing writes back to `social_post_team_usage.limit` — the team stays flagged "exceeded" against their old cap until the usage window rolls over, and any pending `usage_based_upgrade` schedule (created by the usage-limit cron's auto-upgrade logic) becomes stale.

This PR syncs the raised cap immediately from the Stripe webhook and releases the now-redundant scheduled auto-upgrade, reusing the targeted-release helper from #345.

**Stacks on #345** — base branch is `feat/pfm-1063`, and the diff view will only show this PR's own commit once #345 merges.

## Changes

- `dashboard/app/routes/api.stripe.webhook/.server/sync-usage-limit.ts` (new) — on `customer.subscription.updated`, resolves the new cap from the subscription's `social_post_limit` product metadata (same convention as `trigger/backfill-team-usage.ts`), updates the team's currently-open usage window's `limit` only when it's a genuine upgrade, then calls `releaseSchedulesForCustomer({ mode: "matching", type: USAGE_BASED_UPGRADE })` to release just the stale auto-upgrade schedule — never a `mode: "all"` release.
- `dashboard/app/routes/api.stripe.webhook/.server/subscription-event.ts` — wires the sync into `handleSubscriptionEvent`, best-effort (errors logged, never break the webhook or the Unkey API-key toggle).
- `dashboard/app/routes/api.stripe.webhook/.server/subscription-lifecycle-tracking.ts` — exported `resolveTeam`/`TeamRow` so the new module reuses the existing customer→team lookup instead of duplicating it.
- Downgrades are intentionally out of scope: nothing writes `limit` on a downgrade today either, so this only ever raises the cap.
- No changes needed in `trigger/process-usage-limits.ts` — it only reads `limit` and already filters schedule lookups to `USAGE_BASED_UPGRADE`, so it self-heals once the webhook releases a stale schedule.

## Testing

- `cd dashboard && bun run typecheck` — passes.
- `cd dashboard && bun run lint` — passes.
- `cd dashboard && bunx vitest run app/routes/api.stripe.webhook/.server/sync-usage-limit.test.ts app/routes/api.stripe.webhook/.server/subscription-event.test.ts` — 11 new tests, all passing (no team found, no valid metadata, no/closed window, non-upgrade no-op, genuine upgrade updates limit + releases schedule, multi-line-item metadata resolution, event-type gating, error-swallowing).
- Not yet exercised against a live Stripe Billing Portal upgrade or local Supabase — recommend a manual pass with the Stripe CLI (`stripe trigger customer.subscription.updated`) before merge.

## Notes

Marked as draft: stacked on #345 and pending that manual Stripe-CLI verification pass.

Closes PFM-1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)