### PR TITLE
feat(api): adds local unkey middleware for local development

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -11,6 +11,22 @@ DATABASE_URL=
 UNKEY_ROOT_KEY=
 UNKEY_API_ID=
 
+# Local-only Unkey gateway bypass (see src/auth/local-unkey-principal.middleware.ts).
+# In production, Unkey's gateway sits in front of the app, verifies the caller's
+# API key, and injects the X-Unkey-Principal header itself. Locally there's no
+# gateway, so @Protect()/@VerifyKey() routes 401 unless you set the header by
+# hand on every request. Set LOCAL_UNKEY_PRINCIPAL=true to have the API inject
+# a hardcoded principal built from the IDs below for any request that doesn't
+# already carry one. NEVER set this outside local dev — it bypasses real auth.
+# Find real IDs against your local seed with:
+#   docker exec supabase_db_post-for-me psql -U postgres -d postgres -t -c \
+#     "select u.id, t.id, p.id from auth.users u join public.teams t on t.name = 'Example Team' join public.projects p on p.team_id = t.id and p.name = 'Example Project' where u.email = 'user1@example.com';"
+LOCAL_UNKEY_PRINCIPAL=
+LOCAL_UNKEY_USER_ID=
+LOCAL_UNKEY_PROJECT_ID=
+LOCAL_UNKEY_TEAM_ID=
+LOCAL_UNKEY_PLAN_TYPE=
+
 # Private namespace (internal CMS endpoints) is authorized via Unkey RBAC:
 # each route requires a permission query (default `cms.read`, overridable
 # per-route via the `@ProtectPrivate({ permissions })` decorator). Grant

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 
 import { ConfigModule } from '@nestjs/config';
@@ -13,6 +13,7 @@ import { SupabaseModule } from './supabase/supabase.module';
 import { KyselyModule } from './kysely/kysely.module';
 import { AuthGuard } from './auth/auth.guard';
 import { VerifyKeyGuard } from './auth/verify-key.guard';
+import { LocalUnkeyPrincipalMiddleware } from './auth/local-unkey-principal.middleware';
 import { SocialPostPreviewsModule } from './social-posts-previews/social-posts-previews.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { SocialAccountFeedsModule } from './social-account-feeds/social-account-feeds.module';
@@ -45,4 +46,13 @@ import { HealthcheckModule } from './healthcheck/healthcheck.module';
     VerifyKeyGuard,
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.LOCAL_UNKEY_PRINCIPAL === 'true'
+    ) {
+      consumer.apply(LocalUnkeyPrincipalMiddleware).forRoutes('*');
+    }
+  }
+}

--- a/api/src/auth/local-unkey-principal.middleware.ts
+++ b/api/src/auth/local-unkey-principal.middleware.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+
+/**
+ * Local stand-in for the Unkey gateway. In every real environment, Unkey
+ * verifies the caller's API key and injects `X-Unkey-Principal` before the
+ * request reaches this app (see unkey-principal.ts). Nothing does that on
+ * `bun run start:dev`, so every `@Protect()` / `@VerifyKey()` route 401s
+ * unless a caller sets the header by hand.
+ *
+ * Enabled only when LOCAL_UNKEY_PRINCIPAL=true AND NODE_ENV !== 'production'
+ * — never enable this outside local dev, it bypasses real authentication.
+ * A caller-supplied header always wins, so `curl -H "X-Unkey-Principal:
+ * ..."` still lets you test other principals against the same server.
+ */
+@Injectable()
+export class LocalUnkeyPrincipalMiddleware implements NestMiddleware {
+  private static warned = false;
+
+  use(req: Request, _res: Response, next: NextFunction) {
+    if (req.headers['x-unkey-principal']) {
+      return next();
+    }
+
+    if (!LocalUnkeyPrincipalMiddleware.warned) {
+      Logger.warn(
+        'Injecting a hardcoded X-Unkey-Principal for local development ' +
+          '(LOCAL_UNKEY_PRINCIPAL=true). This must never be enabled outside local dev.',
+        'LocalUnkeyPrincipalMiddleware',
+      );
+      LocalUnkeyPrincipalMiddleware.warned = true;
+    }
+
+    req.headers['x-unkey-principal'] = JSON.stringify({
+      version: 'v1',
+      subject: 'local-dev',
+      type: 'API_KEY',
+      identity: {
+        externalId: process.env.LOCAL_UNKEY_PROJECT_ID,
+      },
+      source: {
+        key: {
+          keyId: 'local_dev_key',
+          keySpaceId: 'local_dev',
+          meta: {
+            created_by: process.env.LOCAL_UNKEY_USER_ID,
+            team_id: process.env.LOCAL_UNKEY_TEAM_ID,
+            plan_type: process.env.LOCAL_UNKEY_PLAN_TYPE || 'new_pricing',
+          },
+          roles: ['admin'],
+          permissions: ['cms.read', 'cms.write'],
+        },
+      },
+    });
+
+    next();
+  }
+}


### PR DESCRIPTION
This adds a double trigger for local unkey development to mock a principal as a workaround for the new gateway changes until we can use a better supported method to handle this